### PR TITLE
read length as unsigned int to fix decoding of very large GRIB1 files

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionBinaryData.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionBinaryData.java
@@ -90,7 +90,7 @@ public class Grib1SectionBinaryData {
     startingPosition = raf.getFilePointer();
 
     // octets 1-3 (Length of section)
-    length = GribNumbers.int3(raf);
+    length = GribNumbers.uint3(raf);
     //if (length < 0)
     //  throw new IllegalStateException("GRIB record has bad length, pos = " + startingPosition);
     raf.seek(startingPosition + length);

--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionIndicator.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionIndicator.java
@@ -65,7 +65,7 @@ public class Grib1SectionIndicator {
       if (b[i] != MAGIC[i])
         throw new IllegalArgumentException("Not a GRIB record");
 
-    messageLength = GribNumbers.int3(raf);
+    messageLength = GribNumbers.uint3(raf);
     int edition = raf.read();
     if (edition != 1)
       throw new IllegalArgumentException("Not a GRIB-1 record");


### PR DESCRIPTION
When decoding very large GRIB1 files, reading the section length as a signed int results in a negative length, causing the index file to be empty and the following exception during decoding:

```
java.io.IOException: GribCollection 0101.grib has no files
    at ucar.nc2.grib.grib1.Grib1CollectionBuilder.createIndex(Grib1CollectionBuilder.java:610)
    at ucar.nc2.grib.grib1.Grib1CollectionBuilder.createIndex(Grib1CollectionBuilder.java:447)
    at ucar.nc2.grib.grib1.Grib1CollectionBuilder.readOrCreateIndex(Grib1CollectionBuilder.java:152)
    at ucar.nc2.grib.grib1.Grib1CollectionBuilder.readOrCreateIndexFromSingleFile(Grib1CollectionBuilder.java:67)
    at ucar.nc2.grib.GribIndex.makeGribCollectionFromSingleFile(GribIndex.java:120)
    at ucar.nc2.grib.grib1.Grib1Iosp.open(Grib1Iosp.java:136)
    at ucar.nc2.NetcdfFile.<init>(NetcdfFile.java:1520)
    at ucar.nc2.NetcdfFile.open(NetcdfFile.java:812)
    at ucar.nc2.NetcdfFile.open(NetcdfFile.java:420)
```

This fix decodes the length as an unsigned int.
