### PR TITLE
Fixed problem for thin grid with bitmaps...

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
@@ -126,6 +126,20 @@ public abstract class Grib1Gds {
     return data;
   }
 
+  public int getNpts() {
+	  
+	  if (nptsInLine != null) {
+		  int npts = 0;
+		  for (int pts : nptsInLine) {
+			  npts += pts;
+		  }
+		  return npts;
+	  } else {
+		  return nx * ny;
+	  }
+	  
+  }
+
   public int[] getNptsInLine() {
     return nptsInLine;
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Record.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Record.java
@@ -145,7 +145,7 @@ public class Grib1Record {
   // isolate dependencies here - in case we have a "minimal I/O" mode where not all fields are available
   public float[] readData(RandomAccessFile raf) throws IOException {
     Grib1Gds gds = gdss.getGDS();
-    Grib1DataReader reader = new Grib1DataReader(pdss.getDecimalScale(), gds.getScanMode(), gds.getNx(), gds.getNy(), dataSection.getStartingPosition());
+    Grib1DataReader reader = new Grib1DataReader(pdss.getDecimalScale(), gds.getScanMode(), gds.getNx(), gds.getNy(), gds.getNpts(), dataSection.getStartingPosition());
     byte[] bm = (bitmap == null) ? null : bitmap.getBitmap(raf);
     float[] data = reader.getData(raf, bm);
 


### PR DESCRIPTION
Hi,

this one was not reported to the mailing list, yet.

However: when opening Grib 1 files with reduced gaussian grids AND a bitmap applied, there was an error reported to the log file and the record was skipped.
"Grib1DataReader - Bitmap section length = 105438 != grid length"

The problem was in Grib1DataReader.getData(..). There was an array copied and the length of the array was exptected to be nx \* ny as for regular grid. Since reduced gaussian grids contain less data, this failed.

Should be fixed with this pull request.

Cheers,
Jochen
