### PR TITLE
Fix xml representation to correctly format the dataset offsets

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
@@ -541,11 +541,11 @@ public class GridDatasetInv {
         double[] bound1 = tc.getBound1();
         double[] bound2 = tc.getBound2();
         for (int j = 0; j < bound1.length; j++)
-          sbuff.format("%f %f,", bound1[j], bound2[j]);
+          sbuff.format((Locale) null, "%f %f,", bound1[j], bound2[j]);
 
       } else {
         for (double offset : tc.getOffsetTimes())
-          sbuff.format("%f,", offset);
+          sbuff.format((Locale) null, "%f,", offset);
       }
       timeElement.addContent(sbuff.toString());
 

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/TimeCoord.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/TimeCoord.java
@@ -208,9 +208,9 @@ public class TimeCoord implements Comparable {
     Formatter out = new Formatter();
     out.format("%-10s %-26s offsets=", getName(), runDate);
     if (isInterval)
-      for (int i=0; i<bound1.length; i++) out.format("(%3.1f,%3.1f) ", bound1[i], bound2[i]);
+      for (int i=0; i<bound1.length; i++) out.format((Locale) null, "(%3.1f,%3.1f) ", bound1[i], bound2[i]);
     else
-      for (double val : offset) out.format("%3.1f, ", val);
+      for (double val : offset) out.format((Locale) null, "%3.1f, ", val);
     return out.toString();
   }
 


### PR DESCRIPTION
Apply no localization to the java.util.Formatter.format function in the GridDatasetInv class. Same fix applied to the TimeCoord string representation.

This is our problem:

We have a dataset with the offset array set to [-24.0 -21.0 -18.0 .. 66.0 69.0 72.0]. The java.util.Formatter.format function, without the Locale parameter, use the default locale of the Java virtual machine. In our case is es_ES, so the format function format each offset value (double) with comma instance of point. For example, -24.0 => -24,0. The result of the xml representation of the offset array is: "-24,000000,-21,000000,-18,000000, ... ,66,000000,69,000000,72,000000,", giving us the double of offsets.

How we fix it:

We have modified the GridDatasetInv and TimeCoord classes. The format function is called with the Locale parameter set to null (no localization applied). With this fix the xml representation is:
"-24.000000,-21.000000,-18.000000, ... ,66.000000,69.000000,72.000000,". 

We think these modifications fix the problem explained in the email with subject "FMRC feature collection problem", that was sent to the Thredds mailing list.
