### PR TITLE
bumping version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -765,8 +765,8 @@
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
 
     <!-- Dependency versions -->
-    <visad.version>2.0-20120411</visad.version>
-    <!-- was 2010-08-09, other options 2011-05-12 or 2011-08-22 -->
+    <visad.version>2.0-20130124</visad.version>
+    <!-- was 2.0-20120411, other options 2010-08-09, 2011-05-12 or 2011-08-22 -->
     <edu.wisc.version>2011-08-22</edu.wisc.version>
     <!-- uk.ac.rdg.resc.version>1.0.tds.4.3-20120605.2335</uk.ac.rdg.resc.version-->
     <!-- uk.ac.rdg.resc.version>1.0.tds.4.3.20120807.1030</uk.ac.rdg.resc.version-->    


### PR DESCRIPTION
Bumped the VisAD version from 2.0-20120411 to 2.0-20130124. As a reminder thredds uses this git mirror for VisAD: https://github.com/julienchastang/visad. I recently updated the mirror to reflect the latest from SSEC. Before merging in I would recommend checking to see if mvn install is not complaining. You may have to mvn install the VisAD mirror project onto your Nexus server, or however you manage local mvn artifacts. Thanks. 
