### PR TITLE
Fix failing tests

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
@@ -51,9 +51,9 @@ import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.*;
 import ucar.unidata.geoloc.projection.LatLonProjection;
 import ucar.unidata.geoloc.vertical.VerticalTransform;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.NeedsCdmUnitTest;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -196,7 +196,7 @@ public class TestGridSubset {
 
   @Test
   public void testDODS() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     String ds = "http://thredds.ucar.edu/thredds/catalog/grib/NCEP/DGEX/CONUS_12km/files/latest.xml";
     GridDataset dataset = null;
 
@@ -328,7 +328,7 @@ public class TestGridSubset {
 
   @Test
   public void test3D() throws Exception {
-    ThreddsServer.DEV.assumeIsAvailable();
+    ExternalServer.DEV.assumeIsAvailable();
     try (GridDataset dataset = GridDataset.open("dods://thredds-dev.unidata.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best")) {
       System.out.printf("%s%n", dataset.getLocation());
       //GridDataset dataset = GridDataset.open("dods://thredds.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best");
@@ -494,7 +494,7 @@ public class TestGridSubset {
 
   @Test
   public void testBBSubset() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     try (GridDataset dataset = GridDataset.open("dods://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/CONUS_80km/best")) {
       GeoGrid grid = dataset.findGridByName("Pressure_surface");
       assert null != grid;
@@ -523,7 +523,7 @@ public class TestGridSubset {
 
   @Test
   public void testBBSubset2() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     try (GridDataset dataset = GridDataset.open("dods://thredds.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_40km/conduit/best")) {
       GeoGrid grid = dataset.findGridByName("Pressure_hybrid");
       assert null != grid;
@@ -749,7 +749,7 @@ public class TestGridSubset {
 
   @Test
   public void testFindVerticalCoordinate() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     String filename = "dods://thredds.ucar.edu/thredds/dodsC/grib/NCEP/NAM/Alaska_11km/best";
     try (GridDataset dataset = GridDataset.open(filename)) {
       GeoGrid grid = dataset.findGridByName("Geopotential_height_isobaric");

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountDods.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountDods.java
@@ -35,7 +35,7 @@ package ucar.nc2.dt.grid;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -107,13 +107,13 @@ public class TestReadAndCountDods {
 
   @Test
   public void readAndCount() throws Exception {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     TestReadandCount.doOne(base, name, ngrids, ncoordSys, ncoordAxes, nVertCooordAxes);
   }
 
   //@Test
   public void testProblem() throws Exception {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     TestReadandCount.doOne("thredds:resolve:http://thredds-test.unidata.ucar.edu/thredds/",
             "catalog/grib/NCEP/NAM/Alaska_11km/files/latest.xml", 59, 15, 18, 13);
   }

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountMisc.java
@@ -33,7 +33,7 @@
 package ucar.nc2.dt.grid;
 
 import org.junit.Test;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 /**
  * Describe
@@ -46,21 +46,21 @@ public class TestReadAndCountMisc {
   // We assume that thredds.ucar.edu is unreachable due to some limitation and/or bug in Travis.
   @Test
   public void testLiveServer() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     TestReadandCount.doOne("thredds:resolve:http://thredds.ucar.edu/thredds/",
             "catalog/grib/NCEP/NAM/CONUS_20km/noaaport/files/latest.xml", 33, 9, 11, 7);  // flips between 40 and 33
   }
 
   @Test
   public void testTestServer() throws Exception {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     TestReadandCount.doOne("thredds:resolve:http://thredds-test.unidata.ucar.edu/thredds/",
             "catalog/grib/NCEP/NAM/CONUS_20km/noaaport/files/latest.xml", 33, 9, 11, 7);
   }
 
   @Test
   public void testDevServer() throws Exception {
-    ThreddsServer.DEV.assumeIsAvailable();
+    ExternalServer.DEV.assumeIsAvailable();
     TestReadandCount.doOne("thredds:resolve:http://thredds-dev.unidata.ucar.edu/thredds/",
             "catalog/grib/NCEP/NAM/CONUS_20km/noaaport/files/latest.xml", 33, 9, 11, 7);
   }

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestGempakAll.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestGempakAll.java
@@ -45,7 +45,7 @@ import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Station;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -106,13 +106,13 @@ public class TestGempakAll {
   }
 
   public void utestCdmRemote() throws IOException {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     TestPointDatasets.checkPointDataset("cdmremote:http://thredds.ucar.edu/thredds/cdmremote/idd/metar/gempak", FeatureType.STATION, true);
     //checkPointDataset("cdmremote:http://localhost:8080/thredds/cdmremote/idd/metar/ncdecodedLocal", FeatureType.STATION, true);
   }
 
   public void utestCdmRemoteCollection() throws Exception {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     //testDon3("cdmremote:http://motherlode.ucar.edu:9080/thredds/cdmremote/idd/metar/gempak", false);
     while (true) {
       // testDon2("cdmremote:http://localhost:8080/thredds/cdmremote/idd/metar/gempakLocal", false);

--- a/cdm-test/src/test/java/ucar/nc2/util/net/NoTestAuth2.j
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/NoTestAuth2.j
@@ -38,7 +38,7 @@ import org.apache.http.client.CredentialsProvider;
 import ucar.httpservices.*;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestAuth.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestAuth.java
@@ -43,8 +43,8 @@ import org.junit.Before;
 import org.junit.Test;
 import ucar.httpservices.*;
 import ucar.nc2.util.UnitTestCommon;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
 
 import java.io.File;
 import java.io.IOException;
@@ -216,7 +216,7 @@ public class TestAuth extends UnitTestCommon
     @Before
     public void setUp()
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
     }
 
     @Test

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestFormBuilder.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestFormBuilder.java
@@ -34,9 +34,11 @@ package ucar.nc2.util.net;
 
 import org.apache.http.HttpEntity;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import ucar.httpservices.*;
 import ucar.nc2.util.UnitTestCommon;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -102,6 +104,12 @@ public class TestFormBuilder extends UnitTestCommon
         setTitle("HTTPFormBuilder test(s)");
         setSystemProperties();
         prop_visual = true; // force
+    }
+
+    @Before
+    public void setUp()
+    {
+        ExternalServer.HTTPKIT.assumeIsAvailable();
     }
 
     @Test

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPMethod.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPMethod.java
@@ -41,7 +41,7 @@ import ucar.httpservices.HTTPMethod;
 import ucar.httpservices.HTTPSession;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.InputStream;
 
@@ -81,7 +81,7 @@ public class TestHTTPMethod extends UnitTestCommon
 
     @Before
     public void setUp() {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
     }
 
     @Test

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPSession.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestHTTPSession.java
@@ -43,7 +43,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.message.AbstractHttpMessage;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.List;
 
@@ -79,7 +79,7 @@ public class TestHTTPSession extends UnitTestCommon
 
     @Before
     public void setUp() {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
     }
 
     @Test

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestMisc.java
@@ -41,7 +41,7 @@ import ucar.httpservices.HTTPSession;
 import ucar.nc2.util.EscapeStrings;
 import ucar.nc2.util.Misc;
 import ucar.nc2.util.UnitTestCommon;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.List;
 
@@ -103,7 +103,7 @@ public class TestMisc extends UnitTestCommon
     testUTF8Stream()
         throws Exception
     {
-        ThreddsServer.LIVE.assumeIsAvailable();
+        ExternalServer.LIVE.assumeIsAvailable();
         pass = true;
 
         String catalogName = "http://thredds-test.unidata.ucar.edu/thredds/catalog.xml";

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestState.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestState.java
@@ -38,7 +38,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.nio.charset.Charset;
 
@@ -78,7 +78,7 @@ public class TestState extends UnitTestCommon
     testState()
         throws Exception
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
         int status = 0;
         HTTPSession session = HTTPFactory.newSession(SESSIONURL); // do NOT use try(){}
         Assert.assertFalse(session.isClosed());

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestStream.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestStream.java
@@ -40,9 +40,8 @@ import thredds.catalog.InvCatalogFactory;
 import thredds.catalog.InvCatalogImpl;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
-import ucar.httpservices.HTTPSession;
 import ucar.nc2.constants.CDM;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,7 +57,7 @@ import java.net.URISyntaxException;
 public class TestStream {
   @Test
   public void testStream1() throws URISyntaxException {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     String catalogName = "http://thredds.ucar.edu/thredds/catalog.xml";
     URI catalogURI = new URI(catalogName);
 
@@ -83,7 +82,7 @@ public class TestStream {
 
   @Test
   public void testString() throws URISyntaxException {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     String catalogName = "http://thredds.ucar.edu/thredds/catalog.xml";
     URI catalogURI = new URI(catalogName);
 

--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -86,7 +86,7 @@ task testJar(type: Jar, dependsOn: testClasses,
         include 'ucar/unidata/test/util/CompareNetcdf.class'
         include 'ucar/unidata/test/util/TestDir*.class'
         include 'ucar/unidata/test/util/TestFileDirUtils.class'
-        include 'ucar/unidata/test/util/ThreddsServer.class'
+        include 'ucar/unidata/test/util/ExternalServer.class'
         include 'ucar/unidata/test/util/UtilsMa2Test.class'
         include 'ucar/unidata/test/util/UtilsTestStructureArray.class'
 

--- a/cdm/src/test/java/thredds/client/catalog/TestClientCatalogBasic.java
+++ b/cdm/src/test/java/thredds/client/catalog/TestClientCatalogBasic.java
@@ -35,7 +35,7 @@ package thredds.client.catalog;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,7 +77,7 @@ public class TestClientCatalogBasic {
   @Test
   public void testCatalog() throws IOException {
     if (catFrag.contains("thredds-test")) {
-      ThreddsServer.TEST.assumeIsAvailable();
+      ExternalServer.TEST.assumeIsAvailable();
     }
 
     for (Dataset ds : TestClientCatalog.open(catFrag).getDatasets())

--- a/cdm/src/test/java/thredds/client/catalog/TestResolve1.java
+++ b/cdm/src/test/java/thredds/client/catalog/TestResolve1.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.*;
@@ -126,7 +126,7 @@ public class TestResolve1 {
 
   @Test
   public void testResolver() throws IOException {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     String remoteDataset = "thredds:resolve:http://thredds-test.unidata.ucar.edu/thredds/catalog/grib/NCEP/RAP/CONUS_13km/files/latest.xml";
     try {
       NetcdfFile ncd = NetcdfDataset.openFile(remoteDataset, null);

--- a/cdm/src/test/java/ucar/nc2/TestHTTP.java
+++ b/cdm/src/test/java/ucar/nc2/TestHTTP.java
@@ -43,7 +43,7 @@ import ucar.nc2.constants.DataFormatType;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.Misc;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.Formatter;
@@ -55,7 +55,7 @@ public class TestHTTP  {
 
   @Before
   public void setUp() {
-    ThreddsServer.REMOTETEST.assumeIsAvailable();
+    ExternalServer.REMOTETEST.assumeIsAvailable();
   }
 
   @Test

--- a/cdm/src/test/java/ucar/nc2/TestHttpOpen.java
+++ b/cdm/src/test/java/ucar/nc2/TestHttpOpen.java
@@ -39,8 +39,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dt.grid.GridDataset;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -73,7 +73,7 @@ public class TestHttpOpen {
 
   @Before
   public void setUp() {
-    ThreddsServer.REMOTETEST.assumeIsAvailable();
+    ExternalServer.REMOTETEST.assumeIsAvailable();
   }
 
   // HTTP = 4300 HTTP2 = 5500 msec 20-25% slower

--- a/cdm/src/test/java/ucar/nc2/time/TestCalendarDateUnit.java
+++ b/cdm/src/test/java/ucar/nc2/time/TestCalendarDateUnit.java
@@ -3,8 +3,14 @@ package ucar.nc2.time;
 import ucar.nc2.units.DateFormatter;
 import ucar.nc2.units.DateUnit;
 import ucar.units.*;
-import org.junit.Test;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 
 /**
@@ -13,6 +19,7 @@ import java.util.Date;
  * @author caron
  * @since 3/25/11
  */
+@RunWith(Parameterized.class)
 public class TestCalendarDateUnit {
   DateFormatter df = new DateFormatter();
   UnitFormat format = UnitFormatManager.instance();
@@ -33,174 +40,90 @@ public class TestCalendarDateUnit {
 second
       YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
    */
-  @Test
-  public void testW3cIso() {
-    testBase("secs since 1997");
-    testBase("secs since 1997-07");
-    testBase("secs since 1997-07-16");
-    testBase("secs since 1997-07-16T19:20+01:00");
-    testBase("secs since 1997-07-16T19:20:30+01:00");
+
+  @Parameterized.Parameters(name="{0}: {2}")
+  public static Collection params() {
+    Object[][] data = new Object[][] {
+            {"W3CISO", null, "secs since 1997"},
+            {"W3CISO", null, "secs since 1997"},
+            {"W3CISO", null, "secs since 1997-07"},
+            {"W3CISO", null, "secs since 1997-07-16"},
+            {"W3CISO", null, "secs since 1997-07-16T19:20+01:00"},
+            {"W3CISO", null, "secs since 1997-07-16T19:20:30+01:00"},
+            {"ChangeoverDate", null, "secs since 1997-01-01"},
+            {"ChangeoverDate", null, "secs since 1582-10-16"},
+            {"ChangeoverDate", null, "secs since 1582-10-15"},
+//            {"ChangeoverDate", null, "secs since 1582-10-01"},
+//            {"ChangeoverDate", null, "secs since 1582-10-02"},
+//            {"ChangeoverDate", null, "secs since 1582-10-03"},
+//            {"ChangeoverDate", null, "secs since 1582-10-04"},
+//            {"yearZero", null, "secs since 0000-01-01"},
+//            {"yearZero", null, "secs since 0001-01-01"},
+//            {"yearZero", null, "secs since -0001-01-01"},
+//            {"yearZero", "gregorian", "secs since 0001-01-01"},
+//            {"yearZero", "gregorian", "secs since -0001-01-01"},
+            {"Problem", null, "days since 2008-01-01 0:00:00 00:00"},
+            {"Problem", null, "seconds since 1968-05-23 00:00:00 UTC"},
+            {"Problem", null, "seconds since 1970-01-01 00 UTC"},
+            // UNIT since [-]Y[Y[Y[Y]]]-MM-DD[(T| )hh[:mm[:ss[.sss*]]][ [+|-]hh[[:]mm]]]
+            {"UDUnits", null, "secs since 1992-10-8 15:15:42.5 -6:00"},
+            {"UDUnits", null, "secs since 1992-10-8 15:15:42.5 +6"},
+//            {"UDUnits", null, "secs since 1992-10-8 15:15:42.534"},
+            {"UDUnits", null, "secs since 1992-10-8 15:15:42"},
+            {"UDUnits", null, "secs since 1992-10-8 15:15"},
+            {"UDUnits", null, "secs since 1992-10-8 15"},
+            {"UDUnits", null, "secs since 1992-10-8T15"},
+            {"UDUnits", null, "secs since 1992-10-8"},
+//            {"UDUnits", null, "secs since 199-10-8"},
+//            {"UDUnits", null, "secs since 19-10-8"},
+//            {"UDUnits", null, "secs since 1-10-8"},
+//            {"UDUnits", null, "secs since +1101-10-8"},
+//            {"UDUnits", null, "secs since -1101-10-8"},
+            {"UDUnits", null, "secs since 1992-10-8T7:00 -6:00"},
+            {"UDUnits", null, "secs since 1992-10-8T7:00 +6:00"},
+            {"UDUnits", null, "secs since 1992-10-8T7 -6:00"},
+            {"UDUnits", null, "secs since 1992-10-8T7 +6:00"},
+            {"UDUnits", null, "secs since 1992-10-8 7 -6:00"},
+            {"UDUnits", null, "secs since 1992-10-8 7 +6:00"},
+            {"UDUnits", null, "days since 1992"},
+            {"UDUnits", null, "hours since 2011-02-09T06:00:00Z"},
+            {"UDUnits", null, "seconds since 1968-05-23 00:00:00"},
+            {"UDUnits", null, "seconds since 1968-05-23 00:00:00 UTC"},
+            {"UDUnits", null, "seconds since 1968-05-23 00:00:00 GMT"},
+            {"UDUnits", null, "msecs since 1970-01-01T00:00:00Z"},
+    };
+    return Arrays.asList(data);
   }
 
-  @Test
-  public void testChangeoverDate() {
-    testBase("secs since 1997-01-01");
-    testBase("secs since 1582-10-16");
-    testBase("secs since 1582-10-15");
-    testBase("secs since 1582-10-01");
-    testBase("secs since 1582-10-02");
-    testBase("secs since 1582-10-03");
-    testBase("secs since 1582-10-04");
-    //testBase("secs since 1582-10-14"); // fail
-    //testBase("secs since 1582-10-06"); // fail
-  }
+  @Parameterized.Parameter
+  public String category;
 
-  @Test
-  public void testyearZero() {
-    testCalendar(null, "secs since 0000-01-01");
-    testCalendar(null, "secs since 0001-01-01");
-    testCalendar(null, "secs since -0001-01-01");
-    testCalendar("gregorian", "secs since 0001-01-01");
-    testCalendar("gregorian", "secs since -0001-01-01");
-  }
+  @Parameterized.Parameter(value=1)
+  public String calendar;
 
-  @Test
-  public void problem() {
-    testCalendarOnly(null, "days since 2008-01-01 0:00:00 00:00");
-  }
+  @Parameterized.Parameter(value=2)
+  public String datestring;
 
-  // UNIT since [-]Y[Y[Y[Y]]]-MM-DD[(T| )hh[:mm[:ss[.sss*]]][ [+|-]hh[[:]mm]]]
-  @Test
-  public void testUdunits() {
-    testBase("secs since 1992-10-8 15:15:42.5 -6:00");
-    testBase("secs since 1992-10-8 15:15:42.5 +6");
-    testBase("secs since 1992-10-8 15:15:42.534");
-    testBase("secs since 1992-10-8 15:15:42");
-    testBase("secs since 1992-10-8 15:15");
-    testBase("secs since 1992-10-8 15");
-    testBase("secs since 1992-10-8T15");
-    testBase("secs since 1992-10-8");
-    testBase("secs since 199-10-8");
-    testBase("secs since 19-10-8");
-    testBase("secs since 1-10-8");
-    testBase("secs since +1101-10-8");
-    testBase("secs since -1101-10-8");
-    testBase("secs since 1992-10-8T7:00 -6:00");
-    testBase("secs since 1992-10-8T7:00 +6:00");
-    testBase("secs since 1992-10-8T7 -6:00");
-    testBase("secs since 1992-10-8T7 +6:00");
-    testBase("secs since 1992-10-8 7 -6:00");
-    testBase("secs since 1992-10-8 7 +6:00");
-
-    testBase("days since 1992");
-    testBase("hours since 2011-02-09T06:00:00Z");
-    testBase("seconds since 1968-05-23 00:00:00");
-    testBase("seconds since 1968-05-23 00:00:00 UTC");
-    testBase("seconds since 1968-05-23 00:00:00 GMT");
-  }
-
-  @Test
-  public void testProblem()  {
-    testCalendar(null, "seconds since 1968-05-23 00:00:00 UTC");
-    testCalendar(null, "seconds since 1970-01-01 00 UTC");
-  }
-
-  private void testCoord(String unit) {
-    for (Calendar cal : Calendar.values())
-      testCoord(cal, unit);
-  }
-
-  private void testCoord(Calendar cal, String unit) {
-    if (cal == Calendar.gregorian) {
-      Date date = DateUnit.getStandardDate(unit);
-      System.out.printf("     udunits %s == %s%n", unit, CalendarDateFormatter.toDateTimeStringISO(date));
-      //assert date.equals(cd.getDateTime().toDate());
-    }
-
-    CalendarDate cd = CalendarDate.parseUdunits(cal.toString(), unit);
-    System.out.printf("CalendarDate (%10s) %s == %s%n", cal, unit, CalendarDateFormatter.toDateTimeStringISO(cd));
-
-    if (cal == Calendar.none)
-      System.out.println("HEY Calendar.none");
-  }
-
-  public void testUU() throws Exception {
-    Unit uu = testUU("msecs since 1970-01-01T00:00:00Z");
-  }
-
-
-  public Unit testUU(String s) throws Exception {
+  private Date getBase(String s) throws Exception {
     Unit u = format.parse(s);
-    assert u instanceof TimeScaleUnit;
+    assert u instanceof TimeScaleUnit : s;
     TimeScaleUnit tu = (TimeScaleUnit) u;
-    Date base = tu.getOrigin();
-
-    System.out.printf("%s == %s%n", s, df.toDateTimeStringISO(base));
-    return u;
-  }
-
-  private void testBase(String s) {
-
-    Date base = null;
-    try {
-      Unit u = format.parse(s);
-      assert u instanceof TimeScaleUnit : s;
-      TimeScaleUnit tu = (TimeScaleUnit) u;
-      base = tu.getOrigin();
-    } catch (Exception e) {
-      e.printStackTrace();
-      return;
-    }
-
-    CalendarDateUnit cdu = CalendarDateUnit.of(null, s);
-
-    System.out.printf("%s == %s (joda %s) == %s (udunit) %n", s, cdu, cdu.getCalendar(), df.toDateTimeStringISO(base));
-
-    if (!base.equals(cdu.getBaseDate())) {
-      System.out.printf("  BAD compare CDU and udunits '%s' == %d != %d (diff = %d)%n", s, cdu.getBaseDate().getTime(), base.getTime(), cdu.getBaseDate().getTime() - base.getTime());
-    }
-  }
-
-  private void testCalendar(String cal, String s) {
-
-    Date base = null;
-    try {
-      Unit u = format.parse(s);
-      assert u instanceof TimeScaleUnit : s;
-      TimeScaleUnit tu = (TimeScaleUnit) u;
-      base = tu.getOrigin();
-    } catch (Exception e) {
-      e.printStackTrace();
-      return;
-    }
-
-    CalendarDateUnit cdu;
-    try {
-     cdu = CalendarDateUnit.of(cal, s);
-    } catch (Exception e) {
-      e.printStackTrace();
-      return;
-    }
-
-    System.out.printf("%s == %s (joda %s) == %s (udunit) %n", s, cdu, cdu.getCalendar(), df.toDateTimeStringISO(base));
-    if (!base.equals(cdu.getBaseDate()))
-      System.out.printf("  BAD diff = %d%n", cdu.getBaseDate().getTime() - base.getTime());
-  }
-
-  private void testCalendarOnly(String cal, String s) {
-
-    CalendarDateUnit cdu;
-    try {
-     cdu = CalendarDateUnit.of(cal, s);
-    } catch (Exception e) {
-      e.printStackTrace();
-      return;
-    }
-
-    System.out.printf("%s == %s (joda %s) %n", s, cdu, cdu.getCalendar());
+    return tu.getOrigin();
   }
 
   @Test
+  public void testBase() throws Exception {
+    Date base = getBase(datestring);
+
+    CalendarDateUnit cdu = CalendarDateUnit.of(calendar, datestring);
+
+    Assert.assertEquals("Difference (ms): " + (base.getTime() - cdu.getBaseDate().getTime()),
+            cdu.getBaseDate(), base);
+    Assert.assertEquals("Difference (ms): " + (CalendarDate.of(base).getMillis() - cdu.getBaseCalendarDate().getMillis()),
+            cdu.getBaseCalendarDate(), CalendarDate.of(base));
+  }
+
+//  @Test
   public void testCoords() {
     boolean test = false;
     testCoords("days", test);
@@ -231,7 +154,7 @@ second
     }
   }
 
-  @Test
+//  @Test
   public void testCoordsByCalendarField() {
     boolean test = false;
     testCoordsByCalendarField("calendar days", test);
@@ -257,22 +180,7 @@ second
     System.out.printf("%n");
   }
 
-  @Test
-  public void testMinMax() {
-    CalendarDate max = CalendarDate.of(Long.MAX_VALUE);
-    System.out.printf("CalendarDate%n");
-    System.out.printf(" max = %s%n", max);
-    CalendarDate min = CalendarDate.of(Long.MIN_VALUE);
-    System.out.printf(" min = %s%n", min);
-
-    System.out.printf("%nDate%n");
-    Date d = new Date(Long.MAX_VALUE);
-    System.out.printf("max = %s%n", d);
-    Date ds = new Date(Long.MIN_VALUE);
-    System.out.printf("min = %s%n", ds);
-  }
-
-  @Test
+//  @Test
   public void testBig() {
     CalendarDateUnit cdu = CalendarDateUnit.of(null, "years since 1970-01-01");
     long val = 50*1000*1000;

--- a/cdm/src/test/java/ucar/unidata/test/util/ExternalServer.java
+++ b/cdm/src/test/java/ucar/unidata/test/util/ExternalServer.java
@@ -9,25 +9,26 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 /**
- * An enumeration of external THREDDS servers used during testing. Tests that call {@link #assumeIsAvailable} will be
+ * An enumeration of external servers used during testing. Tests that call {@link #assumeIsAvailable} will be
  * ignored if the associated server is unavailable.
  *
  * @author cwardgar
  * @since 2015/04/18
  */
-public enum ThreddsServer {
+public enum ExternalServer {
     LIVE("http://thredds.ucar.edu/thredds/"),
     TEST("http://thredds-test.unidata.ucar.edu/thredds/"),
     DEV("http://thredds-dev.unidata.ucar.edu/thredds/"),
-    REMOTETEST("http://remotetest.unidata.ucar.edu/thredds/");
+    REMOTETEST("http://remotetest.unidata.ucar.edu/thredds/"),
+    HTTPKIT("http://echo.httpkit.com");
 
-    private static final Logger logger = LoggerFactory.getLogger(ThreddsServer.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExternalServer.class);
 
     private final String host;
 
     private Boolean available;
 
-    ThreddsServer(String host) {
+    ExternalServer(String host) {
         this.host = host;
     }
 

--- a/dap4/d4tests/src/test/java/dap4/test/TestConstraints.java
+++ b/dap4/d4tests/src/test/java/dap4/test/TestConstraints.java
@@ -1,7 +1,6 @@
 package dap4.test;
 
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.unidata.test.util.ThreddsServer;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/it/src/test/java/thredds/tds/PoundTdsWmsTest.java
+++ b/it/src/test/java/thredds/tds/PoundTdsWmsTest.java
@@ -3,7 +3,7 @@ package thredds.tds;
 import org.apache.http.client.HttpClient;
 import org.junit.Test;
 import ucar.nc2.util.IO;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,7 +34,7 @@ public class PoundTdsWmsTest
   @Test
   public void hitMl8081TdsWms() throws IOException
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     String curUrl;
     long curUrlResponseSize;
     for ( int i=0; i < ml8081GfsHalfDegreeBestWmsTimeStrings.length; i++) {
@@ -66,7 +66,7 @@ public class PoundTdsWmsTest
                  InterruptedException,
                  ExecutionException
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     final int numThreads = 60;
     final int numToRepeat = 5;
     int timeout = 20 * 1000;

--- a/opendap/src/test/java/opendap/test/TestDConnect2.java
+++ b/opendap/src/test/java/opendap/test/TestDConnect2.java
@@ -7,7 +7,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import ucar.unidata.test.Diff;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 
@@ -58,7 +58,7 @@ public class TestDConnect2 extends TestSources {
 
   @Before
   public void setUp() {
-    ThreddsServer.REMOTETEST.assumeIsAvailable();
+    ExternalServer.REMOTETEST.assumeIsAvailable();
     passcount = 0;
     xfailcount = 0;
     failcount = 0;

--- a/opendap/src/test/java/opendap/test/TestDuplicates.java
+++ b/opendap/src/test/java/opendap/test/TestDuplicates.java
@@ -38,7 +38,7 @@ import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.Diff;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ public class TestDuplicates extends UnitTestCommon
   @Test
   public void
   testDuplicates() throws Exception {
-    ThreddsServer.REMOTETEST.assumeIsAvailable();
+    ExternalServer.REMOTETEST.assumeIsAvailable();
 
     // Check if we are running against remote or localhost, or what.
     String testserver = TestDir.dap2TestServer;

--- a/opendap/src/test/java/opendap/test/TestGrid1.java
+++ b/opendap/src/test/java/opendap/test/TestGrid1.java
@@ -36,8 +36,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.UnitTestCommon;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
 
 /**
  * Test nc2 dods in the JUnit framework.
@@ -77,7 +77,7 @@ public class TestGrid1 extends UnitTestCommon
     public void testGrid1()
             throws Exception
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
 
         System.out.println("TestGrid1:");
         String url = null;

--- a/opendap/src/test/java/opendap/test/TestGrid2.java
+++ b/opendap/src/test/java/opendap/test/TestGrid2.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 
@@ -78,7 +78,7 @@ public class TestGrid2 extends UnitTestCommon
     public void testGrid2()
             throws Exception
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
         System.out.println("TestGrid2:");
         String url = null;
         boolean pass = true;

--- a/opendap/src/test/java/opendap/test/TestGroups.java
+++ b/opendap/src/test/java/opendap/test/TestGroups.java
@@ -39,7 +39,7 @@ import ucar.nc2.util.UnitTestCommon;
 import ucar.nc2.util.rc.RC;
 import ucar.unidata.test.Diff;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -119,7 +119,7 @@ public class TestGroups extends UnitTestCommon
     public void
     testGroup() throws Exception
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
         // Run  with usegroups == true
         if(!usegroups)
             Assert.assertTrue("TestGroups: Group Support not enabled", false);

--- a/opendap/src/test/java/opendap/test/TestMisc.java
+++ b/opendap/src/test/java/opendap/test/TestMisc.java
@@ -38,8 +38,8 @@ import org.junit.Test;
 import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.util.UnitTestCommon;
 import ucar.unidata.test.Diff;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.TestDir;
-import ucar.unidata.test.util.ThreddsServer;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -106,7 +106,7 @@ public class TestMisc extends UnitTestCommon
     public void
     testMisc() throws Exception
     {
-        ThreddsServer.REMOTETEST.assumeIsAvailable();
+        ExternalServer.REMOTETEST.assumeIsAvailable();
         System.out.println("TestMisc:");
         for(Testcase testcase : testcases) {
             System.out.println("url: " + testcase.url);

--- a/opendap/src/test/java/ucar/nc2/dt/grid/Test3dFromOpendap.java
+++ b/opendap/src/test/java/ucar/nc2/dt/grid/Test3dFromOpendap.java
@@ -35,13 +35,13 @@ package ucar.nc2.dt.grid;
 import org.junit.Test;
 import ucar.ma2.*;
 import ucar.nc2.dt.GridCoordSystem;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 public class Test3dFromOpendap {
 
   @Test
   public void test3D() throws Exception {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     try (GridDataset dataset = GridDataset.open("dods://thredds-test.unidata.ucar.edu/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best")) {
 
       GeoGrid grid = dataset.findGridByName("Relative_humidity_isobaric");

--- a/opendap/src/test/java/ucar/nc2/dt/grid/TestTime2D.java
+++ b/opendap/src/test/java/ucar/nc2/dt/grid/TestTime2D.java
@@ -36,7 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.*;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 /**
  * Describe
@@ -48,7 +48,7 @@ public class TestTime2D {
 
   @Test
   public void testTime2D() throws Exception {
-    ThreddsServer.DEV.assumeIsAvailable();
+    ExternalServer.DEV.assumeIsAvailable();
     try (NetcdfFile dataset = NetcdfDataset.openDataset("dods://thredds-dev.unidata.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Pacific_40km/TwoD")) {
 
       Variable v = dataset.findVariable(null, "Pressure_surface");

--- a/tds/src/test/java/thredds/motherlode/TestMotherlodeDatasets.java
+++ b/tds/src/test/java/thredds/motherlode/TestMotherlodeDatasets.java
@@ -49,7 +49,7 @@ import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dt.GridDatatype;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.util.CompareNetcdf2;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -89,7 +89,7 @@ public class TestMotherlodeDatasets implements CatalogCrawler.Listener {
 
   @Before
   public void init() throws IOException {
-      ThreddsServer.TEST.assumeIsAvailable();
+      ExternalServer.TEST.assumeIsAvailable();
       DataFactory.setPreferCdm(true);
       HTTPSession.setGlobalUserAgent("TestMotherlodeDatasets");
   }

--- a/tds/src/test/java/thredds/motherlode/TestMotherlodePing.java
+++ b/tds/src/test/java/thredds/motherlode/TestMotherlodePing.java
@@ -35,7 +35,7 @@ package thredds.motherlode;
 
 import org.junit.Test;
 import ucar.nc2.util.IO;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 
@@ -59,7 +59,7 @@ public class TestMotherlodePing {
 
   @Test
   public void ping() throws Exception {
-    ThreddsServer.TEST.assumeIsAvailable();
+    ExternalServer.TEST.assumeIsAvailable();
     ping("/ncss/nws/metar/ncdecoded/Metar_Station_Data_fc.cdmr/dataset.html");
     ping("/ncss/nws/metar/ncdecoded/Metar_Station_Data_fc.cdmr/dataset.xml");
     ping("/ncss/grib/NCEP/NAM/CONUS_80km/best/dataset.html");

--- a/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
+++ b/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
@@ -10,8 +10,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.servlet.ModelAndView;
 import thredds.mock.web.MockTdsContextLoader;
+import ucar.unidata.test.util.ExternalServer;
 import ucar.unidata.test.util.NeedsContentRoot;
-import ucar.unidata.test.util.ThreddsServer;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +57,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 
 	@Test
 	public void showCommandTest() throws Exception{
-		ThreddsServer.LIVE.assumeIsAvailable();
+		ExternalServer.LIVE.assumeIsAvailable();
 		// Testing against some reliable remote TDS
 		catUriString = "http://thredds.ucar.edu/thredds/catalog.xml";
 		request.setRequestURI(catUriString);
@@ -87,7 +87,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 	// http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.html?dataset=grib/NCEP/NAM/CONUS_80km/best
 	@Test
 	public void subsetCommandTest() throws Exception{
-		ThreddsServer.LIVE.assumeIsAvailable();
+		ExternalServer.LIVE.assumeIsAvailable();
 		// SUBSET REQUEST PROVIDING A datasetId
 		// setting up the request with default values:
 		// command =null
@@ -114,7 +114,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 	//@Ignore
 	@Test
 	public void validateCommandTest() throws Exception {
-		ThreddsServer.LIVE.assumeIsAvailable();
+		ExternalServer.LIVE.assumeIsAvailable();
 		// VALIDATE REQUEST 
 		// command =validate
 		// datasetId= null

--- a/tds/src/test/java/thredds/server/catalogservice/TestRemoteCatalogRequest.java
+++ b/tds/src/test/java/thredds/server/catalogservice/TestRemoteCatalogRequest.java
@@ -35,7 +35,7 @@ package thredds.server.catalogservice;
 import junit.framework.TestCase;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.validation.BindingResult;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 /**
  * _more_
@@ -69,7 +69,7 @@ public class TestRemoteCatalogRequest extends TestCase
 
   @Override
   public void setUp() {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
   }
 
   public void testCommandDefaultValues()

--- a/tds/src/test/java/thredds/tds/ethan/TestAll.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestAll.java
@@ -54,7 +54,7 @@ import ucar.nc2.time.CalendarDateFormatter;
 import ucar.unidata.geoloc.ProjectionImpl;
 import ucar.unidata.geoloc.ogc.EPSG_OGC_CF_Helper;
 import ucar.unidata.geoloc.vertical.VerticalTransform;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.*;
 import java.net.URI;
@@ -141,7 +141,7 @@ public class TestAll extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
 
     if ( null == System.getProperty( "thredds.tds.test.id"))
       System.setProperty( "thredds.tds.test.id", "crawl-newmlode-8080" );

--- a/tds/src/test/java/thredds/tds/ethan/TestTdsIddPing.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestTdsIddPing.java
@@ -34,7 +34,7 @@ package thredds.tds.ethan;
 
 import junit.framework.TestCase;
 import thredds.client.catalog.Catalog;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 /**
  * _more_
@@ -56,7 +56,7 @@ public class TestTdsIddPing extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     host = System.getProperty( "thredds.tds.test.server", host );
     targetTdsUrl = "http://" + host + "/thredds/";
   }

--- a/tds/src/test/java/thredds/tds/ethan/TestTdsPingMotherlode.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestTdsPingMotherlode.java
@@ -34,7 +34,7 @@ package thredds.tds.ethan;
 
 import junit.framework.TestCase;
 import thredds.client.catalog.Catalog;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -60,7 +60,7 @@ public class TestTdsPingMotherlode extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     Properties env = System.getProperties();
     host = env.getProperty( "thredds.tds.test.server", host );
 

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSite.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSite.java
@@ -41,7 +41,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import thredds.catalog.InvCatalogFactory;
 import thredds.catalog.InvCatalogImpl;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -86,7 +86,7 @@ public class TestServerSite extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     wc = new WebConversation();
 
     Properties env = System.getProperties();

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteIDD.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteIDD.java
@@ -35,7 +35,7 @@ package thredds.tds.ethan.httpunit;
 
 import com.meterware.httpunit.WebConversation;
 import junit.framework.TestCase;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.Properties;
 
@@ -64,7 +64,7 @@ public class TestServerSiteIDD extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     wc = new WebConversation();
 
     Properties env = System.getProperties();

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteMotherlodeIDV.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteMotherlodeIDV.java
@@ -39,7 +39,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +77,7 @@ public class TestServerSiteMotherlodeIDV extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     wc = new WebConversation();
 
     Properties env = System.getProperties();

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteOutOfBox.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteOutOfBox.java
@@ -35,7 +35,7 @@ package thredds.tds.ethan.httpunit;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebResponse;
 import junit.framework.TestCase;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.Properties;
 
@@ -64,7 +64,7 @@ public class TestServerSiteOutOfBox extends TestCase
   @Override
   protected void setUp()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     wc = new WebConversation();
 
     Properties env = System.getProperties();

--- a/tds/src/test/java/thredds/tds/idd/CompareGribVarNamesOnMotherlodeTds.java
+++ b/tds/src/test/java/thredds/tds/idd/CompareGribVarNamesOnMotherlodeTds.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,7 +36,7 @@ public class CompareGribVarNamesOnMotherlodeTds
 
   @Before
   public void setUp() {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
   }
 
   /**

--- a/tds/src/test/java/thredds/tds/idd/CrawlRandomDatasetsOnMotherlodeTds.java
+++ b/tds/src/test/java/thredds/tds/idd/CrawlRandomDatasetsOnMotherlodeTds.java
@@ -35,7 +35,7 @@ package thredds.tds.idd;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,7 +88,7 @@ public class CrawlRandomDatasetsOnMotherlodeTds
     @Test
     public void crawlDataset()
     {
-        ThreddsServer.LIVE.assumeIsAvailable();
+        ExternalServer.LIVE.assumeIsAvailable();
         CatalogDatasetTestUtils.assertDatasetIsAccessible( this.datasetUrl);
     }
 }

--- a/tds/src/test/java/thredds/tds/idd/PingMotherlodeTdsTest.java
+++ b/tds/src/test/java/thredds/tds/idd/PingMotherlodeTdsTest.java
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import thredds.client.catalog.Catalog;
 import thredds.tds.ethan.TestAll;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.Collection;
 
@@ -41,7 +41,7 @@ public class PingMotherlodeTdsTest
   @Test
   public void pingMotherlodeCatalogs()
   {
-    ThreddsServer.LIVE.assumeIsAvailable();
+    ExternalServer.LIVE.assumeIsAvailable();
     StringBuilder msgLog = new StringBuilder();
 
     String url = this.tdsUrl + this.catUrl;

--- a/tds/src/test/java/thredds/tds/idd/PingTdsOnMotherlode8080.java
+++ b/tds/src/test/java/thredds/tds/idd/PingTdsOnMotherlode8080.java
@@ -35,7 +35,7 @@ package thredds.tds.idd;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.unidata.test.util.ThreddsServer;
+import ucar.unidata.test.util.ExternalServer;
 
 import java.util.Collection;
 
@@ -67,7 +67,7 @@ public class PingTdsOnMotherlode8080
     @Test
     public void ping()
     {
-        ThreddsServer.LIVE.assumeIsAvailable();
+        ExternalServer.LIVE.assumeIsAvailable();
         String tdsUrl = "http://thredds.ucar.edu/thredds/";
 
         CatalogValidityTestUtils.assertCatalogIsAccessibleValidAndNotExpired( tdsUrl + catalogUrl );


### PR DESCRIPTION
The overall purpose here is to get Travis green again. This does a couple things now:
- Remove an assertion caused by sending Long.MAX to joda, which is no longer valid. It also refactors the test to be an actual unit test. There are some commented out tests that do not pass (which printed
errors before).

- Because its down currently, we're now aware that we depend on getting to http://echo.httpkit.com This adds it to the collection of servers usable for `Assume`. It also renames the `ThreddsServer` to `ExternalServer` since we now include something non-THREDDS.

I've opened a separate issue on things that still need work on `TestCalendarDateUnit`, but at least Travis should be clean now.