### PR TITLE
compute fileIdentifier as specified by ACDD

### DIFF
--- a/tds/src/main/webapp/WEB-INF/classes/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/tds/src/main/webapp/WEB-INF/classes/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -28,7 +28,7 @@
     <xsl:variable name="standardNameCnt" select="count(/nc:netcdf/nc:variable/nc:attribute[@name='standard_name'])"/>
     <xsl:variable name="dimensionCnt" select="count(/nc:netcdf/nc:dimension)"/>
     <!-- Identifier Fields: 4 possible -->
-    <xsl:variable name="id" as="xs:string*" select="(/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='id']/@value,/nc:netcdf/nc:attribute[@name='id']/@value)"/>
+    <xsl:variable name="id" as="xs:string*" select="(/nc:attribute[@name='id']/@value,/nc:netcdf/nc:attribute[@name='id']/@value,/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='id']/@value)"/>
     <xsl:variable name="identifierNameSpace" as="xs:string*" select="(/nc:netcdf/nc:attribute[@name='naming_authority']/@value,
     /nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='authority']/@value)"/>
     <xsl:variable name="metadataConvention" as="xs:string*" select="/nc:netcdf/nc:attribute[@name='Metadata_Conventions']/@value"/>
@@ -178,7 +178,7 @@
             </xsl:attribute>
             <gmd:fileIdentifier>
                 <xsl:call-template name="writeCharacterString">
-                    <xsl:with-param name="stringToWrite" select="$id[1]"/>
+                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], '.', $id[1])"/>
                 </xsl:call-template>
             </gmd:fileIdentifier>
             <gmd:language>


### PR DESCRIPTION
This PR fixes  #121.

We implemented this change on our development 4.6 TDS server, and it worked:
The `naming_authority` and `id` specified in the [OPeNDAP Dataset Access Form](http://geoport-dev.whoi.edu/thredds/dodsC/usgs/data0/bbleh/spring2012/00_dir_roms.ncml.html)
```
id: COAWST.Barnegat_Bay.spring2012
naming_authority: gov.usgs.marine
```
are reflected in the `fileIdentifier` in the [ISO metadata](http://geoport-dev.whoi.edu/thredds/iso/usgs/data0/bbleh/spring2012/00_dir_roms.ncml?catalog=http%3A%2F%2Fgeoport-dev.whoi.edu%2Fthredds%2Fcatalog%2Fusgs%2Fdata0%2Fbbleh%2Fspring2012%2Fcatalog.html&dataset=usgs%2Fdata0%2Fbbleh%2Fspring2012%2F00_dir_roms.ncml):
```
   <gmd:fileIdentifier>
     <gco:CharacterString>gov.usgs.marine.COAWST.Barnegat_Bay.spring2012</gco:CharacterString>
   </gmd:fileIdentifier>
```