### PR TITLE
NetcdfSubset didn't fire basic challenge when dataset is restricted

### DIFF
--- a/tds/src/main/java/thredds/server/ncss/controller/NcssDatasetInfoController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssDatasetInfoController.java
@@ -89,7 +89,7 @@ class NcssDatasetInfoController extends AbstractNcssController {
       fd = datasetService.findDatasetByPath(req, res, datasetPath);
 
       if (fd == null)
-        throw new UnsupportedOperationException("Feature Type not supported");
+    	  return;
 
       String strResponse = ncssShowDatasetInfo.showForm(fd, buildDatasetUrl(datasetPath), wantXML, showPointForm);
 


### PR DESCRIPTION
fd is null when a Feature type is not supported and when a dataset is restricted if the user is not logged in. Maybe the final solution is to split the behaviour in the Dataset service  throwing like an Unauthenticated exception that can be catched by the controllers. This solution mentioned requires to modify all the controllers which use FeatureDatasetService in order to catch it.

Fixes #103 

