### PR TITLE
Fix problem reading huge attributes.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
@@ -241,7 +241,7 @@ Where startingBlockSize is from the header, ie the same for all indirect blocks.
         switch (subtype) {
           case 1:
           case 2:
-            offset = h5.makeIntFromBytes(heapId, 1, (heapid.length-1));
+            offset = h5.makeIntFromBytes(heapId, 1, (heapId.length-1));
             break;
         }
       } else if (type == 2) {

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
@@ -240,8 +240,8 @@ Where startingBlockSize is from the header, ie the same for all indirect blocks.
 
         switch (subtype) {
           case 1:
-            n = h5.getNumBytesFromMax(nManagedObjects);      // guess
-            offset = h5.makeIntFromBytes(heapId, 1, n);      // [16,1,0,0,0,0,0,0]
+          case 2:
+            offset = h5.makeIntFromBytes(heapId, 1, (heapid.length-1));
             break;
         }
       } else if (type == 2) {


### PR DESCRIPTION
netCDF-Java was unable to open HDF5 datasets with huge attributes because of exception thrown due to bad BTree address.