### PR TITLE
Implement readTimeseries at ThreddsScalarLayer to improve efficiency

### DIFF
--- a/tds/src/main/java/thredds/server/wms/ThreddsScalarLayer.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsScalarLayer.java
@@ -179,6 +179,27 @@ class ThreddsScalarLayer extends AbstractScalarLayer implements ThreddsLayer {
 
   }
     
+  @Override
+  public List<Float> readTimeseries(List<DateTime> times, double elevation, HorizontalPosition xy)
+      throws InvalidDimensionValueException, IOException
+  {
+      Domain<HorizontalPosition> singlePoint = new HorizontalDomain(xy);;
+      HorizontalGrid hg = CdmUtils.createHorizontalGrid(grid.getCoordinateSystem());
+      PixelMap pixelMap = new PixelMap(hg, singlePoint);
+      List<Float> timePoints = new ArrayList<Float>(times.size());
+      int zIndex = this.findAndCheckElevationIndex(elevation);
+      for (DateTime time : times)
+      {
+          int tIndex = this.findAndCheckTimeIndex(time);
+          try{
+              timePoints.add(CdmUtils.readHorizontalPoints(null, grid,  tIndex, zIndex, pixelMap, this.dataReadingStrategy, 1).get(0));
+          }catch(Exception e){
+              //Catching and wrapping any exception reading data into a new IOException
+              throw new IOException(e);
+          }
+      }
+      return timePoints;
+  }
 
     /*public List<Float> readHorizonalPoints(DateTime time, double elevation, Domain<HorizontalPosition> domain)
             throws InvalidDimensionValueException, IOException


### PR DESCRIPTION
We have implemented the method readTimeseries at ThreddsScalarLayer in order to improve efficiency when accessing data values for a single point.

The problem was that the generic method defined at AbstractScalarLayer (in ncwms) was calling readHorizontalPoints for each time included in the timeseries requested and there are some variables that could be calculated only once. With this new method, we avoid repeating this calculations more than one time (CdmUtils.createHorizontalGrid, for example).

Tested in our thredds server, with a significant improvement in the response time of GetFeatureInfo requests (with a time interval as a parameter). 