### PR TITLE
Changed scope of 'open' to be able to use custom RandomAccessFile implementations

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -747,7 +747,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable {
     return openInMemory(uri.toString(), contents);
   }
 
-  private static NetcdfFile open(ucar.unidata.io.RandomAccessFile raf, String location, ucar.nc2.util.CancelTask cancelTask,
+  public static NetcdfFile open(ucar.unidata.io.RandomAccessFile raf, String location, ucar.nc2.util.CancelTask cancelTask,
                                  Object iospMessage) throws IOException {
 
     IOServiceProvider spi = null;


### PR DESCRIPTION
This trivial patch allows to provide custom implementations of RandomAccessFile to open Netcdf files stored on various filesystems not yet supported.
