### PR TITLE
S3 datasets

### DIFF
--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     compile libraries["protobuf-java"]
     compile libraries["guava"]
     compile libraries["jcommander"]
+    compile 'com.amazonaws:aws-java-sdk:1.9.0'
+    compile 'commons-io:commons-io:2.4'
+    compile 'net.sf.ehcache:ehcache:2.10.0'
 
     compile libraries["slf4j-api"]
 }

--- a/cdm/src/main/java/thredds/crawlabledataset/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/CrawlableDatasetAmazonS3.java
@@ -2,15 +2,14 @@ package thredds.crawlabledataset;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
+import net.sf.ehcache.*;
+import net.sf.ehcache.event.CacheEventListener;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
 {
@@ -20,7 +19,11 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
     private final String path;
     private ThreddsS3Object s3Object = null;
 
-    private static final String EHCACHE_S3_KEY = "S3";
+    private static final String EHCACHE_S3_OBJECT_KEY = "S3Objects";
+    private static final String EHCACHE_S3_LISTING_KEY = "S3Listing";
+    private static final int EHCACHE_MAX_OBJECTS = 1000;
+    private static final int EHCACHE_TTL = 60;
+    private static final int EHCACHE_TTI = 60;
 
     public CrawlableDatasetAmazonS3(String path, Object configObject)
     {
@@ -33,6 +36,36 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
     {
         this(S3Helper.concat(parent.getPath(), s3Object.key), null);
         this.s3Object = s3Object;
+    }
+
+    public static Cache getS3Cache(String cacheName) {
+        return getS3Cache(cacheName, null);
+    }
+
+    public static Cache getS3Cache(String cacheName, CacheEventListener eventListener)
+    {
+        CacheManager cacheManager = CacheManager.create();
+
+        if (!cacheManager.cacheExists(cacheName)) {
+            Cache newCache = new Cache(cacheName, EHCACHE_MAX_OBJECTS, false, false, EHCACHE_TTL, EHCACHE_TTI);
+
+            if (null != eventListener)
+                newCache.getCacheEventNotificationService().registerListener(eventListener);
+
+            cacheManager.addCache(newCache);
+        }
+
+        return cacheManager.getCache(cacheName);
+    }
+
+    private Cache getS3ObjectCache()
+    {
+        return getS3Cache(EHCACHE_S3_OBJECT_KEY, new S3CacheEventListener());
+    }
+
+    private Cache getS3ListingCache()
+    {
+        return getS3Cache(EHCACHE_S3_LISTING_KEY);
     }
 
     @Override
@@ -50,13 +83,13 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
     @Override
     public String getName()
     {
-        return new File(path).getName();
+        return S3Helper.basename(path);
     }
 
     @Override
     public File getFile()
     {
-        return S3Helper.getS3File(path);
+        return S3Helper.getS3File(path, getS3ObjectCache());
     }
 
     @Override
@@ -100,7 +133,7 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
             throw new IllegalStateException(tmpMsg);
         }
 
-        List<ThreddsS3Object> listing = S3Helper.listS3Dir(this.path);
+        List<ThreddsS3Object> listing = S3Helper.listS3Dir(this.path, getS3ListingCache());
 
         if (listing.isEmpty())
         {
@@ -165,6 +198,7 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
     {
         private static String S3_PREFIX = "s3://";
         private static String S3_DELIMITER = "/";
+        private static HashMap<String, File> fileStore = new HashMap<String, File>();
 
         public static String concat(String parent, String child)
         {
@@ -178,6 +212,11 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
         {
             int delim = uri.lastIndexOf(S3_DELIMITER);
             return uri.substring(0, delim);
+        }
+
+        public static String basename(String uri)
+        {
+            return new File(uri).getName();
         }
 
         public static String[] s3UriParts(String uri) throws Exception
@@ -216,9 +255,39 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
             return  s3Client;
         }
 
-        public static File getS3File(String uri)
+        public static File createTempFile(String uri) throws IOException
+        {
+            // We have to save the key twice, as Ehcache will not provide
+            // us with tmpFile when eviction happens, so we use fileStore
+            Path tmpDir = Files.createTempDirectory("S3Download_");
+            String fileBasename = basename(uri);
+            File file = new File(tmpDir.toFile(), fileBasename);
+            file.deleteOnExit();
+            fileStore.put(uri, file);
+            return file;
+        }
+
+        public static void deleteFileElement(Element element)
+        {
+            File file = (File) fileStore.get(element.getObjectKey());
+            if (null == file)
+                return;
+
+            // Should cleanup what createTempFile has created, meaning we have
+            // to get rid of both the file and its containing directory
+            file.delete();
+            file.getParentFile().delete();
+
+            fileStore.remove(element.getObjectKey());
+        }
+
+        public static File getS3File(String uri, Cache cache)
         {
             log.debug(String.format("S3 Downloading '%s'", uri));
+
+            Element element;
+            if ((element = cache.get(uri)) != null && ((File) element.getObjectValue()).exists())
+                return (File) element.getObjectValue();
 
             try
             {
@@ -228,15 +297,15 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
 
                 S3Object object = getS3Client().getObject(new GetObjectRequest(s3Bucket, s3Key));
 
-                Path tmpDir = Files.createTempDirectory("S3Download_");
-                String fileBasename = new File(uri).getName();
-                File tmpFile = new File(tmpDir.toFile(), fileBasename);
+                File tmpFile = createTempFile(uri);
 
                 log.info(String.format("S3 Downloading 's3://%s/%s' to '%s'", s3Bucket, s3Key, tmpFile.toString()));
                 OutputStream os = new FileOutputStream(tmpFile);
                 InputStream is = object.getObjectContent();
 
                 IOUtils.copy(is, os);
+
+                cache.put(new Element(uri, tmpFile));
 
                 return tmpFile;
             }
@@ -249,8 +318,12 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
             return null;
         }
 
-        public static List<ThreddsS3Object> listS3Dir(String uri)
+        public static List<ThreddsS3Object> listS3Dir(String uri, Cache cache)
         {
+            Element element;
+            if ((element = cache.get(uri)) != null)
+                return (List<ThreddsS3Object>) element.getObjectValue();
+
             List<ThreddsS3Object> listing = new ArrayList<ThreddsS3Object>();
 
             log.debug(String.format("S3 Listing '%s'", uri));
@@ -288,6 +361,8 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
 
                     listing.add(new ThreddsS3Object(key, ThreddsS3Object.Type.DIR));
                 }
+
+                cache.put(new Element(uri, listing));
             }
             catch (Exception e)
             {
@@ -299,4 +374,30 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
         }
     }
 
+    public static class S3CacheEventListener implements CacheEventListener
+    {
+        public void notifyElementRemoved(final Ehcache cache, final Element element) throws CacheException
+        {
+            S3Helper.deleteFileElement(element);
+        }
+
+        public void notifyElementExpired(final Ehcache cache, final Element element)
+        {
+            S3Helper.deleteFileElement(element);
+        }
+
+        public void notifyElementEvicted(Ehcache cache, Element element)
+        {
+            S3Helper.deleteFileElement(element);
+        }
+
+        public void notifyElementPut(final Ehcache cache, final Element element) throws CacheException {}
+        public void notifyElementUpdated(final Ehcache cache, final Element element) throws CacheException {}
+        public void notifyRemoveAll(Ehcache cache) {}
+        public void dispose() {}
+        public Object clone() throws CloneNotSupportedException
+        {
+            return super.clone();
+        }
+    }
 }

--- a/cdm/src/main/java/thredds/crawlabledataset/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/CrawlableDatasetAmazonS3.java
@@ -1,0 +1,302 @@
+package thredds.crawlabledataset;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile
+{
+    static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CrawlableDatasetAmazonS3.class);
+
+    private final Object configObject;
+    private final String path;
+    private ThreddsS3Object s3Object = null;
+
+    private static final String EHCACHE_S3_KEY = "S3";
+
+    public CrawlableDatasetAmazonS3(String path, Object configObject)
+    {
+        super(path, configObject);
+        this.path = path;
+        this.configObject = configObject;
+    }
+
+    private CrawlableDatasetAmazonS3(CrawlableDatasetAmazonS3 parent, ThreddsS3Object s3Object)
+    {
+        this(S3Helper.concat(parent.getPath(), s3Object.key), null);
+        this.s3Object = s3Object;
+    }
+
+    @Override
+    public Object getConfigObject()
+    {
+        return configObject;
+    }
+
+    @Override
+    public String getPath()
+    {
+        return path;
+    }
+
+    @Override
+    public String getName()
+    {
+        return new File(path).getName();
+    }
+
+    @Override
+    public File getFile()
+    {
+        return S3Helper.getS3File(path);
+    }
+
+    @Override
+    public CrawlableDataset getParentDataset()
+    {
+        return new CrawlableDatasetAmazonS3(S3Helper.parent(path), configObject);
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isCollection()
+    {
+        if (null == s3Object)
+            return true;
+        else
+            return s3Object.type == ThreddsS3Object.Type.DIR;
+    }
+
+    @Override
+    public CrawlableDataset getDescendant(String relativePath)
+    {
+        if (relativePath.startsWith("/"))
+            throw new IllegalArgumentException("Path must be relative <" + relativePath + ">.");
+
+        ThreddsS3Object obj = new ThreddsS3Object(relativePath, ThreddsS3Object.Type.DIR);
+        return new CrawlableDatasetAmazonS3(this, obj);
+    }
+
+    @Override
+    public List<CrawlableDataset> listDatasets() throws IOException
+    {
+        if (!this.isCollection())
+        {
+            String tmpMsg = "This dataset <" + this.getPath() + "> is not a collection dataset.";
+            log.error( "listDatasets(): " + tmpMsg);
+            throw new IllegalStateException(tmpMsg);
+        }
+
+        List<ThreddsS3Object> listing = S3Helper.listS3Dir(this.path);
+
+        if (listing.isEmpty())
+        {
+            log.error("listDatasets(): the underlying file [" + this.path + "] exists, but is empty");
+            return Collections.emptyList();
+        }
+
+        List<CrawlableDataset> list = new ArrayList<CrawlableDataset>();
+        for (ThreddsS3Object s3Object : listing)
+        {
+            CrawlableDatasetAmazonS3 crDs = new CrawlableDatasetAmazonS3(this, s3Object);
+            list.add(crDs);
+        }
+
+        return list;
+    }
+
+    @Override
+    public long length()
+    {
+        if (null != s3Object)
+            return s3Object.size;
+
+        throw new RuntimeException(String.format("Uknown size for object '%s'", path));
+    }
+
+    @Override
+    public Date lastModified()
+    {
+        if (null != s3Object)
+            return s3Object.lastModified;
+
+        throw new RuntimeException(String.format("Uknown lastModified for object '%s'", path));
+    }
+
+    public static class ThreddsS3Object
+    {
+        public final String key;
+        public final long size;
+        public final Date lastModified;
+        public enum Type {
+            DIR,
+            FILE
+        }
+        public final Type type;
+
+        public ThreddsS3Object(String key, long size, Date lastModified, Type type)
+        {
+            this.key = key;
+            this.size = size;
+            this.lastModified = lastModified;
+            this.type = type;
+        }
+
+        public ThreddsS3Object(String key, Type type)
+        {
+            this(key, -1, null, type);
+        }
+    }
+
+    public static class S3Helper
+    {
+        private static String S3_PREFIX = "s3://";
+        private static String S3_DELIMITER = "/";
+
+        public static String concat(String parent, String child)
+        {
+            if (child.isEmpty())
+                return parent;
+            else
+                return parent + S3_DELIMITER + removeTrailingSlash(child);
+        }
+
+        public static String parent(String uri)
+        {
+            int delim = uri.lastIndexOf(S3_DELIMITER);
+            return uri.substring(0, delim);
+        }
+
+        public static String[] s3UriParts(String uri) throws Exception
+        {
+            if (uri.startsWith(S3_PREFIX))
+            {
+                uri = stripPrefix(uri, S3_PREFIX);
+                String[] parts = new String[2];
+                int delim = uri.indexOf(S3_DELIMITER);
+                parts[0] = uri.substring(0, delim);
+                parts[1] = uri.substring(Math.min(delim + 1, uri.length()), uri.length());
+                return parts;
+            }
+            else
+                throw new IllegalArgumentException(String.format("Not a valid s3 uri: %s", uri));
+        }
+
+        private static String stripPrefix(String key, String prefix)
+        {
+            return key.replaceFirst(prefix, "");
+        }
+
+        private static String removeTrailingSlash(String str)
+        {
+            if (str.endsWith(S3_DELIMITER))
+                str = str.substring(0, str.length() - 1);
+
+            return str;
+        }
+
+        private static AmazonS3Client getS3Client()
+        {
+            // Use HTTP, it's much faster
+            AmazonS3Client s3Client = new AmazonS3Client();
+            s3Client.setEndpoint("http://s3.amazonaws.com");
+            return  s3Client;
+        }
+
+        public static File getS3File(String uri)
+        {
+            log.debug(String.format("S3 Downloading '%s'", uri));
+
+            try
+            {
+                String[] uriParts = s3UriParts(uri);
+                String s3Bucket = uriParts[0];
+                String s3Key = uriParts[1];
+
+                S3Object object = getS3Client().getObject(new GetObjectRequest(s3Bucket, s3Key));
+
+                Path tmpDir = Files.createTempDirectory("S3Download_");
+                String fileBasename = new File(uri).getName();
+                File tmpFile = new File(tmpDir.toFile(), fileBasename);
+
+                log.info(String.format("S3 Downloading 's3://%s/%s' to '%s'", s3Bucket, s3Key, tmpFile.toString()));
+                OutputStream os = new FileOutputStream(tmpFile);
+                InputStream is = object.getObjectContent();
+
+                IOUtils.copy(is, os);
+
+                return tmpFile;
+            }
+            catch (Exception e)
+            {
+                log.error(String.format(String.format("S3 Error downloading '%s'", uri)));
+                e.printStackTrace();
+            }
+
+            return null;
+        }
+
+        public static List<ThreddsS3Object> listS3Dir(String uri)
+        {
+            List<ThreddsS3Object> listing = new ArrayList<ThreddsS3Object>();
+
+            log.debug(String.format("S3 Listing '%s'", uri));
+
+            try
+            {
+                String[] uriParts = s3UriParts(uri);
+                String s3Bucket = uriParts[0];
+                String s3Key = uriParts[1];
+
+                if (!s3Key.endsWith(S3_DELIMITER))
+                    s3Key += S3_DELIMITER;
+
+                final ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
+                        .withBucketName(s3Bucket)
+                        .withPrefix(s3Key)
+                        .withDelimiter(S3_DELIMITER);
+
+                final ObjectListing objectListing = getS3Client().listObjects(listObjectsRequest);
+
+                for (final S3ObjectSummary objectSummary : objectListing.getObjectSummaries())
+                {
+                    listing.add(new ThreddsS3Object(
+                            stripPrefix(objectSummary.getKey(), s3Key),
+                            objectSummary.getSize(),
+                            objectSummary.getLastModified(),
+                            ThreddsS3Object.Type.FILE
+                    ));
+                }
+
+                for (final String commonPrefix : objectListing.getCommonPrefixes())
+                {
+                    String key = stripPrefix(commonPrefix, s3Key);
+                    key = removeTrailingSlash(key);
+
+                    listing.add(new ThreddsS3Object(key, ThreddsS3Object.Type.DIR));
+                }
+            }
+            catch (Exception e)
+            {
+                log.error(String.format(String.format("S3 Error listing '%s'", uri)));
+                e.printStackTrace();
+            }
+
+            return listing;
+        }
+    }
+
+}

--- a/cdm/src/test/java/thredds/crawlabledataset/TestCrawlableDatasetAmazonS3.java
+++ b/cdm/src/test/java/thredds/crawlabledataset/TestCrawlableDatasetAmazonS3.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1998-2009 University Corporation for Atmospheric Research/Unidata
+ *
+ * Portions of this software were developed by the Unidata Program at the
+ * University Corporation for Atmospheric Research.
+ *
+ * Access and use of this software shall impose the following obligations
+ * and understandings on the user. The user is granted the right, without
+ * any fee or cost, to use, copy, modify, alter, enhance and distribute
+ * this software, and any derivative works thereof, and its supporting
+ * documentation for any purpose whatsoever, provided that this entire
+ * notice appears in all copies of the software, derivative works and
+ * supporting documentation.  Further, UCAR requests that the user credit
+ * UCAR/Unidata in any publications that result from the use of this
+ * software or in any product that includes this software. The names UCAR
+ * and/or Unidata, however, may not be used in any advertising or publicity
+ * to endorse or promote any products or commercial entity unless specific
+ * written permission is obtained from UCAR/Unidata. The user also
+ * understands that UCAR/Unidata is not obligated to provide the user with
+ * any support, consulting, training or assistance of any kind with regard
+ * to the use, operation and performance of this software nor to provide
+ * the user with any updates, revisions, new versions or "bug fixes."
+ *
+ * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+ * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+ * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+package thredds.crawlabledataset;
+
+import net.sf.ehcache.Element;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.*;
+
+public class TestCrawlableDatasetAmazonS3
+{
+    @Test
+    public void testS3HelperParent()
+    {
+        assertEquals("s3://bucket/path/to", CrawlableDatasetAmazonS3.S3Helper.parent("s3://bucket/path/to/object"));
+    }
+
+    @Test
+    public void testS3HelperConcat()
+    {
+        assertEquals("s3://bucket/path/to/object", CrawlableDatasetAmazonS3.S3Helper.concat("s3://bucket/path/to", "object"));
+        assertEquals("s3://bucket/path/to/object", CrawlableDatasetAmazonS3.S3Helper.concat("s3://bucket/path/to", "object/"));
+        assertEquals("s3://bucket/path/to", CrawlableDatasetAmazonS3.S3Helper.concat("s3://bucket/path/to", ""));
+    }
+
+    @Test
+    public void testS3HelperS3UriParts() throws Exception
+    {
+        String[] parts = CrawlableDatasetAmazonS3.S3Helper.s3UriParts("s3://bucket/path/to/object");
+        assertEquals("bucket", parts[0]);
+        assertEquals("path/to/object", parts[1]);
+    }
+
+    @Test
+    public void testS3HelperFileCreationDeletion() throws Exception
+    {
+        File tmpFile = CrawlableDatasetAmazonS3.S3Helper.createTempFile("s3://bucket/path/to/object");
+        assertEquals(tmpFile.getName(), "object");
+        tmpFile.createNewFile();
+        assertTrue(tmpFile.exists());
+
+        CrawlableDatasetAmazonS3.S3Helper.deleteFileElement(new Element("s3://bucket/path/to/object", null));
+        assertFalse(tmpFile.exists());
+    }
+}


### PR DESCRIPTION
This is a S3 crawlable dataset implementation, it is rather concise and provides thredds the capability of browsing S3 buckets. At the moment it'll cache files for up to 1 minute (hardcoded, but can be modified).

A configuration for a dataset would look like:
```
  <datasetScan name="Amazon S3 Dataset" ID="testS3" path="IMOS" location="s3://bucket-name/path">
    <metadata inherited="true">
      <serviceName>all</serviceName>
      <dataType>Grid</dataType>
    </metadata>
    <addDatasetSize/>
    <crawlableDatasetImpl className="thredds.crawlabledataset.CrawlableDatasetAmazonS3"/>
  </datasetScan>
```

At IMOS, we are about to migrate large portions of data to S3. Thredds is one of our main front facing applications and we have decided to implement proper S3 support for it, rather than use one of the available (and experimental) filesystem interfaces to S3.