### PR TITLE
ignore shade plugin generated dependency-reduced-pom for ncIdv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 # Coverity files 
 cov-int
 thredds.tgz
+
+# ignore shade plugin generated dependency-reduced-pom for ncIdv
+ncIdv/dependency-reduced-pom.xml


### PR DESCRIPTION
Like the commit says - ignore shade plugin generated dependency-reduced-pom for ncIdv. Since it is an automatically generated pom file, might as well ignore it...minor annoyance in the grand scheme of things, I know.
