### PR TITLE
Fix unit test with broken Assume.

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestAuth.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestAuth.java
@@ -38,11 +38,11 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.junit.Assume;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import ucar.httpservices.*;
 import ucar.nc2.util.UnitTestCommon;
-import ucar.unidata.test.util.NotJenkins;
 import ucar.unidata.test.util.TestDir;
 import ucar.unidata.test.util.ThreddsServer;
 
@@ -203,24 +203,14 @@ public class TestAuth extends UnitTestCommon
     //////////////////////////////////////////////////
     // Constructor(s)
 
-    public TestAuth(String name, String testdir)
+    public TestAuth()
     {
-        super(name);
+        super("TestAuth");
         setTitle("DAP Authorization tests");
         // Make sure temp file exist
         temppath = getThreddsroot() + "/" + MODULE + "/" + TEMPROOT;
         new File(temppath).mkdirs();
         //HTTPSession.debugHeaders(true);
-    }
-
-    public TestAuth(String name)
-    {
-        this(name, null);
-    }
-
-    public TestAuth()
-    {
-        this("TestAuth", null);
     }
 
     @Before
@@ -248,7 +238,7 @@ public class TestAuth extends UnitTestCommon
                 int status = method.execute();
                 System.out.printf("\tstatus code = %d\n", status);
                 pass = (status == 200);
-                assertTrue("testSSH", pass);
+                Assert.assertTrue("testSSH", pass);
             }
         }
     }
@@ -293,8 +283,8 @@ public class TestAuth extends UnitTestCommon
                 this.result = invoke(session, data.url);
             }
             pass &= (this.result.status == 200 || this.result.status == 404); // non-existence is ok
-            assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
-            assertTrue("no content", this.result.contents.length > 0);
+            Assert.assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
+            Assert.assertTrue("no content", this.result.contents.length > 0);
         }
 
         for(AuthDataBasic data : basictests) {
@@ -308,11 +298,11 @@ public class TestAuth extends UnitTestCommon
                 this.result = invoke(session, data.url);
             }
             pass &= (this.result.status == 200 || this.result.status == 404); // non-existence is ok
-            assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
-            assertTrue("no content", this.result.contents.length > 0);
+            Assert.assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
+            Assert.assertTrue("no content", this.result.contents.length > 0);
 
         }
-        assertTrue("testBasic", pass);
+        Assert.assertTrue("testBasic", pass);
     }
 
     @Test
@@ -333,7 +323,7 @@ public class TestAuth extends UnitTestCommon
                 this.result = invoke(session, data.url);
             }
             pass &= (this.result.status == 200 || this.result.status == 404); // non-existence is ok
-            assertTrue("no content", this.result.contents.length > 0);
+            Assert.assertTrue("no content", this.result.contents.length > 0);
         }
 
         for(AuthDataBasic data : basictests) {
@@ -348,9 +338,9 @@ public class TestAuth extends UnitTestCommon
 
             }
             pass &= (this.result.status == 200 || this.result.status == 404); // non-existence is ok
-            assertTrue("no content", this.result.contents.length > 0);
+            Assert.assertTrue("no content", this.result.contents.length > 0);
         }
-        assertTrue("testBasic", pass);
+        Assert.assertTrue("testBasic", pass);
     }
 
 
@@ -372,7 +362,7 @@ public class TestAuth extends UnitTestCommon
                 this.result = invoke(session, data.url);
             }
             pass &= (this.result.status == 401); // bad password should fail
-            assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
+            Assert.assertTrue("Credentials provider called: " + this.result.count, this.result.count == 1);
             // Look at the invalidation list
             List<HTTPCachingProvider.Auth> removed = HTTPCachingProvider.getTestList();
             if(removed.size() == 1) {
@@ -388,10 +378,10 @@ public class TestAuth extends UnitTestCommon
                     session.setCredentialsProvider(data.url, this.provider);
                     this.result = invoke(session, data.url);
                 }
-                assertTrue(result.status == 200);
+                Assert.assertTrue(result.status == 200);
             }
         }
-        assertTrue("testBasic", pass);
+        Assert.assertTrue("testBasic", pass);
     }
 
     @Test

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestFormBuilder.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestFormBuilder.java
@@ -33,6 +33,7 @@
 package ucar.nc2.util.net;
 
 import org.apache.http.HttpEntity;
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.httpservices.*;
 import ucar.nc2.util.UnitTestCommon;
@@ -139,7 +140,7 @@ public class TestFormBuilder extends UnitTestCommon
             exc.printStackTrace();
             pass = false;
         }
-        assertTrue("TestFormBuilder.simple: failed", pass);
+        Assert.assertTrue("TestFormBuilder.simple: failed", pass);
     }
 
     @Test
@@ -185,7 +186,7 @@ public class TestFormBuilder extends UnitTestCommon
             exc.printStackTrace();
             pass = false;
         }
-        assertTrue("TestFormBuilder.multipart: failed", pass);
+        Assert.assertTrue("TestFormBuilder.multipart: failed", pass);
     }
 
     protected HTTPFormBuilder buildForm(boolean multipart)

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPMethod.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPMethod.java
@@ -32,6 +32,9 @@
 
 package ucar.nc2.util.net;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import ucar.httpservices.HTTPException;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
@@ -76,11 +79,12 @@ public class TestHTTPMethod extends UnitTestCommon
         setTitle("HTTP Method tests");
     }
 
-    @Override
+    @Before
     public void setUp() {
         ThreddsServer.REMOTETEST.assumeIsAvailable();
     }
 
+    @Test
     public void
     testGetStream() throws Exception
     {
@@ -105,9 +109,10 @@ public class TestHTTPMethod extends UnitTestCommon
                 pass = true;
             }
         }
-        assertTrue("TestHTTPMethod.testGetStream", pass);
+        Assert.assertTrue("TestHTTPMethod.testGetStream", pass);
     }
 
+    @Test
     public void
     testGetStreamPartial() throws Exception
     {
@@ -131,6 +136,6 @@ public class TestHTTPMethod extends UnitTestCommon
                 pass = true;
             }
         }
-        assertTrue("TestHTTPMethod.testGetStreamPartial", pass);
+        Assert.assertTrue("TestHTTPMethod.testGetStreamPartial", pass);
     }
 }

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPSession.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPSession.java
@@ -32,6 +32,7 @@
 
 package ucar.nc2.util.net;
 
+import org.junit.Assert;
 import org.junit.Before;
 import ucar.httpservices.*;
 
@@ -98,11 +99,11 @@ public class TestHTTPSession extends UnitTestCommon
             // Use special interface to access the request
             // Look for the user agent header
             List<Header> agents = HTTPSession.debugRequestInterceptor().getHeaders(HTTPSession.HEADER_USERAGENT);
-            assertFalse("User-Agent Header not found", agents.size() == 0);
-            assertFalse("Multiple User-Agent Headers", agents.size() > 1);
-            assertTrue(String.format("User-Agent mismatch: expected %s found:%s",
-                    GLOBALAGENT, agents.get(0).getValue()),
-                GLOBALAGENT.equals(agents.get(0).getValue()));
+            Assert.assertFalse("User-Agent Header not found", agents.size() == 0);
+            Assert.assertFalse("Multiple User-Agent Headers", agents.size() > 1);
+            Assert.assertTrue(String.format("User-Agent mismatch: expected %s found:%s",
+                            GLOBALAGENT, agents.get(0).getValue()),
+                    GLOBALAGENT.equals(agents.get(0).getValue()));
             System.out.println("*** Pass: set global agent");
 
             System.out.println("Test: HTTPSession.setUserAgent(" + SESSIONAGENT + ")");
@@ -113,11 +114,11 @@ public class TestHTTPSession extends UnitTestCommon
 
             // Use special interface to access the request
             agents = HTTPSession.debugRequestInterceptor().getHeaders(HTTPSession.HEADER_USERAGENT);
-            assertFalse("User-Agent Header not found", agents.size() == 0);
-            assertFalse("Multiple User-Agent Headers", agents.size() > 1);
-            assertTrue(String.format("User-Agent mismatch: expected %s found:%s",
-                    SESSIONAGENT, agents.get(0).getValue()),
-                SESSIONAGENT.equals(agents.get(0).getValue()));
+            Assert.assertFalse("User-Agent Header not found", agents.size() == 0);
+            Assert.assertFalse("Multiple User-Agent Headers", agents.size() > 1);
+            Assert.assertTrue(String.format("User-Agent mismatch: expected %s found:%s",
+                            SESSIONAGENT, agents.get(0).getValue()),
+                    SESSIONAGENT.equals(agents.get(0).getValue()));
             System.out.println("*** Pass: set session agent");
         }
     }
@@ -153,22 +154,22 @@ public class TestHTTPSession extends UnitTestCommon
 
             boolean b = dbgreq.getParams().getBooleanParameter(HTTPSession.ALLOW_CIRCULAR_REDIRECTS, true);
             System.out.println("Test: Circular Redirects");
-            assertTrue("*** Fail: Circular Redirects", b);
+            Assert.assertTrue("*** Fail: Circular Redirects", b);
             System.out.println("*** Pass: Circular Redirects");
 
             System.out.println("Test: Max Redirects");
             int n = dbgreq.getParams().getIntParameter(MAX_REDIRECTS, -1);
-            assertTrue("*** Fail: Max Redirects", n == 111);
+            Assert.assertTrue("*** Fail: Max Redirects", n == 111);
             System.out.println("*** Pass: Max Redirects");
 
             System.out.println("Test: SO Timeout");
             n = dbgreq.getParams().getIntParameter(SO_TIMEOUT, -1);
-            assertTrue("*** Fail: SO Timeout", n == 17777);
+            Assert.assertTrue("*** Fail: SO Timeout", n == 17777);
             System.out.println("*** Pass: SO Timeout");
 
             System.out.println("Test: Connection Timeout");
             n = dbgreq.getParams().getIntParameter(CONN_TIMEOUT, -1);
-            assertTrue("*** Fail: Connection Timeout", n == 37777);
+            Assert.assertTrue("*** Fail: Connection Timeout", n == 37777);
             System.out.println("*** Pass: SO Timeout");
 
         /* no longer used

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestMisc.java
@@ -32,6 +32,9 @@
 
 package ucar.nc2.util.net;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.httpservices.HTTPSession;
@@ -40,7 +43,6 @@ import ucar.nc2.util.Misc;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.ThreddsServer;
 
-import java.net.URI;
 import java.util.List;
 
 public class TestMisc extends UnitTestCommon
@@ -79,6 +81,7 @@ public class TestMisc extends UnitTestCommon
         "http://localhost:8081/%3c%3e%5e/%60/",
     };
 
+    @Test
     public void
     testEscapeStrings() throws Exception
     {
@@ -92,9 +95,10 @@ public class TestMisc extends UnitTestCommon
             if(!result.equals(esoutputs[i])) pass = false;
             System.out.printf("input=%s output=%s pass=%s\n", esinputs[i], result, pass);
         }
-        assertTrue("TestMisc.testEscapeStrings", pass);
+        Assert.assertTrue("TestMisc.testEscapeStrings", pass);
     }
 
+    @Test
     public void
     testUTF8Stream()
         throws Exception
@@ -136,26 +140,27 @@ public class TestMisc extends UnitTestCommon
         return ok;
     }
 
+    @Test
     public void
     testGetProtocols()
     {
         String tag = "TestMisc.testGetProtocols";
-        assertTrue(tag, protocheck("http://server/thredds/dodsC/", "http:"));
-        assertTrue(tag, protocheck("dods://thredds-test.unidata.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best", "dods:"));
-        assertTrue(tag, protocheck("dap4://ucar.edu:8080/x/y/z", "dap4:"));
-        assertTrue(tag, protocheck("dap4:https://ucar.edu:8080/x/y/z", "dap4:https:"));
-        assertTrue(tag, protocheck("file:///x/y/z", "file:"));
-        assertTrue(tag, protocheck("file://c:/x/y/z", "file:"));
-        assertTrue(tag, protocheck("file:c:/x/y/z", "file:"));
-        assertTrue(tag, protocheck("file:/blah/blah/some_file_2014-04-13_16:00:00.nc.dds", "file:"));
-        assertTrue(tag, protocheck("/blah/blah/some_file_2014-04-13_16:00:00.nc.dds", ""));
-        assertTrue(tag, protocheck("c:/x/y/z", null));
-        assertTrue(tag, protocheck("x::a/y/z", null));
-        assertTrue(tag, protocheck("x::/y/z", null));
-        assertTrue(tag, protocheck("::/y/z", ""));
-        assertTrue(tag, protocheck("dap4:&/y/z", null));
-        assertTrue(tag, protocheck("file:x/z::a", "file:"));
-        assertTrue(tag, protocheck("x/z::a", null));
+        Assert.assertTrue(tag, protocheck("http://server/thredds/dodsC/", "http:"));
+        Assert.assertTrue(tag, protocheck("dods://thredds-test.unidata.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best", "dods:"));
+        Assert.assertTrue(tag, protocheck("dap4://ucar.edu:8080/x/y/z", "dap4:"));
+        Assert.assertTrue(tag, protocheck("dap4:https://ucar.edu:8080/x/y/z", "dap4:https:"));
+        Assert.assertTrue(tag, protocheck("file:///x/y/z", "file:"));
+        Assert.assertTrue(tag, protocheck("file://c:/x/y/z", "file:"));
+        Assert.assertTrue(tag, protocheck("file:c:/x/y/z", "file:"));
+        Assert.assertTrue(tag, protocheck("file:/blah/blah/some_file_2014-04-13_16:00:00.nc.dds", "file:"));
+        Assert.assertTrue(tag, protocheck("/blah/blah/some_file_2014-04-13_16:00:00.nc.dds", ""));
+        Assert.assertTrue(tag, protocheck("c:/x/y/z", null));
+        Assert.assertTrue(tag, protocheck("x::a/y/z", null));
+        Assert.assertTrue(tag, protocheck("x::/y/z", null));
+        Assert.assertTrue(tag, protocheck("::/y/z", ""));
+        Assert.assertTrue(tag, protocheck("dap4:&/y/z", null));
+        Assert.assertTrue(tag, protocheck("file:x/z::a", "file:"));
+        Assert.assertTrue(tag, protocheck("x/z::a", null));
     }
 
 }

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestState.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestState.java
@@ -34,6 +34,7 @@ package ucar.nc2.util.net;
 
 import ucar.httpservices.*;
 
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
@@ -80,69 +81,69 @@ public class TestState extends UnitTestCommon
         ThreddsServer.REMOTETEST.assumeIsAvailable();
         int status = 0;
         HTTPSession session = HTTPFactory.newSession(SESSIONURL); // do NOT use try(){}
-        assertFalse(session.isClosed());
+        Assert.assertFalse(session.isClosed());
 
         // Check state transitions for open and execute
         HTTPMethod method = HTTPFactory.Get(session, TESTSOURCE1);
-        assertFalse(method.isClosed());
+        Assert.assertFalse(method.isClosed());
         int methodcount = session.getMethodcount();
-        assertTrue(methodcount == 1);
+        Assert.assertTrue(methodcount == 1);
 
         // Check that stream close causes method close
         status = method.execute();
         HTTPMethodStream stream = (HTTPMethodStream) method.getResponseBodyAsStream();
-        assertTrue(method.hasStreamOpen());
+        Assert.assertTrue(method.hasStreamOpen());
         stream.close();
-        assertTrue(method.isClosed());
-        assertFalse(method.hasStreamOpen());
+        Assert.assertTrue(method.isClosed());
+        Assert.assertFalse(method.hasStreamOpen());
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 0);
+        Assert.assertTrue(methodcount == 0);
 
         // Check that method close forcibly closes streams
         method = HTTPFactory.Get(session, TESTSOURCE1);
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 1);
+        Assert.assertTrue(methodcount == 1);
         status = method.execute();
         stream = (HTTPMethodStream) method.getResponseBodyAsStream();
         method.close();
-        assertTrue(stream.isClosed());
-        assertFalse(method.hasStreamOpen());
-        assertTrue(method.isClosed());
+        Assert.assertTrue(stream.isClosed());
+        Assert.assertFalse(method.hasStreamOpen());
+        Assert.assertTrue(method.isClosed());
 
         // Check that session close closes methods and streams
         // and transitively until stream close
         method = HTTPFactory.Get(session,TESTSOURCE1);
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 1);
+        Assert.assertTrue(methodcount == 1);
         status = method.execute();
         stream = (HTTPMethodStream) method.getResponseBodyAsStream();
         session.close();
-        assertTrue(stream.isClosed());
-        assertTrue(method.isClosed());
+        Assert.assertTrue(stream.isClosed());
+        Assert.assertTrue(method.isClosed());
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 0);
-        assertTrue(session.isClosed());
+        Assert.assertTrue(methodcount == 0);
+        Assert.assertTrue(session.isClosed());
 
         // Test Local session
         method = HTTPFactory.Get(TESTSOURCE1);
-        assertTrue(method.isSessionLocal());
+        Assert.assertTrue(method.isSessionLocal());
         session = method.getSession();
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 1);
+        Assert.assertTrue(methodcount == 1);
         status = method.execute();
         String body = method.getResponseAsString();// will close stream
         try {
             stream = (HTTPMethodStream) method.getResponseBodyAsStream();
             readbinaryfile(stream);
             System.err.println("Stream not closed.");
-            assertFalse(stream.isClosed());
+            Assert.assertFalse(stream.isClosed());
         } catch (Exception e) {
-            assertFalse(method.hasStreamOpen());
+            Assert.assertFalse(method.hasStreamOpen());
         }
-        assertTrue(method.isClosed());
+        Assert.assertTrue(method.isClosed());
         methodcount = session.getMethodcount();
-        assertTrue(methodcount == 0);
-        assertTrue(session.isClosed());
+        Assert.assertTrue(methodcount == 0);
+        Assert.assertTrue(session.isClosed());
     }
 
 

--- a/cdm/src/test/java/ucar/nc2/util/UnitTestCommon.java
+++ b/cdm/src/test/java/ucar/nc2/util/UnitTestCommon.java
@@ -4,7 +4,6 @@
 
 package ucar.nc2.util;
 
-import junit.framework.TestCase;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.nc2.NetcdfFile;
@@ -17,7 +16,7 @@ import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.Set;
 
-public class UnitTestCommon extends TestCase
+public class UnitTestCommon
 {
     //////////////////////////////////////////////////
     // Static Constants
@@ -135,7 +134,6 @@ public class UnitTestCommon extends TestCase
 
     public UnitTestCommon(String name)
     {
-        super(name);
         this.name = name;
         setSystemProperties();
         initPaths();
@@ -197,6 +195,10 @@ public class UnitTestCommon extends TestCase
     public String getThreddsroot()
     {
         return this.threddsroot;
+    }
+
+    public String getName() {
+        return this.name;
     }
 
     //////////////////////////////////////////////////

--- a/opendap/src/test/java/opendap/test/TestCeParser.java
+++ b/opendap/src/test/java/opendap/test/TestCeParser.java
@@ -37,6 +37,7 @@ import opendap.dap.*;
 import opendap.dap.parsers.*;
 import opendap.servers.*;
 import opendap.servers.parsers.CeParser;
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.util.UnitTestCommon;
 //import opendap.dts.*;
@@ -557,7 +558,7 @@ public class TestCeParser extends UnitTestCommon
       }
       if (!generate && !pass) break;
     }
-    assertTrue("TestCeParser", pass || generate);
+    Assert.assertTrue("TestCeParser", pass || generate);
   }
 
 }

--- a/opendap/src/test/java/opendap/test/TestClone.java
+++ b/opendap/src/test/java/opendap/test/TestClone.java
@@ -35,6 +35,7 @@ package opendap.test;
 
 import opendap.dap.parsers.*;
 import opendap.dap.*;
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.unidata.test.Diff;
 
@@ -155,7 +156,7 @@ public class TestClone extends TestFiles {
         clonerdr.close();
         resultrdr.close();
         if (!pass)
-          assertTrue(testname, pass);
+          Assert.assertTrue(testname, pass);
       } catch (IOException ioe) {
         System.err.println("Close failure");
       }

--- a/opendap/src/test/java/opendap/test/TestDConnect2.java
+++ b/opendap/src/test/java/opendap/test/TestDConnect2.java
@@ -3,6 +3,8 @@ package opendap.test;
 import opendap.dap.*;
 import opendap.util.Getopts;
 import opendap.util.InvalidSwitch;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import ucar.unidata.test.Diff;
 import ucar.unidata.test.util.ThreddsServer;
@@ -54,8 +56,8 @@ public class TestDConnect2 extends TestSources {
     setTitle("DAP DConnect2 Tests");
   }
 
-  @Override
-  protected void setUp() {
+  @Before
+  public void setUp() {
     ThreddsServer.REMOTETEST.assumeIsAvailable();
     passcount = 0;
     xfailcount = 0;
@@ -98,7 +100,7 @@ public class TestDConnect2 extends TestSources {
     testpart(TestPart.DDS, ce);
     if (constrained) testpart(TestPart.DATADDS, ce);
     if (!pass)
-      assertTrue(testname, pass);
+      Assert.assertTrue(testname, pass);
 
   }
 

--- a/opendap/src/test/java/opendap/test/TestDapParser.java
+++ b/opendap/src/test/java/opendap/test/TestDapParser.java
@@ -37,8 +37,10 @@ import opendap.dap.DAP2Exception;
 import opendap.dap.DAS;
 import opendap.dap.DDS;
 import opendap.dap.parsers.ParseException;
-import ucar.nc2.util.UnitTestCommon;
+import org.junit.Assert;
+import org.junit.Test;
 import ucar.unidata.test.Diff;
+
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -76,6 +78,7 @@ abstract public class TestDapParser extends TestFiles
         setTitle("DAP Parser Tests");
     }
 
+    @Test
     public void
     testDapParser() throws Exception
     {
@@ -214,7 +217,7 @@ abstract public class TestDapParser extends TestFiles
         Diff diff = new Diff(test);
         boolean pass = !diff.doDiff(baseline, result);
         if(!pass)
-            assertTrue(testname, pass);
+            Assert.assertTrue(testname, pass);
         System.out.flush();
         System.err.flush();
     }

--- a/opendap/src/test/java/opendap/test/TestDuplicates.java
+++ b/opendap/src/test/java/opendap/test/TestDuplicates.java
@@ -32,6 +32,7 @@
 
 package opendap.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.util.UnitTestCommon;
@@ -132,7 +133,7 @@ public class TestDuplicates extends UnitTestCommon
     }
     System.out.flush();
     System.err.flush();
-    assertTrue("Testing " + getTitle(), pass);
+    Assert.assertTrue("Testing " + getTitle(), pass);
   }
 
 

--- a/opendap/src/test/java/opendap/test/TestGrid1.java
+++ b/opendap/src/test/java/opendap/test/TestGrid1.java
@@ -32,6 +32,8 @@
  */
 package opendap.test;
 
+import org.junit.Assert;
+import org.junit.Test;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
@@ -71,6 +73,7 @@ public class TestGrid1 extends UnitTestCommon
         setSystemProperties();
     }
 
+    @Test
     public void testGrid1()
             throws Exception
     {
@@ -92,7 +95,7 @@ public class TestGrid1 extends UnitTestCommon
             pass = false;
         }
 
-        assertTrue("TestGrid1: cannot find dataset", pass);
+        Assert.assertTrue("TestGrid1: cannot find dataset", pass);
 
         System.out.println("url: " + url);
 
@@ -116,7 +119,7 @@ public class TestGrid1 extends UnitTestCommon
                     pass = false;
             }
         }
-        assertTrue("Testing TestGrid1" + getTitle(), pass
+        Assert.assertTrue("Testing TestGrid1" + getTitle(), pass
 
         );
     }

--- a/opendap/src/test/java/opendap/test/TestGrid2.java
+++ b/opendap/src/test/java/opendap/test/TestGrid2.java
@@ -32,6 +32,9 @@
  */
 package opendap.test;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
@@ -71,6 +74,7 @@ public class TestGrid2 extends UnitTestCommon
         setSystemProperties();
     }
 
+    @Test
     public void testGrid2()
             throws Exception
     {
@@ -91,7 +95,7 @@ public class TestGrid2 extends UnitTestCommon
             pass = false;
         }
 
-        assertTrue("XFAIL : TestGrid2: cannot open dataset ="+url, true);
+        Assert.assertTrue("XFAIL : TestGrid2: cannot open dataset =" + url, true);
         if(!pass) return;
 
         System.out.println("url: " + url);
@@ -117,7 +121,7 @@ public class TestGrid2 extends UnitTestCommon
                 }
             }
         }
-        assertTrue("XFAIL : Testing TestGrid2" + getTitle(), true);
+        Assert.assertTrue("XFAIL : Testing TestGrid2" + getTitle(), true);
     }
 
     String ncdumpmetadata(NetcdfDataset ncfile)

--- a/opendap/src/test/java/opendap/test/TestGroups.java
+++ b/opendap/src/test/java/opendap/test/TestGroups.java
@@ -32,6 +32,8 @@
 
 package opendap.test;
 
+import org.junit.Assert;
+import org.junit.Test;
 import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.nc2.util.rc.RC;
@@ -77,7 +79,7 @@ public class TestGroups extends UnitTestCommon
     definetestcases()
     {
         String threddsRoot = getThreddsroot();
-        testcases = new ArrayList<Testcase>();
+        testcases = new ArrayList<>();
         if(false) {// use this arm to do debugging
             testcases.add(new Testcase("External user provided group example",
                 "http://" + testserver + "/thredds/dodsC/testdods/K1VHR.nc",
@@ -113,19 +115,20 @@ public class TestGroups extends UnitTestCommon
         }
     }
 
+    @Test
     public void
     testGroup() throws Exception
     {
         ThreddsServer.REMOTETEST.assumeIsAvailable();
         // Run  with usegroups == true
         if(!usegroups)
-            assertTrue("TestGroups: Group Support not enabled", false);
+            Assert.assertTrue("TestGroups: Group Support not enabled", false);
         System.out.println("TestGroups:");
         for(Testcase testcase : testcases) {
             System.out.println("url: " + testcase.url);
             boolean pass = process1(testcase);
             if(!pass)
-                assertTrue("Testing " + testcase.title, pass);
+                Assert.assertTrue("Testing " + testcase.title, pass);
         }
     }
 

--- a/opendap/src/test/java/opendap/test/TestMisc.java
+++ b/opendap/src/test/java/opendap/test/TestMisc.java
@@ -32,6 +32,9 @@
 
 package opendap.test;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.Diff;
@@ -99,6 +102,7 @@ public class TestMisc extends UnitTestCommon
     }
 
 
+    @Test
     public void
     testMisc() throws Exception
     {
@@ -108,7 +112,7 @@ public class TestMisc extends UnitTestCommon
             System.out.println("url: " + testcase.url);
             boolean pass = process1(testcase);
             if(!pass) {
-                assertTrue("Testing " + testcase.title, pass);
+                Assert.assertTrue("Testing " + testcase.title, pass);
             }
         }
     }

--- a/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
+++ b/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
@@ -37,6 +37,7 @@ import opendap.dap.BaseType;
 import opendap.servers.*;
 import opendap.servlet.AsciiWriter;
 import opendap.servlet.GuardedDataset;
+import org.junit.Test;
 import thredds.server.opendap.GuardedDatasetCacheAndClone;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.Diff;
@@ -101,9 +102,9 @@ public class TestCEEvaluator extends UnitTestCommon
     //////////////////////////////////////////////////
     // Constructors + etc.
 
-    public TestCEEvaluator(String name)
+    public TestCEEvaluator()
     {
-        super(name);
+        super("TestCEEvaluator");
         // Check to see if we are in the correct working directory
         String userdir = System.getProperty( "user.dir" );
         //if(userdir.endsWith("cdm")) {
@@ -113,13 +114,9 @@ public class TestCEEvaluator extends UnitTestCommon
         }
     }
 
-    protected void setUp()
-    {
-    }
-
-
     //////////////////////////////////////////////////
 
+    @Test
     public void testCEEvaluator() throws Exception
     {
         if(generate) dogenerate();


### PR DESCRIPTION
Assume doesn't work, because `TestAuth` inherits `UnitTestCommon`, which inherits `TestCase`. TestCase is JUnit 3.x, which is incompatible with the annotations of JUnit 4.x, especially `Assume`.

This ports users of UnitTestCommon to use annotations where necessary (some were using already).

Let's see if the tests pass....