### PR TITLE
Target 4.3.22 interpolation fix

### DIFF
--- a/grib/src/main/java/ucar/grib/QuasiRegular.java
+++ b/grib/src/main/java/ucar/grib/QuasiRegular.java
@@ -155,8 +155,8 @@ public final class QuasiRegular {
       /* interpolate the output row */
       for (int i = 0; i < ni; i++) {
         double mapped_i;  /* i mapped to input space */
-        mapped_i = (float) i / ((float) ni - 1)
-            * ((float) npoints - 1);
+        mapped_i = (float) i / ((float) ni) * ((float) npoints);
+        
         //System.out.println( " mapped_i ="+  mapped_i );
         /* map output point to input space */
         cubicSpline(  /* interpolate the value */
@@ -273,6 +273,8 @@ public final class QuasiRegular {
 
     a = hi - x;
     b = x - low;
+
+	hi = hi > (y2d.length - 1) ? 0 : hi;
 
     /* evalualte the polynomial */
 

--- a/grib/src/main/java/ucar/nc2/grib/QuasiRegular.java
+++ b/grib/src/main/java/ucar/nc2/grib/QuasiRegular.java
@@ -108,7 +108,7 @@ public class QuasiRegular {
       /* interpolate the output row */
       for (int i = 0; i < nx; i++) {
         double mapped_i;  /* i mapped to input space */
-        mapped_i = (float) i / ((float) nx - 1) * ((float) npoints - 1);
+        mapped_i = (float) i / ((float) nx) * ((float) npoints);
 
         /* map output point to input space */
         cubicSpline(  /* interpolate the value */
@@ -133,7 +133,7 @@ public class QuasiRegular {
     return max;
   }
 
-  private static void secondDerivative(float[] inpt, int idx, int n, double x1d,
+  public static void secondDerivative(float[] inpt, int idx, int n, double x1d,
                                        double xnd, double[] y2d) {
     //    float *inpt;        /* input data */
     //    float idx;          /* input data index*/
@@ -186,7 +186,7 @@ public class QuasiRegular {
   }
 
 
-  private static void cubicSpline(float[] inpt, int iIdx, double[] y2d, double x,
+  public static void cubicSpline(float[] inpt, int iIdx, double[] y2d, double x,
                                   float[] outpt, int oIdx) {
     //    float *inpt;        /* input row */
     //    int iIdx;           /* input data index*/
@@ -213,6 +213,8 @@ public class QuasiRegular {
     a = hi - x;
     b = x - low;
 
+	hi = hi > (y2d.length - 1) ? 0 : hi;
+	
     /* evalualte the polynomial */
 
     //*outpt = a * inpt[low] + b * inpt[hi] + ((a * a * a - a) * y2d[low] + (b * b * b - b) * y2d[hi]) / 6.0;

--- a/grib/src/test/java/ucar/nc2/grib/QuasiRegularTest.java
+++ b/grib/src/test/java/ucar/nc2/grib/QuasiRegularTest.java
@@ -1,0 +1,40 @@
+package ucar.nc2.grib;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class QuasiRegularTest {
+
+	private static final double x1d = 1.0e30;  /* derivative of the first end point */
+    private static final double xnd = 1.0e30;  /* derivative of the nth end point */
+
+	@Test
+	public void testCubicSpline() throws IOException {
+		float[] in = new float[]{0.0f, 9.0f, 18.0f, 27.0f};
+		
+		double[] d2 = new double[4];
+		QuasiRegular.secondDerivative(in, 0, 4, x1d, xnd, d2);
+
+		float[] out = new float[8];
+		QuasiRegular.cubicSpline(in, 0, d2, 0.0, out, 0);
+		assertEquals(0.0, out[0], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 0.5, out, 1);
+		assertEquals(4.5, out[1], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 1.0, out, 2);
+		assertEquals(9.0, out[2], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 1.5, out, 3);
+		assertEquals(13.5, out[3], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 2.0, out, 4);
+		assertEquals(18.0, out[4], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 2.5, out, 5);
+		assertEquals(22.5, out[5], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 3.0, out, 6);
+		assertEquals(27.0, out[6], 0.0);
+		QuasiRegular.cubicSpline(in, 0, d2, 3.5, out, 7);
+		assertEquals(13.5, out[7], 0.0);
+	}
+
+}


### PR DESCRIPTION
Hi,

I think we've found a bug in the interpolation of reduced gaussian grids to regular lat lon.

It seems the interpolation expects the grid points to be equally distributed from 0 to the maximum longitude (aka. "lo2"). 

For gaussian grids the last point in each line is at 360° - (360° / nPtsInLine). All points beyond that longitude (in the regular lat lon grid) are interpolate between the last point and the first point (of the reduced gaussian grid).

I attached a small drawing to visualize the problem. The upper figure show what is currently implemented, while the below figure show how the proposed fix works.

Tests are also included.

Regards,
Jochen

![2014-06-03 16 49 34](https://cloud.githubusercontent.com/assets/3090579/3161830/be37d91c-eb2f-11e3-94f0-af76bf79897b.jpg)
