### PR TITLE
Added ability to utilize IOServiceProvider instances registered using SPI

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -58,6 +58,7 @@ import java.io.*;
 import java.nio.channels.WritableByteChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import javax.imageio.spi.ServiceRegistry;
 
 /**
  * HI TOM!
@@ -528,6 +529,12 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable {
     if (N3header.isValidFile(raf)) {
       return true;
     } else {
+      Iterator<IOServiceProvider> iterator = ServiceRegistry.lookupProviders(ucar.nc2.iosp.IOServiceProvider.class);
+      while(iterator.hasNext()) {
+          if (iterator.next().isValidFile(raf)) {
+              return true;
+          }
+      }
       for (IOServiceProvider registeredSpi : registeredProviders) {
         if (registeredSpi.isValidFile(raf))
           return true;
@@ -836,6 +843,22 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable {
       // spi = new ucar.nc2.iosp.hdf5.H5iosp();
 
     } else {
+      Iterator<IOServiceProvider> iterator = ServiceRegistry.lookupProviders(IOServiceProvider.class);
+      while(iterator.hasNext()) {
+          IOServiceProvider currentSpi = iterator.next();
+          if (currentSpi.isValidFile(raf)) {
+             Class c = currentSpi.getClass();
+            try {
+                spi = (IOServiceProvider) c.newInstance();
+            } catch (InstantiationException e) {
+                throw new IOException("IOServiceProvider " + c.getName() + "must have no-arg constructor."); // shouldnt happen
+            } catch (IllegalAccessException e) {
+                throw new IOException("IOServiceProvider " + c.getName() + " IllegalAccessException: " + e.getMessage()); // shouldnt happen
+            }
+            break;
+          }
+      }
+
       // look for registered providers
       for (IOServiceProvider registeredSpi : registeredProviders) {
         if (debugSPI) System.out.println(" try iosp = " + registeredSpi.getClass().getName());


### PR DESCRIPTION
Added ability to utilize IOServiceProvider instances registered using [javax.imageio.spi.ServiceRegistry](http://docs.oracle.com/javase/6/docs/api/javax/imageio/spi/ServiceRegistry.html)

For this to work, a jar with ucar.nc2.iosp.IOServiceProvider implementations needs to create a file named META-INF/services/ucar.nc2.IOServiceProvider with the fully qualified class name for each IOSP implementation listed on a single line.

As an example the current BUFR IOSP jar would contain a file with a single line of:

```
ucar.nc2.iosp.bufr.BufrIosp
```

This should allow Unidata to remove the registration via class name if desired.  This will also allow users to add IOSP simply by placing jars (compliant with usage described above) on the class path without having to to edit or compile any source.
