### PR TITLE
UAMIV IOSP Updates for better Projection and Unit Awareness

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/uamiv/UAMIVServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/uamiv/UAMIVServiceProvider.java
@@ -464,7 +464,7 @@ public class UAMIVServiceProvider extends AbstractIOServiceProvider {
     } else {
       if (log.isDebugEnabled()) log.debug("UAMIVServiceProvider: adding projection file");
       BufferedWriter bw = new BufferedWriter(new java.io.FileWriter(paramFile));
-      bw.write("# Projection parameters are based on IOAPI.  For details, see www.baronsams.com/products/ioapi");
+      bw.write("# Projection parameters are based on IOAPI.  For details, see www.baronams.com/products/ioapi/GRIDS.html");
       bw.newLine();
       bw.write("GDTYP=");
       bw.write(gdtyp.toString());


### PR DESCRIPTION
The UAMIV IOSP was written primarily to provide users access to CAMx data.  CAMx data did not have sufficient meta-data to describe its projection.  As a result, the UAMIV IOSP created a text file (camxproj.txt) for users to supply additional data. In the latest CAMx release, previously unused "dummy" variables were allocated to defining the projection.  This update incorporates the new data into a default projection. The IOSP still allows a user supplied camxproj.txt to over-ride the files meta-data.  This allows use of CAMx data with and without meta-data and allows users to modify the projection if so desired.

Tested using CAMx version 6 met inputs and average outputs with toolsUI.
