### PR TITLE
Create a temp file to test writable

### DIFF
--- a/cdm/src/main/java/ucar/nc2/util/DiskCache2.java
+++ b/cdm/src/main/java/ucar/nc2/util/DiskCache2.java
@@ -262,13 +262,24 @@ public class DiskCache2 {
       filename = filename.substring(5);
     Path path = Paths.get(filename).toAbsolutePath(); */
     Path path = f.toPath().toAbsolutePath();
-    return Files.isWritable(path.getParent());
+    //return Files.isWritable(path.getParent());
     /* Path apath = path.toAbsolutePath();
     System.out.printf("%s%n", path.toAbsolutePath());
     File parent = f.getParentFile();
     System.out.printf("%s%n", parent.exists());
     Path p = parent.toPath();
     return Files.isWritable(p);  */
+    try
+    {
+         /*
+          * Create and delete temp file in order to check file permissions 
+          */
+    	return File.createTempFile("nc_", ".tmp", path.getParent().toFile()).delete();
+    }
+    catch(java.io.IOException e)
+    {
+          return false;//Operation is aborted, assuming non-writable path.
+    }
   }
 
   /**


### PR DESCRIPTION
Relates to issue #141 

Because Java NIO has some issues with windows UNC read-only shares, my
proposal it's to create a real temp file on File parent path.