### PR TITLE
Remove memory leak in HTTPSession.java

### DIFF
--- a/cdm/src/main/java/ucar/nc2/util/net/HTTPSession.java
+++ b/cdm/src/main/java/ucar/nc2/util/net/HTTPSession.java
@@ -153,10 +153,10 @@ static public Cookie[] getGlobalCookies()
 
 static private synchronized void kill()
 {
-    for (HTTPSession session : sessionList) {
-        session.close();
-    }
-    sessionList.clear();
+//    for (HTTPSession session : sessionList) {
+//        session.close();
+//    }
+//    sessionList.clear();
     // Rebuild the connection manager
     connmgr.shutdown();
     connmgr = new MultiThreadedHttpConnectionManager();
@@ -256,7 +256,7 @@ static MultiThreadedHttpConnectionManager connmgr;
 //fix: protected static SchemeRegistry schemes;
 static String globalAgent = "/NetcdfJava/HttpClient3";
 static int threadcount = DFALTTHREADCOUNT;
-static List<HTTPSession> sessionList; // List of all HTTPSession instances
+//static List<HTTPSession> sessionList; // List of all HTTPSession instances
 static boolean globalauthpreemptive = false;
 static int globalSoTimeout = 0;
 static int globalConnectionTimeout = 0;
@@ -278,7 +278,7 @@ static {
                                   new EasySSLProtocolSocketFactory(),
                                   8443)); // std tomcat https entry
 
-    sessionList = new ArrayList<HTTPSession>(); // see kill function
+//    sessionList = new ArrayList<HTTPSession>(); // see kill function
     setGlobalConnectionTimeout(DFALTTIMEOUT);
     setGlobalSoTimeout(DFALTTIMEOUT);
     getGlobalProxyD(); // get info from -D if possible
@@ -373,7 +373,7 @@ construct(String legalurl)
 
         setProxy();
 
-        sessionList.add(this);
+//        sessionList.add(this);
 
     } catch (Exception e) {
         throw new HTTPException("url="+legalurl,e);


### PR DESCRIPTION
This is a nasty beast that has been bringing down our services using the NetCDF-Java OPeNDAP client.  Every HTTPSession instance created is added to a static ArrayList instance meaning the retained storage can not be GC'd.  A 17GB heap dump after an OOME showed 16.95 GB of references to Strings (and other objects) relating to HTTP Response headers from DAP calls.

From the code it looks like the functionality is designed to provide clean-up after tests.  I would recommend this session tracking and clean-up code be moved to the testing code base.

Can provide heap dump on request!
