### PR TITLE
GRIB index file descriptor leak - fix

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1CollectionBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1CollectionBuilder.java
@@ -176,6 +176,7 @@ public class Grib1CollectionBuilder extends GribCollectionBuilder {
   // reading
 
   public boolean readIndex(String filename) throws IOException {
+    //this RAF instance is set on the GribCollection in readIndex(), then subsequently closed
     return readIndex( new RandomAccessFile(filename, "r") );
   }
 
@@ -284,6 +285,14 @@ public class Grib1CollectionBuilder extends GribCollectionBuilder {
 
     } catch (Throwable t) {
       logger.error("Error reading index " + raf.getLocation(), t);
+      try{
+        //when there are problems reading the index file, close the RAF and set the instance to null on the collection
+        raf.close();
+        gc.setIndexRaf( null );
+      }
+      catch( IOException e ){
+        logger.error( "Could not close RAF", e );
+      }
       return false;
     }
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2CollectionBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2CollectionBuilder.java
@@ -176,6 +176,7 @@ public class Grib2CollectionBuilder extends GribCollectionBuilder {
   }
 
   public boolean readIndex(String filename) throws IOException {
+    //this RAF instance is set on the GribCollection in readIndex(), then subsequently closed
     return readIndex( new RandomAccessFile(filename, "r") );
   }
 
@@ -277,6 +278,14 @@ public class Grib2CollectionBuilder extends GribCollectionBuilder {
 
     } catch (Throwable t) {
       logger.error("Error reading index " + raf.getLocation(), t);
+      try{
+        //when there are problems reading the index file, close the RAF and set the instance to null on the collection
+        raf.close();
+        gc.setIndexRaf( null );
+      }
+      catch( IOException e ){
+        logger.error( "Could not close RAF", e );
+      }
       return false;
     }
   }


### PR DESCRIPTION
Added code to handle the case where there is an Exception resulting from reading a GRIB index file.  When this case happens the RandomAccessFile is now closed properly, fixing a file leak situation.  This case was observed with network file systems returning empty 0-length files in some cases
