### PR TITLE
Dramatically improved navigation speed in CrawlableDatasetAmazonS3

### DIFF
--- a/cdm/src/main/java/thredds/catalog/InvDatasetScan.java
+++ b/cdm/src/main/java/thredds/catalog/InvDatasetScan.java
@@ -32,18 +32,30 @@
  */
 package thredds.catalog;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import thredds.catalog.util.DeepCopyUtils;
-import thredds.cataloggen.*;
+import thredds.cataloggen.CatalogBuilder;
+import thredds.cataloggen.CatalogRefExpander;
+import thredds.cataloggen.DatasetEnhancer;
+import thredds.cataloggen.DatasetScanCatalogBuilder;
+import thredds.cataloggen.ProxyDatasetHandler;
 import thredds.cataloggen.datasetenhancer.RegExpAndDurationTimeCoverageEnhancer;
 import thredds.cataloggen.inserter.SimpleLatestProxyDsHandler;
-import thredds.crawlabledataset.*;
+import thredds.crawlabledataset.CrawlableDataset;
+import thredds.crawlabledataset.CrawlableDatasetFactory;
+import thredds.crawlabledataset.CrawlableDatasetFilter;
+import thredds.crawlabledataset.CrawlableDatasetLabeler;
+import thredds.crawlabledataset.CrawlableDatasetSorter;
+import thredds.crawlabledataset.filter.RegExpMatchOnNameFilter;
 import thredds.crawlabledataset.sorter.LexigraphicByNameSorter;
-import thredds.crawlabledataset.filter.*;
-
-import java.net.URI;
-import java.io.IOException;
-import java.util.*;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * Represents server-side information on how to scan a collection of datasets
@@ -407,46 +419,18 @@ public class InvDatasetScan extends InvCatalogRef {
   public boolean isValid() { return isValid; }
   public String getInvalidMessage() { return invalidMessage.toString(); }
 
-  private CrawlableDataset createScanLocationCrDs()
-  {
-    // Create the CrawlableDataset for the scan location (scanLocation).
-    CrawlableDataset scanLocationCrDs;
-    try
-    {
-      scanLocationCrDs = CrawlableDatasetFactory.createCrawlableDataset( scanLocation, crDsClassName, crDsConfigObj );
-    }
-    catch ( IllegalAccessException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
+  private CrawlableDataset createScanLocationCrDs() {
+    try {
+      // Create the CrawlableDataset for the scan location (scanLocation).
+      return CrawlableDatasetFactory.createCrawlableDataset(scanLocation, crDsClassName, crDsConfigObj);
+    } catch (IllegalAccessException | NoSuchMethodException | IOException | InvocationTargetException |
+            InstantiationException | ClassNotFoundException e) {
+      String message = String.format(
+              "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <%s> and class <%s>",
+              scanLocation, crDsClassName);
+      log.error(message, e);
       return null;
     }
-    catch ( NoSuchMethodException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
-      return null;
-    }
-    catch ( IOException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
-      return null;
-    }
-    catch ( InvocationTargetException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
-      return null;
-    }
-    catch ( InstantiationException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
-      return null;
-    }
-    catch ( ClassNotFoundException e )
-    {
-      log.error( "createScanLocationCrDs(): failed to create CrawlableDataset for collectionLevel <" + scanLocation + "> and class <" + crDsClassName + ">: " + e.getMessage() );
-      return null;
-    }
-
-    return scanLocationCrDs;
   }
 
   private CatalogBuilder buildCatalogBuilder()

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/CachingThreddsS3Client.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/CachingThreddsS3Client.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class CachingThreddsS3Client implements ThreddsS3Client {
     private static final Logger logger = LoggerFactory.getLogger(CachingThreddsS3Client.class);
 
-    private static final long ENTRY_EXPIRATION_TIME = 60 * 10;  // In seconds.
+    private static final long ENTRY_EXPIRATION_TIME = 1;  // In hours.
     private static final long MAX_METADATA_ENTRIES = 10000;
     private static final long MAX_FILE_ENTRIES = 100;
 
@@ -43,15 +43,15 @@ public class CachingThreddsS3Client implements ThreddsS3Client {
 
         // We can't reuse the builder because each of the caches we're creating has different type parameters.
         this.objectMetadataCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.SECONDS)
+                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.HOURS)
                 .maximumSize(MAX_METADATA_ENTRIES)
                 .build();
         this.objectListingCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.SECONDS)
+                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.HOURS)
                 .maximumSize(MAX_METADATA_ENTRIES)
                 .build();
         this.objectFileCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.SECONDS)
+                .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.HOURS)
                 .maximumSize(MAX_FILE_ENTRIES)
                 .removalListener(removalListener)
                 .build();

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
@@ -3,12 +3,17 @@ package thredds.crawlabledataset.s3;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.crawlabledataset.CrawlableDataset;
@@ -23,17 +28,38 @@ import thredds.crawlabledataset.CrawlableDatasetFile;
  */
 public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
     private static final Logger logger = LoggerFactory.getLogger(CrawlableDatasetAmazonS3.class);
-    private static ThreddsS3Client defaultThreddsS3Client;
+
+    private static final long ENTRY_EXPIRATION_TIME = 1;  // In hours.
+    private static final long MAX_SUMMARY_ENTRIES = 10000;
+
+    private static final Cache<S3URI, S3ObjectSummary> objectSummaryCache = CacheBuilder.newBuilder()
+            .expireAfterAccess(ENTRY_EXPIRATION_TIME, TimeUnit.HOURS)
+            .maximumSize(MAX_SUMMARY_ENTRIES)
+            .build();
+
+    private static ThreddsS3Client defaultThreddsS3Client = new CachingThreddsS3Client(new ThreddsS3ClientImpl());
 
     private final S3URI s3uri;
     private final ThreddsS3Client threddsS3Client;
+
+    // A configObject is required by the superclass constructor (CrawlableDatasetFile).
+    // However, it is ignored; in fact, a warning is emitted if it ISN'T null.
+    // So, for convenience, we're providing constructors without the configObject parameter.
+
+    public CrawlableDatasetAmazonS3(String path) {
+        this(path, null);
+    }
 
     public CrawlableDatasetAmazonS3(String path, Object configObject) {  // Used reflectively by CrawlableDatasetFactory
         this(new S3URI(path), configObject);
     }
 
+    public CrawlableDatasetAmazonS3(S3URI s3uri) {
+        this(s3uri, null);
+    }
+
     public CrawlableDatasetAmazonS3(S3URI s3uri, Object configObject) {
-        this(s3uri, configObject, getDefaultThreddsS3Client());
+        this(s3uri, configObject, defaultThreddsS3Client);
     }
 
     public CrawlableDatasetAmazonS3(S3URI s3uri, Object configObject, ThreddsS3Client threddsS3Client) {
@@ -44,21 +70,22 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
 
     //////////////////////////////////////// Static ////////////////////////////////////////
 
-    public static ThreddsS3Client getDefaultThreddsS3Client() {
-        if (defaultThreddsS3Client == null) {
-            defaultThreddsS3Client = new CachingThreddsS3Client(new ThreddsS3ClientImpl());
-        }
-        return defaultThreddsS3Client;
-    }
-
     public static void setDefaultThreddsS3Client(ThreddsS3Client threddsS3Client) {
         defaultThreddsS3Client = threddsS3Client;
     }
 
-    //////////////////////////////////////// Instance ////////////////////////////////////////
+    public static void clearCache() {
+        objectSummaryCache.invalidateAll();
+    }
+
+    //////////////////////////////////////// Getters ////////////////////////////////////////
 
     public S3URI getS3URI() {
         return s3uri;
+    }
+
+    public ThreddsS3Client getThreddsS3Client() {
+        return threddsS3Client;
     }
 
     //////////////////////////////////////// CrawlableDatasetFile ////////////////////////////////////////
@@ -87,50 +114,59 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
 
     @Override
     public CrawlableDataset getParentDataset() {
-        return new CrawlableDatasetAmazonS3(s3uri.getParent(), getConfigObject());
-    }
-
-    @Override
-    public boolean exists() {
-        return threddsS3Client.getObjectMetadata(s3uri) != null || isCollection();
-    }
-
-    @Override
-    public boolean isCollection() {
-        return threddsS3Client.listObjects(s3uri) != null;
+        return new CrawlableDatasetAmazonS3(s3uri.getParent(), getConfigObject(), threddsS3Client);
     }
 
     @Override
     public CrawlableDataset getDescendant(String relativePath) {
-        return new CrawlableDatasetAmazonS3(s3uri.getChild(relativePath), getConfigObject());
+        return new CrawlableDatasetAmazonS3(s3uri.getChild(relativePath), getConfigObject(), threddsS3Client);
+    }
+
+    @Override
+    public boolean exists() {
+        return objectSummaryCache.getIfPresent(s3uri)   != null ||
+               threddsS3Client.getObjectMetadata(s3uri) != null ||
+               threddsS3Client.listObjects(s3uri)       != null;
+    }
+
+    @Override
+    public boolean isCollection() {
+        return objectSummaryCache.getIfPresent(s3uri) == null &&
+               threddsS3Client.listObjects(s3uri)     != null;
     }
 
     @Override
     public List<CrawlableDataset> listDatasets() throws IOException {
-        if (!isCollection()) {
+        boolean isCachedObject = objectSummaryCache.getIfPresent(s3uri) != null;  // Cached objects aren't collections.
+        ObjectListing objectListing;
+
+        if (isCachedObject || (objectListing = threddsS3Client.listObjects(s3uri)) == null) {
             String tmpMsg = String.format("'%s' is not a collection dataset.", s3uri);
             logger.error("listDatasets(): " + tmpMsg);
             throw new IllegalStateException(tmpMsg);
         }
 
-        ObjectListing objectListing = threddsS3Client.listObjects(s3uri);
-        assert objectListing != null : "We checked this in the isCollection() call above.";
-        List<CrawlableDataset> list = new ArrayList<>();
+        List<CrawlableDataset> crawlableDsets = new ArrayList<>();
 
         for (final S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
             S3URI childS3uri = new S3URI(objectSummary.getBucketName(), objectSummary.getKey());
-            CrawlableDatasetAmazonS3 crawlableDset = new CrawlableDatasetAmazonS3(childS3uri, getConfigObject());
-            list.add(crawlableDset);
+            CrawlableDatasetAmazonS3 crawlableDset =
+                    new CrawlableDatasetAmazonS3(childS3uri, getConfigObject(), threddsS3Client);
+            crawlableDsets.add(crawlableDset);
+
+            // Add summary to the cache. The cache will be queried in length() and lastModified().
+            objectSummaryCache.put(childS3uri, objectSummary);
         }
 
         for (String commonPrefix : objectListing.getCommonPrefixes()) {
             S3URI childS3uri = new S3URI(s3uri.getBucket(), commonPrefix);
-            CrawlableDatasetAmazonS3 crawlableDset = new CrawlableDatasetAmazonS3(childS3uri, getConfigObject());
-            list.add(crawlableDset);
+            CrawlableDatasetAmazonS3 crawlableDset =
+                    new CrawlableDatasetAmazonS3(childS3uri, getConfigObject(), threddsS3Client);
+            crawlableDsets.add(crawlableDset);
         }
 
-        assert !list.isEmpty() : "This is a collection and collections shouldn't be empty.";
-        return list;
+        assert !crawlableDsets.isEmpty() : "This is a collection and collections shouldn't be empty.";
+        return crawlableDsets;
     }
 
     /**
@@ -140,6 +176,21 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
      */
     @Override
     public long length() {
+        // If the summary is already in the cache, return it.
+        // It'll have been added by a listDatasets() call on the parent directory.
+        S3ObjectSummary objectSummary = objectSummaryCache.getIfPresent(s3uri);
+        if (objectSummary != null) {
+            return objectSummary.getSize();
+        }
+
+        /* Get the metadata directly from S3. This will be expensive.
+         * We get punished hard if length() and/or lastModified() is called on a bunch of datasets without
+         * listDatasets() first being called on their parent directory.
+         *
+         * So, is the right thing to do here "getParentDataset().listDatasets()" and then query the cache again?
+         * Perhaps, but listDatasets() throws an IOException, and length() and lastModified() do not.
+         * We would have to change their signatures and the upstream client code to make it work.
+         */
         ObjectMetadata metadata = threddsS3Client.getObjectMetadata(s3uri);
         if (metadata != null) {
             return metadata.getContentLength();
@@ -156,6 +207,11 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
      */
     @Override
     public Date lastModified() {
+        S3ObjectSummary objectSummary = objectSummaryCache.getIfPresent(s3uri);
+        if (objectSummary != null) {
+            return objectSummary.getLastModified();
+        }
+
         ObjectMetadata metadata = threddsS3Client.getObjectMetadata(s3uri);
         if (metadata != null) {
             return metadata.getLastModified();
@@ -163,5 +219,35 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
             // "this" may be a collection or non-existent. In both cases, we return null.
             return null;
         }
+    }
+
+    //////////////////////////////////////// Object ////////////////////////////////////////
+
+    @Override
+    public String toString() {
+        return String.format("CrawlableDatasetAmazonS3{'%s'}", s3uri);
+    }
+
+    // Not considering threddsS3Client in either of these becaue ThreddsS3Client doesn't implement equals or hashCode.
+    // It's very hard to provide those methods because ThreddsS3Client contains a AmazonS3Client data member, and that
+    // class doesn't implement those methods either.
+    // Still, it's probably okay because we almost always only care about the S3URI.
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        CrawlableDatasetAmazonS3 that = (CrawlableDatasetAmazonS3) other;
+        return Objects.equals(this.getS3URI(), that.getS3URI()) &&
+               Objects.equals(this.getConfigObject(), that.getConfigObject());
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(new Object[] { this.getS3URI(), this.getConfigObject() });
     }
 }

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/S3URI.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/S3URI.java
@@ -201,6 +201,7 @@ public class S3URI {
         return file;
     }
 
+    //////////////////////////////////////// Object ////////////////////////////////////////
 
     /**
      * Returns a string representation of the URI in the form {@code s3://<bucket>/<key>}.

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
@@ -40,11 +40,11 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
             logger.info(String.format("Downloaded S3 metadata '%s'", s3uri));
             return metadata;
         } catch (IllegalArgumentException e) {  // Thrown by getObjectMetadata() when key == null.
-            logger.info(e.getMessage());
+            logger.debug(e.getMessage());
             return null;
         } catch (AmazonServiceException e) {
             if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                logger.info(String.format(
+                logger.debug(String.format(
                         "There is no S3 bucket '%s' that has key '%s'.", s3uri.getBucket(), s3uri.getKey()));
                 return null;
             } else {
@@ -68,7 +68,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
 
             if (objectListing.getObjectSummaries().isEmpty() && objectListing.getCommonPrefixes().isEmpty()) {
                 // There are no empty directories in a S3 hierarchy.
-                logger.info(String.format("In bucket '%s', the key '%s' does not denote an existing virtual directory.",
+                logger.debug(String.format("In bucket '%s', the key '%s' does not denote an existing virtual directory.",
                         s3uri.getBucket(), s3uri.getKey()));
                 return null;
             } else {
@@ -76,7 +76,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
             }
         } catch (AmazonServiceException e) {
             if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                logger.info(String.format("No S3 bucket named '%s' exists.", s3uri.getBucket()));
+                logger.debug(String.format("No S3 bucket named '%s' exists.", s3uri.getBucket()));
                 return null;
             } else {
                 throw e;
@@ -91,11 +91,11 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
             logger.info(String.format("Downloaded S3 object '%s' to '%s'", s3uri, file));
             return file;
         } catch (IllegalArgumentException e) {  // Thrown by getObject() when key == null.
-            logger.info(e.getMessage());
+            logger.debug(e.getMessage());
             return null;
         } catch (AmazonServiceException e) {
             if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                logger.info(String.format(
+                logger.debug(String.format(
                         "There is no S3 bucket '%s' that has key '%s'.", s3uri.getBucket(), s3uri.getKey()));
                 return null;
             } else {

--- a/cdm/src/test/groovy/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3Spec.groovy
+++ b/cdm/src/test/groovy/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3Spec.groovy
@@ -3,6 +3,7 @@ package thredds.crawlabledataset.s3
 import com.amazonaws.services.s3.model.ObjectListing
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.S3ObjectSummary
+import spock.lang.Shared
 import spock.lang.Specification
 import thredds.crawlabledataset.CrawlableDataset
 
@@ -13,81 +14,261 @@ import thredds.crawlabledataset.CrawlableDataset
  * @since 2015/08/14
  */
 class CrawlableDatasetAmazonS3Spec extends Specification {
-    def "listDatasets success"() {
-        setup: "create mock client that returns a listing with two objects and two directories"
-        S3URI s3uri = new S3URI("s3://bucket/parentDir")
-        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client) {
-            listObjects(s3uri) >> Mock(ObjectListing) {
-                getObjectSummaries() >> [
-                    Mock(S3ObjectSummary) {
-                        getBucketName() >> "bucket"
-                        getKey() >> "parentDir/dataset1.nc"
-                    }, Mock(S3ObjectSummary) {
-                        getBucketName() >> "bucket"
-                        getKey() >> "parentDir/dataset2.nc"
-                    }
-                ]
-                getCommonPrefixes() >> ['parentDir/childDir1', 'parentDir/childDir2']
-            }
+    // Shared resources are initialized in setupSpec()
+    @Shared S3URI parentDirUri, childDir1Uri, childDir2Uri, dataset1Uri, dataset2Uri
+    @Shared long dataset1Length, dataset2Length
+    @Shared Date dataset1LastModified, dataset2LastModified
+
+    @Shared ObjectListing parentDirObjectListing, childDir1ObjectListing, childDir2ObjectListing
+    @Shared ObjectMetadata dataset1ObjectMetadata, dataset2ObjectMetadata
+
+    // create mock client that returns a listing with two objects and two directories
+    def setupSpec() {
+        parentDirUri = new S3URI("s3://bucket/parentDir")
+        childDir1Uri = new S3URI("s3://bucket/parentDir/childDir1")
+        childDir2Uri = new S3URI("s3://bucket/parentDir/childDir2")
+        dataset1Uri  = new S3URI("s3://bucket/parentDir/childDir1/dataset1.nc")
+        dataset2Uri  = new S3URI("s3://bucket/parentDir/childDir2/dataset2.nc")
+
+        dataset1Length = 1337
+        dataset2Length = 42
+
+        dataset1LastModified = new Date(1941, 11, 7)
+        dataset2LastModified = new Date(1952, 2, 11)
+
+        /*
+         * These are return values from a mocked ThreddsS3Client. Together, they describe the following file collection:
+         *   parentDir/
+         *     childDir1/
+         *       dataset1.nc
+         *     childDir2/
+         *       dataset2.nc
+         */
+
+        // To be returned by: threddsS3Client.listObjects(parentDirUri)
+        parentDirObjectListing = Mock(ObjectListing) {
+            getObjectSummaries() >> []
+            getCommonPrefixes() >> [childDir1Uri.key, childDir2Uri.key]
         }
 
-        and: "create CrawlableDatasetAmazonS3 with mock ThreddsS3Client"
-        CrawlableDataset parentDataset = new CrawlableDatasetAmazonS3(s3uri, null, threddsS3Client)
+        // To be returned by: threddsS3Client.listObjects(childDir1Uri)
+        childDir1ObjectListing = Mock(ObjectListing) {
+            getObjectSummaries() >> [
+                    Mock(S3ObjectSummary) {
+                        getBucketName() >> dataset1Uri.bucket
+                        getKey() >> dataset1Uri.key
+                        getSize() >> dataset1Length
+                        getLastModified() >> dataset1LastModified
+                    }
+            ]
+            getCommonPrefixes() >> []
+        }
+
+        // To be returned by: threddsS3Client.listObjects(childDir2Uri)
+        childDir2ObjectListing = Mock(ObjectListing) {
+            getObjectSummaries() >> [
+                    Mock(S3ObjectSummary) {
+                        getBucketName() >> dataset2Uri.bucket
+                        getKey() >> dataset2Uri.key
+                        getSize() >> dataset2Length
+                        getLastModified() >> dataset2LastModified
+                    }
+            ]
+            getCommonPrefixes() >> []
+        }
+
+        // To be returned by: threddsS3Client.getObjectMetadata(dataset1Uri)
+        dataset1ObjectMetadata = Mock(ObjectMetadata) {
+            getContentLength() >> dataset1Length
+            getLastModified() >> dataset1LastModified
+        }
+
+        // To be returned by: threddsS3Client.getObjectMetadata(dataset2Uri)
+        dataset2ObjectMetadata = Mock(ObjectMetadata) {
+            getContentLength() >> dataset2Length
+            getLastModified() >> dataset2LastModified
+        }
+
+        // The default client is a mock ThreddsS3Client that returns default values from all its methods.
+        CrawlableDatasetAmazonS3.defaultThreddsS3Client = Mock(ThreddsS3Client)
+    }
+
+    // Clear the object summary cache before each feature method runs.
+    def setup() {
+        CrawlableDatasetAmazonS3.clearCache()
+    }
+
+
+    // These getter methods rely heavily on S3URI functionality, which is already tested thoroughly in S3URISpec.
+    def "getPath"() {
+        expect:
+        new CrawlableDatasetAmazonS3("s3://bucket/some/key").path == "s3://bucket/some/key"
+    }
+
+    def "getName"() {
+        expect:
+        new CrawlableDatasetAmazonS3("s3://bucket/some/other-key").name == "other-key"
+    }
+
+    def "getParentDataset"() {
+        setup: "use defaultThreddsS3Client"
+        CrawlableDatasetAmazonS3 parent = new CrawlableDatasetAmazonS3("s3://bucket/one/two")
+        CrawlableDatasetAmazonS3 child  = new CrawlableDatasetAmazonS3("s3://bucket/one/two/three")
+
+        expect:
+        child.getParentDataset() == parent
+    }
+
+    def "getDescendant"() {
+        setup: "use defaultThreddsS3Client"
+        CrawlableDatasetAmazonS3 parent = new CrawlableDatasetAmazonS3("s3://bucket/one/two")
+        CrawlableDatasetAmazonS3 child = new CrawlableDatasetAmazonS3("s3://bucket/one/two/three")
+
+        expect:
+        parent.getDescendant("three") == child
+    }
+
+    def "exists"() {
+        setup:
+        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client) {
+            1 * listObjects(childDir1Uri) >> childDir1ObjectListing
+            1 * getObjectMetadata(dataset1Uri) >> dataset1ObjectMetadata
+        }
+
+        expect:
+        new CrawlableDatasetAmazonS3(childDir1Uri, null, threddsS3Client).exists()
+        new CrawlableDatasetAmazonS3(dataset1Uri, null, threddsS3Client).exists()
+        !new CrawlableDatasetAmazonS3(parentDirUri.getChild("non-existent-dataset.nc"), null, threddsS3Client).exists()
+    }
+
+    def "isCollection"() {
+        setup:
+        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client) {
+            1 * listObjects(parentDirUri) >> parentDirObjectListing
+            1 * listObjects(childDir2Uri) >> childDir2ObjectListing
+        }
+
+        expect:
+        new CrawlableDatasetAmazonS3(parentDirUri, null, threddsS3Client).isCollection()
+        new CrawlableDatasetAmazonS3(childDir2Uri, null, threddsS3Client).isCollection()
+        !new CrawlableDatasetAmazonS3(dataset1Uri, null, threddsS3Client).isCollection()
+    }
+
+    def "listDatasets success"() {
+        setup:
+        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client) {
+            1 * listObjects(parentDirUri) >> parentDirObjectListing
+            1 * listObjects(childDir1Uri) >> childDir1ObjectListing
+            1 * listObjects(childDir2Uri) >> childDir2ObjectListing
+        }
+
+        and: "s3://bucket/parentDir"
+        CrawlableDatasetAmazonS3 parentDir = new CrawlableDatasetAmazonS3(parentDirUri, null, threddsS3Client)
 
         when:
-        List<CrawlableDataset> childDatasets = parentDataset.listDatasets();
+        List<CrawlableDataset> childDirs = parentDir.listDatasets();
 
-        then:
-        childDatasets.size() == 4
-        (childDatasets[0] as CrawlableDatasetAmazonS3).s3URI == new S3URI("s3://bucket/parentDir/dataset1.nc")
-        (childDatasets[1] as CrawlableDatasetAmazonS3).s3URI == new S3URI("s3://bucket/parentDir/dataset2.nc")
-        (childDatasets[2] as CrawlableDatasetAmazonS3).s3URI == new S3URI("s3://bucket/parentDir/childDir1")
-        (childDatasets[3] as CrawlableDatasetAmazonS3).s3URI == new S3URI("s3://bucket/parentDir/childDir2")
+        then: "there are two datasets"
+        childDirs.size() == 2
+
+        and: "s3://bucket/parentDir/childDir1"
+        CrawlableDatasetAmazonS3 childDir1 = childDirs[0] as CrawlableDatasetAmazonS3
+        childDir1.s3URI == childDir1Uri
+
+        and: "s3://bucket/parentDir/childDir2"
+        CrawlableDatasetAmazonS3 childDir2 = childDirs[1] as CrawlableDatasetAmazonS3
+        childDir2.s3URI == childDir2Uri
+
+        when:
+        List<CrawlableDataset> childDir1Datasets = childDir1.listDatasets()
+
+        then: "s3://bucket/parentDir/childDir1/dataset1.nc"
+        childDir1Datasets.size() == 1
+        (childDir1Datasets[0] as CrawlableDatasetAmazonS3).s3URI == dataset1Uri
+
+        when:
+        List<CrawlableDataset> childDir2Datasets = childDir2.listDatasets()
+
+        then: "s3://bucket/parentDir/childDir1/dataset2.nc"
+        childDir2Datasets.size() == 1
+        (childDir2Datasets[0] as CrawlableDatasetAmazonS3).s3URI == dataset2Uri
     }
 
     def "listDatasets failure"() {
-        setup: "create CrawlableDataset that will fail"
-        S3URI s3uri = new S3URI("s3://bucket/dir")
-        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client)
-        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(s3uri, null, threddsS3Client)
+        setup: "use defaultThreddsS3Client"
+        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(dataset1Uri)
 
-        when:
+        when: "listObjects(dataset1Uri) will return null"
         dataset.listDatasets()
 
         then:
         IllegalStateException e = thrown()
-        e.message == "'$s3uri' is not a collection dataset."
+        e.message == "'$dataset1Uri' is not a collection dataset."
     }
 
-    def "length and lastModified missing"() {
+    def "length and lastModified success (missing cache)"() {
         setup:
-        S3URI s3uri = new S3URI("s3://bucket/foo/dataset1.nc")
-
-        and: "create mock client that returns null for every method"
         ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client)
-        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(s3uri, null, threddsS3Client)
+        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(dataset1Uri, null, threddsS3Client)
 
-        expect:
-        dataset.length() == 0
-        dataset.lastModified() == null
+        when: "call length() and lastModified() without first doing listDatasets() on parent"
+        def length = dataset.length()
+        def lastModified = dataset.lastModified()
+
+        then: "get the metadata directly from threddsS3Client because it wasn't in the cache"
+        2 * threddsS3Client.getObjectMetadata(dataset1Uri) >> dataset1ObjectMetadata
+
+        and: "length() is returning the stubbed value"
+        length == dataset1ObjectMetadata.contentLength
+
+        and: "lastModified() is returning the stubbed value"
+        lastModified == dataset1ObjectMetadata.lastModified
     }
 
-    def "length and lastModified found"() {
+    def "length and lastModified success (hitting cache)"() {
         setup:
-        S3URI s3uri = new S3URI("s3://bucket/foo/dataset2.nc")
-        Date lastModified = new Date()
+        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client)
+        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(dataset2Uri, null, threddsS3Client)
 
-        and: "create mock client whose ObjectMetadata returns real values"
-        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client) {
-            getObjectMetadata(s3uri) >> Mock(ObjectMetadata) {
-                getContentLength() >> 237
-                getLastModified() >> lastModified
-            }
-        }
-        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(s3uri, null, threddsS3Client)
+        when: "we listDatasets() on the parent directory, filling the cache with object summaries"
+        dataset.getParentDataset().listDatasets()
 
-        expect:
-        dataset.length() == 237
-        dataset.lastModified() == lastModified
+        and: "call length() and lastModified() with object summaries in the cache"
+        def length = dataset.length()
+        def lastModified = dataset.lastModified()
+
+        then: "listObjects() is called once and getObjectMetadata never gets called"
+        1 * threddsS3Client.listObjects(childDir2Uri) >> childDir2ObjectListing
+        0 * threddsS3Client.getObjectMetadata(_)
+
+        and: "length() is returning the stubbed value"
+        length == dataset2ObjectMetadata.contentLength
+
+        and: "lastModified() is returning the stubbed value"
+        lastModified == dataset2ObjectMetadata.lastModified
+    }
+
+    def "length and lastModified failure (missing cache)"() {
+        setup:
+        S3URI nonExistentUri = parentDirUri.getChild("non-existent-dataset.nc")
+        ThreddsS3Client threddsS3Client = Mock(ThreddsS3Client)
+        CrawlableDataset dataset = new CrawlableDatasetAmazonS3(nonExistentUri, null, threddsS3Client)
+
+        when: "we listDatasets() on the parent directory, there will be no summary for nonExistentUri"
+        dataset.getParentDataset().listDatasets()
+
+        and: "call length() and lastModified() with object summaries in the cache"
+        def length = dataset.length()
+        def lastModified = dataset.lastModified()
+
+        then: "getObjectMetadata() will get called due to cache misses"
+        1 * threddsS3Client.listObjects(nonExistentUri.parent) >> parentDirObjectListing
+        2 * threddsS3Client.getObjectMetadata(nonExistentUri) >> null
+
+        and: "length() is returning the missing value: 0"
+        length == 0L
+
+        and: "lastModified() is returning the missing value: null"
+        lastModified == null
     }
 }


### PR DESCRIPTION
* Added 2nd level of caching for the S3ObjectSummary objects that we get
  when we do a listDatasets() call
* All relevant methods check the cache first to avoid using
  ThreddsS3Client if at all possible. I believe I've fully minimized its
  use.
* Greatly improved the testing done in CrawlableDatasetAmazonS3Spec. It
  has 80-90% code coverage and even verifies the cache interactions.
* ThreddsS3ClientImpl logs more to DEBUG instead of spamming INFO.