### PR TITLE
All NcML writing is done by the new NcMLWriter

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlWriteAndCompareLocal.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlWriteAndCompareLocal.java
@@ -1,28 +1,26 @@
 package ucar.nc2.ncml;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
 import org.apache.commons.io.filefilter.SuffixFileFilter;
+import org.jdom2.Element;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.ma2.DataType;
-import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
-import ucar.nc2.Variable;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.iosp.netcdf4.Nc4;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.nc2.util.CompareNetcdf2;
 import ucar.unidata.test.util.TestDir;
 import ucar.unidata.util.StringUtil2;
-
-import java.io.*;
-import java.util.ArrayList;
-import java.util.Formatter;
-import java.util.List;
 
 /**
  * TestWrite NcML, read back and compare with original.
@@ -113,21 +111,22 @@ public class TestNcmlWriteAndCompareLocal {
     if (useRecords)
       org.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
 
-    NcMLWriter writer = new NcMLWriter();
-
     // create a file and write it out
     int pos = location.lastIndexOf("/");
     String filenameTmp = location.substring(pos + 1);
     String ncmlOut = TestDir.temporaryLocalDataDir + filenameTmp + ".ncml";
     if (showFiles) System.out.println(" output filename= " + ncmlOut);
     try {
-      OutputStream out = new BufferedOutputStream(new FileOutputStream(ncmlOut, false));
-      if (explicit)
-        writer.writeXMLexplicit(org, out, null);
-      else
-        writer.writeXML(org, out, null);
-      out.close();
+      NcMLWriter ncmlWriter = new NcMLWriter();
+      Element netcdfElement;
 
+      if (explicit) {
+        netcdfElement = ncmlWriter.makeExplicitNetcdfElement(org, null);
+      } else {
+        netcdfElement = ncmlWriter.makeNetcdfElement(org, null);
+      }
+
+      ncmlWriter.writeToFile(netcdfElement, new File(ncmlOut));
     } catch (IOException ioe) {
       // ioe.printStackTrace();
       assert false : ioe.getMessage();

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlWriteAndCompareShared.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlWriteAndCompareShared.java
@@ -1,7 +1,15 @@
 package ucar.nc2.ncml;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
 import org.apache.commons.io.filefilter.NotFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
+import org.jdom2.Element;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -9,23 +17,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import ucar.ma2.DataType;
-import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
-import ucar.nc2.Variable;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.iosp.netcdf4.Nc4;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.nc2.util.CompareNetcdf2;
 import ucar.unidata.test.util.NeedsCdmUnitTest;
 import ucar.unidata.test.util.TestDir;
 import ucar.unidata.util.StringUtil2;
-
-import java.io.*;
-import java.util.ArrayList;
-import java.util.Formatter;
-import java.util.List;
 
 /**
  * TestWrite NcML, read back and compare with original.
@@ -141,21 +139,22 @@ public class TestNcmlWriteAndCompareShared {
     if (useRecords)
       org.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
 
-    NcMLWriter writer = new NcMLWriter();
-
     // create a file and write it out
     int pos = location.lastIndexOf("/");
     String filenameTmp = location.substring(pos + 1);
     String ncmlOut = TestDir.temporaryLocalDataDir + filenameTmp + ".ncml";
     if (showFiles) System.out.println(" output filename= " + ncmlOut);
     try {
-      OutputStream out = new BufferedOutputStream(new FileOutputStream(ncmlOut, false));
-      if (explicit)
-        writer.writeXMLexplicit( org, out, null);
-      else
-        writer.writeXML(org, out, null);
-      out.close();
+      NcMLWriter ncmlWriter = new NcMLWriter();
+      Element netcdfElement;
 
+      if (explicit) {
+        netcdfElement = ncmlWriter.makeExplicitNetcdfElement(org, null);
+      } else {
+        netcdfElement = ncmlWriter.makeNetcdfElement(org, null);
+      }
+
+      ncmlWriter.writeToFile(netcdfElement, new File(ncmlOut));
     } catch (IOException ioe) {
       // ioe.printStackTrace();
       assert false : ioe.getMessage();

--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -2,19 +2,25 @@ description = "The NetCDF-Java Library is a Java interface to NetCDF files, as w
         "scientific data formats."
 ext.title = "CDM core library"
 
+apply plugin: 'groovy'  // For Spock tests.
+
 dependencies {
     compile project(':udunits')
     compile project(':httpservices')
-
-    compile libraries["guava"]
-    compile libraries["jcip-annotations"]
-    compile libraries["jdom2"]
+    
     compile libraries["joda-time"]
-    compile libraries["jsr305"]
+    compile libraries["jdom2"]
+    compile libraries["jcip-annotations"]
     compile libraries["protobuf-java"]
-
+    compile libraries["guava"]
     compile libraries["jcommander"]
     compile libraries["validation-api"]
+    compile libraries["jsr305"]
+
+    testCompile libraries["groovy-all"]
+    testCompile libraries["spock-core"]
+
+    compile libraries["slf4j-api"]
 }
 
 test {

--- a/cdm/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/src/main/java/ucar/nc2/Attribute.java
@@ -32,16 +32,19 @@
  */
 package ucar.nc2;
 
-import ucar.ma2.*;
+import net.jcip.annotations.Immutable;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayChar;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.nc2.util.Indent;
+import ucar.unidata.util.StringUtil2;
 
+import java.nio.ByteBuffer;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
-import java.nio.ByteBuffer;
 import java.util.Map;
-
-import net.jcip.annotations.Immutable;
-import ucar.nc2.util.Indent;
 
 /**
  * An Attribute has a name and a value, used for associating arbitrary metadata with a Variable or a Group.
@@ -258,7 +261,7 @@ public class Attribute extends CDMNode {
         if (i != 0) f.format(", ");
         String val = getStringValue(i);
         if (val != null)
-          f.format("\"%s\"", NCdumpW.encodeString(val));
+          f.format("\"%s\"", encodeString(val));
       }
     } else {
       f.format(" = ");
@@ -283,6 +286,18 @@ public class Attribute extends CDMNode {
     }
   }
 
+  private static char[] org = {'\b', '\f', '\n', '\r', '\t', '\\', '\'', '\"'};
+  private static String[] replace = {"\\b", "\\f", "\\n", "\\r", "\\t", "\\\\", "\\\'", "\\\""};
+
+  /**
+   * Replace special characters '\t', '\n', '\f', '\r'.
+   *
+   * @param s string to quote
+   * @return equivilent string replacing special chars
+   */
+  static public String encodeString(String s) {
+    return StringUtil2.replace(s, org, replace);
+  }
 
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/cdm/src/main/java/ucar/nc2/Structure.java
+++ b/cdm/src/main/java/ucar/nc2/Structure.java
@@ -32,11 +32,23 @@
  */
 package ucar.nc2;
 
-import ucar.ma2.*;
-import ucar.nc2.util.Indent;
-
-import java.util.*;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayStructure;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.ma2.Section;
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataIterator;
+import ucar.ma2.StructureMembers;
+import ucar.nc2.util.Indent;
 
 /**
  * A Structure is a type of Variable that contains other Variables, like a struct in C.
@@ -44,7 +56,7 @@ import java.io.IOException;
  *<p>
  * A call to structure.read() will read all of the data in a Structure,
  * including nested structures, and returns an Array of StructureData, with all of the data in memory.
- * If there is a nested sequence, the sequence data may be read into memory all at once, ot it may be
+ * If there is a nested sequence, the sequence data may be read into memory all at once, or it may be
  * read in increments as the iteration proceeds.
  * <p>
  * Generally, the programmer can assume that the data in one Structure are stored together,

--- a/cdm/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -32,7 +32,21 @@
  */
 package ucar.nc2.dataset;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.http.Header;
+import org.jdom2.Element;
 import thredds.client.catalog.ServiceType;
 import thredds.client.catalog.tools.DataFactory;
 import ucar.httpservices.HTTPFactory;
@@ -40,7 +54,16 @@ import ucar.httpservices.HTTPMethod;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
-import ucar.nc2.*;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.EnumTypedef;
+import ucar.nc2.FileWriter2;
+import ucar.nc2.Group;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFileWriter;
+import ucar.nc2.Sequence;
+import ucar.nc2.Structure;
+import ucar.nc2.Variable;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.iosp.IOServiceProvider;
 import ucar.nc2.ncml.NcMLGWriter;
@@ -55,12 +78,6 @@ import ucar.nc2.util.cache.FileCache;
 import ucar.nc2.util.cache.FileFactory;
 import ucar.unidata.util.StringUtil2;
 import ucar.unidata.util.Urlencoded;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
 
 /**
  * NetcdfDataset extends the netCDF API, adding standard attribute parsing such as
@@ -1354,8 +1371,11 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
    * @param uri use this for the url attribute; if null use getLocation().
    * @throws IOException
    */
+  @Override
   public void writeNcML(java.io.OutputStream os, String uri) throws IOException {
-    new NcMLWriter().writeXML(this, os, uri);
+    NcMLWriter ncmlWriter = new NcMLWriter();
+    Element netcdfElem = ncmlWriter.makeNetcdfElement(this, uri);
+    ncmlWriter.writeToStream(netcdfElem, os);
   }
 
   /**

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/FeatureDatasetPointXML.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/FeatureDatasetPointXML.java
@@ -33,6 +33,16 @@
 
 package ucar.nc2.ft.point.writer;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.List;
+
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -43,7 +53,11 @@ import ucar.nc2.Dimension;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.ft.*;
+import ucar.nc2.ft.FeatureCollection;
+import ucar.nc2.ft.FeatureDataset;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
 import ucar.nc2.ncml.NcMLReader;
 import ucar.nc2.ncml.NcMLWriter;
 import ucar.nc2.time.CalendarDate;
@@ -53,12 +67,6 @@ import ucar.nc2.units.DateUnit;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Station;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.*;
 
 /**
  * generate capabilities XML for a FeatureDatasetPoint / StationTimeSeriesFeatureCollection
@@ -226,6 +234,8 @@ public class FeatureDatasetPointXML {
   }
 
   private Element writeVariable(VariableSimpleIF v) {
+    NcMLWriter ncMLWriter = new NcMLWriter();
+
     Element varElem = new Element("variable");
     varElem.setAttribute("name", v.getShortName());
 
@@ -235,7 +245,7 @@ public class FeatureDatasetPointXML {
 
     // attributes
     for (Attribute att : v.getAttributes()) {
-      varElem.addContent(NcMLWriter.writeAttribute(att, "attribute", null));
+      varElem.addContent(ncMLWriter.makeAttributeElement(att));
     }
 
     return varElem;

--- a/cdm/src/main/java/ucar/nc2/ncml/AggregationOuterDimension.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/AggregationOuterDimension.java
@@ -32,18 +32,39 @@
  */
 package ucar.nc2.ncml;
 
-import ucar.nc2.dataset.*;
-import ucar.nc2.util.CancelTask;
-import ucar.nc2.*;
-import ucar.nc2.units.DateUnit;
-import ucar.nc2.units.DateFromString;
-import ucar.ma2.*;
-
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 
 import thredds.inventory.MFile;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.Range;
+import ucar.ma2.Section;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.ProxyReader;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.VariableDS;
+import ucar.nc2.units.DateFromString;
+import ucar.nc2.units.DateUnit;
+import ucar.nc2.util.CancelTask;
 
 /**
  * Superclass for Aggregations on the outer dimension: joinNew, joinExisting, Fmrc, FmrcSingle
@@ -514,7 +535,7 @@ public abstract class AggregationOuterDimension extends Aggregation implements P
   }
 
   /**
-   * Encapsolates a NetcdfFile that is a component of the aggregation.
+   * Encapsulates a NetcdfFile that is a component of the aggregation.
    */
   class DatasetOuterDimension extends Dataset {
 

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
@@ -32,25 +32,50 @@
  */
 package ucar.nc2.ncml;
 
-import ucar.ma2.*;
-import ucar.nc2.*;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.XMLOutputter;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.Section;
 import ucar.nc2.Attribute;
-import ucar.nc2.dataset.*;
+import ucar.nc2.Dimension;
+import ucar.nc2.EnumTypedef;
+import ucar.nc2.FileWriter2;
+import ucar.nc2.Group;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFileSubclass;
+import ucar.nc2.NetcdfFileWriter;
+import ucar.nc2.Sequence;
+import ucar.nc2.Structure;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.SequenceDS;
+import ucar.nc2.dataset.StructureDS;
+import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.util.AliasTranslator;
-import ucar.nc2.write.Nc4Chunking;
 import ucar.nc2.util.CancelTask;
 import ucar.nc2.util.IO;
 import ucar.nc2.util.URLnaming;
-
-import org.jdom2.*;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.output.XMLOutputter;
+import ucar.nc2.write.Nc4Chunking;
 import ucar.unidata.util.StringUtil2;
-
-import java.io.*;
-import java.net.*;
-import java.util.*;
-
 import static ucar.unidata.util.StringUtil2.getTokens;
 
 /**
@@ -699,9 +724,12 @@ public class NcMLReader {
       if ((isSharedS != null) && isSharedS.equalsIgnoreCase("false"))
         isShared = false;
 
-      int len = Integer.parseInt(lengthS);
-      if (isUnknown)
+      int len;
+      if (isUnknown) {
         len = Dimension.VLEN.getLength();
+      } else {
+        len = Integer.parseInt(lengthS);
+      }
 
       if (debugConstruct) System.out.println(" add new dim = " + name);
       g.addDimension(new Dimension(name, len, isShared, isUnlimited, isUnknown));

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
@@ -1,257 +1,356 @@
 /*
- * Copyright 1998-2015 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright 1998-2014 University Corporation for Atmospheric Research/Unidata
  *
- *  Portions of this software were developed by the Unidata Program at the
- *  University Corporation for Atmospheric Research.
+ *   Portions of this software were developed by the Unidata Program at the
+ *   University Corporation for Atmospheric Research.
  *
- *  Access and use of this software shall impose the following obligations
- *  and understandings on the user. The user is granted the right, without
- *  any fee or cost, to use, copy, modify, alter, enhance and distribute
- *  this software, and any derivative works thereof, and its supporting
- *  documentation for any purpose whatsoever, provided that this entire
- *  notice appears in all copies of the software, derivative works and
- *  supporting documentation.  Further, UCAR requests that the user credit
- *  UCAR/Unidata in any publications that result from the use of this
- *  software or in any product that includes this software. The names UCAR
- *  and/or Unidata, however, may not be used in any advertising or publicity
- *  to endorse or promote any products or commercial entity unless specific
- *  written permission is obtained from UCAR/Unidata. The user also
- *  understands that UCAR/Unidata is not obligated to provide the user with
- *  any support, consulting, training or assistance of any kind with regard
- *  to the use, operation and performance of this software nor to provide
- *  the user with any updates, revisions, new versions or "bug fixes."
+ *   Access and use of this software shall impose the following obligations
+ *   and understandings on the user. The user is granted the right, without
+ *   any fee or cost, to use, copy, modify, alter, enhance and distribute
+ *   this software, and any derivative works thereof, and its supporting
+ *   documentation for any purpose whatsoever, provided that this entire
+ *   notice appears in all copies of the software, derivative works and
+ *   supporting documentation.  Further, UCAR requests that the user credit
+ *   UCAR/Unidata in any publications that result from the use of this
+ *   software or in any product that includes this software. The names UCAR
+ *   and/or Unidata, however, may not be used in any advertising or publicity
+ *   to endorse or promote any products or commercial entity unless specific
+ *   written permission is obtained from UCAR/Unidata. The user also
+ *   understands that UCAR/Unidata is not obligated to provide the user with
+ *   any support, consulting, training or assistance of any kind with regard
+ *   to the use, operation and performance of this software nor to provide
+ *   the user with any updates, revisions, new versions or "bug fixes."
  *
- *  THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *  INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *  WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ *   THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+ *   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+ *   INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+ *   FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ *   NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+ *   WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 package ucar.nc2.ncml;
 
-import ucar.ma2.*;
-import ucar.nc2.*;
-import ucar.nc2.Attribute;
-import ucar.nc2.util.URLnaming;
-import ucar.nc2.dataset.*;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
-import org.jdom2.*;
-import org.jdom2.output.XMLOutputter;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Sets;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.jdom2.output.Format;
+import org.jdom2.output.LineSeparator;
+import org.jdom2.output.XMLOutputter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.client.catalog.Catalog;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.EnumTypedef;
+import ucar.nc2.Group;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Structure;
+import ucar.nc2.Variable;
+import ucar.nc2.util.URLnaming;
 import ucar.nc2.util.xml.Parse;
-
-import java.io.*;
-import java.util.*;
 
 /**
  * Helper class to write NcML.
  *
  * @author caron
+ * @author cwardgar
  * @see ucar.nc2.NetcdfFile
  * @see <a href="http://www.unidata.ucar.edu/software/netcdf/ncml/">http://www.unidata.ucar.edu/software/netcdf/ncml/</a>
  */
-
 public class NcMLWriter {
-  static private final Namespace ncNS = thredds.client.catalog.Catalog.ncmlNS;
-  static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NcMLWriter.class);
+  /**
+   * A default namespace constructed from the NcML URI: {@code http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2}.
+   */
+  // A default namespace means that we can use it without having to prepend the "ncml:" prefix to every element name.
+  // thredds.client.catalog.Catalog.ncmlNS is *not* default and therefore *does* require the prefix.
+  public static final Namespace ncmlDefaultNamespace = Namespace.getNamespace(Catalog.NJ22_NAMESPACE);
 
-  private NetcdfDataset ncd;
-  private XMLOutputter fmt;
-  private Variable aggCoord;
+  private static final Logger log = LoggerFactory.getLogger(NcMLWriter.class);
+
+  //////////////////////////////////////// Variable-writing predicates ////////////////////////////////////////
+
+  /** Predicate that always returns {@code false}. */
+  public static final Predicate<Variable> writeNoVariablesPredicate = Predicates.alwaysFalse();
+
+  /** Predicate that returns {@code true} for variables that are {@link Variable#isMetadata() metadata variables}. */
+  public static final Predicate<Variable> writeMetadataVariablesPredicate = new Predicate<Variable>() {
+    @Override
+    public boolean apply(Variable var) {
+      // The data is not actually present in the file, so we must include it in the NcML.
+      // It could be synthesized (i.e. generated by an IOSP) or specified in a <values> element of the input NcML.
+      return var.isMetadata();
+    }
+  };
 
   /**
-   * Write NcML from specified NetcdfFile to a String.
-   *
-   * @param ncfile      NcML for this NetcdfFile
-   * @return the NcML in a String
-   * @throws IOException on io error
-   */
-  public String writeXML(NetcdfFile ncfile) throws IOException {
-    if (ncfile instanceof NetcdfDataset)
-      ncd = (NetcdfDataset) ncfile;
-    else
-      ncd = new NetcdfDataset(ncfile, false);
+   * Predicate that returns {@code true} for variables that are
+   * {@link Variable#isCoordinateVariable() coordinate variables}.
+   **/
+  public static final Predicate<Variable> writeCoordinateVariablesPredicate = new Predicate<Variable>() {
+    @Override
+    public boolean apply(Variable var) {
+      return var.isCoordinateVariable();
+    }
+  };
 
-    // Output the document, use standard formatter
-    //fmt = new XMLOutputter("  ", true);
-    //fmt.setLineSeparator("\n");
-    fmt = new XMLOutputter(Format.getPrettyFormat());
-    return fmt.outputString(makeDocument( null));
+  /** Predicate that always returns {@code true}. */
+  public static final Predicate<Variable> writeAllVariablesPredicate = Predicates.alwaysTrue();
+
+  /** Predicate that returns {@code true} for variables whose names are specified to the constructor. */
+  public static class WriteVariablesWithNamesPredicate implements Predicate<Variable> {
+    private final Set<String> variableNames;
+
+    public WriteVariablesWithNamesPredicate(Iterable<String> variableNames) {
+      this.variableNames = Sets.newHashSet(variableNames);
+    }
+
+    @Override
+    public boolean apply(Variable var) {
+      return variableNames.contains(var.getFullName());
+    }
   }
 
+  //////////////////////////////////////// Instance variables ////////////////////////////////////////
+
+  private Namespace namespace;
+  private Format xmlFormat;
+  private Predicate<Variable> writeVariablesPredicate;
+
+  private final XMLOutputter xmlOutputter = new XMLOutputter(xmlFormat);
+
+  //////////////////////////////////////// Constructors ////////////////////////////////////////
+
+  public NcMLWriter() {
+    this.namespace = ncmlDefaultNamespace;
+    this.xmlFormat = Format.getPrettyFormat().setLineSeparator(LineSeparator.UNIX);
+    this.writeVariablesPredicate = writeMetadataVariablesPredicate;
+  }
+
+  //////////////////////////////////////// Getters and setters ////////////////////////////////////////
 
   /**
-   * Write a NetcdfFile as an XML document to the specified file.
+   * Gets the XML namespace for the elements in the NcML. By default, it is {@link #ncmlDefaultNamespace}.
    *
-   * @param ncfile      NcML for this NetcdfFile
-   * @param filenameOut write NcML to this location
-   * @throws IOException on io error
+   * @return  the XML namespace.
    */
-  public void writeXML(NetcdfFile ncfile, String filenameOut) throws IOException {
-    OutputStream out = new BufferedOutputStream(new FileOutputStream(filenameOut, false));
-    writeXML(ncfile, out, null);
-    out.close();
+  public Namespace getNamespace() {
+    return namespace;
   }
 
   /**
-   * Write a NetcdfFile as an XML document to the specified stream.
+   * Sets the XML namespace.
    *
-   * @param ncfile   NcML for this NetcdfFile
-   * @param os       write to this OutputStream
-   * @param location normally null, meaning use ncd.getLocation(); otherwise put this into the NcML location
-   * @throws IOException on io error
+   * @param namespace  the new namespace. {@code null} implies {@link Namespace#NO_NAMESPACE}.
    */
-  public void writeXML(NetcdfFile ncfile, OutputStream os, String location) throws IOException {
-
-    if (ncfile instanceof NetcdfDataset)
-      ncd = (NetcdfDataset) ncfile;
-    else
-      ncd = new NetcdfDataset(ncfile, false);
-
-    fmt = new XMLOutputter(Format.getPrettyFormat());
-    fmt.output(makeDocument(location), os);
+  public void setNamespace(Namespace namespace) {
+    this.namespace = namespace == null ? Namespace.NO_NAMESPACE : namespace;
   }
 
-  public void writeXMLexplicit(NetcdfFile ncfile, OutputStream os, String location) throws IOException {
-    if (ncfile instanceof NetcdfDataset)
-      ncd = (NetcdfDataset) ncfile;
-    else
-      ncd = new NetcdfDataset(ncfile, false);
-
-    fmt = new XMLOutputter(Format.getPrettyFormat());
-    Document doc = makeDocument(location);
-    Element root = doc.getRootElement();
-    root.addContent( new Element("explicit", ncNS));
-    fmt.output(doc, os);
+  /**
+   * Gets the object that encapsulates XML formatting options. By default, the format is
+   * {@link Format#getPrettyFormat() pretty} with {@link LineSeparator#UNIX UNIX line separators}.
+   *
+   * @return  the XML formatting options.
+   */
+  public Format getXmlFormat() {
+    return xmlFormat;
   }
 
+  public void setXmlFormat(Format xmlFormat) {
+    this.xmlFormat = Preconditions.checkNotNull(xmlFormat);
+  }
 
-  private Document makeDocument(String location) throws IOException {
-    Element rootElem = new Element("netcdf", ncNS);
-    Document doc = new Document(rootElem);
+  /**
+   * Gets the predicate that will be applied to variables to determine wither their values should be written in
+   * addition to their metadata. The values will be contained within a {@code <values>} element.
+   *
+   * @return the predicate.
+   */
+  public Predicate<Variable> getWriteVariablesPredicate() {
+    return writeVariablesPredicate;
+  }
 
-    // namespaces
-    rootElem.addNamespaceDeclaration(ncNS);
-    /* rootElem.addNamespaceDeclaration(xsiNS);
+  /**
+   * Sets the predicate that will be applied to variables to determine whether their values should be written in
+   * addition to their metadata. The values will be contained within a {@code <values>} element.
+   * <p/>
+   * By default, the predicate will be {@link #writeMetadataVariablesPredicate}. Their could be data loss if the values
+   * of metadata variables aren't included in the NcML, so we recommend that you always use it, possibly as part of a
+   * compound predicate. For example, suppose you wanted to print the values of metadata <b>and</b> coordinate
+   * variables. Just do:
+   * <pre>
+   * Predicate<Variable> compoundPred = Predicates.or(
+   *         writeMetadataVariablesPredicate,
+   *         writeCoordinateVariablesPredicate);
+   * ncmlWriter.setWriteVariablesPredicate(compoundPred);
+   * </pre>
+   *
+   * @param predicate  the predicate to apply.
+   */
+  public void setWriteVariablesPredicate(Predicate<Variable> predicate) {
+    this.writeVariablesPredicate = Preconditions.checkNotNull(predicate);
+  }
 
-    if (ncfile instanceof NetcdfDataset)
-      rootElem.setAttribute("schemaLocation",
-        "http://www.ucar.edu/schemas/netcdf-2.2 http://www.unidata.ucar.edu/schemas/netcdfCS-2.2.xsd", xsiNS);
-    else
-      rootElem.setAttribute("schemaLocation",
-        "http://www.ucar.edu/schemas/netcdf-2.2 http://www.unidata.ucar.edu/schemas/netcdf-2.2.xsd", xsiNS);
-    */
+  //////////////////////////////////////// Writing ////////////////////////////////////////
+
+  /**
+   * Writes an NcML element to a string.
+   *
+   * @param elem an NcML element.
+   * @return the string that represents the NcML document.
+   */
+  public String writeToString(Element elem) {
+    try (StringWriter writer = new StringWriter()) {
+      writeToWriter(elem, writer);
+      return writer.toString();
+    } catch (IOException e) {
+      throw new AssertionError("CAN'T HAPPEN: StringWriter.close() is a no-op.", e);
+    }
+  }
+
+  /**
+   * Writes an NcML element to an output file.
+   *
+   * @param elem  an NcML element.
+   * @param outFile  the file to write the NcML document to.
+   * @throws IOException  if there's any problem writing.
+   */
+  public void writeToFile(Element elem, File outFile) throws IOException {
+    try (OutputStream outStream = new BufferedOutputStream(new FileOutputStream(outFile, false))) {
+      writeToStream(elem, outStream);
+    }
+  }
+
+  /**
+   * Writes an NcML element to an output stream.
+   *
+   * @param elem  an NcML element.
+   * @param outStream  the stream to write the NcML document to. Will be closed at end of the method.
+   * @throws IOException  if there's any problem writing.
+   */
+  public void writeToStream(Element elem, OutputStream outStream) throws IOException {
+    try (Writer writer = new BufferedWriter(new OutputStreamWriter(
+            new BufferedOutputStream(outStream), xmlFormat.getEncoding()))) {
+      writeToWriter(elem, writer);
+    }
+  }
+
+  /**
+   * Writes an NcML element to a Writer.
+   *
+   * @param elem  an NcML element.
+   * @param writer  the Writer to write the NcML document to. Will be closed at end of the method.
+   * @throws IOException  if there's any problem writing.
+   */
+  public void writeToWriter(Element elem, Writer writer) throws IOException {
+    xmlOutputter.setFormat(xmlFormat);
+    elem.detach();  // In case this element had previously been added to a Document.
+    xmlOutputter.output(new Document(elem), writer);
+  }
+
+  //////////////////////////////////////// Element creation ////////////////////////////////////////
+
+  public Element makeExplicitNetcdfElement(NetcdfFile ncFile, String location) {
+    Element netcdfElem = makeNetcdfElement(ncFile, location);
+    netcdfElem.addContent(0, new Element("explicit", namespace));
+    return netcdfElem;
+  }
+
+  public Element makeNetcdfElement(NetcdfFile ncFile, String location) {
+    Element rootElem = makeGroupElement(ncFile.getRootGroup());
+
+    // rootElem isn't just like any other group element; we must undo some of the changes made to it in writeGroup().
+    rootElem.setName("netcdf");         // Was "group".
+    rootElem.removeAttribute("name");   // This attribute is not defined on the root "netcdf" element.
+
+    rootElem.addNamespaceDeclaration(namespace);
 
     if (null == location)
-      location = ncd.getLocation();
+      location = ncFile.getLocation();
 
     if (null != location) {
       rootElem.setAttribute("location", URLnaming.canonicalizeWrite(location));
     }
 
-    if (null != ncd.getId())
-      rootElem.setAttribute("id", ncd.getId());
+    if (null != ncFile.getId())
+      rootElem.setAttribute("id", ncFile.getId());
 
-    if (null != ncd.getTitle())
-      rootElem.setAttribute("title", ncd.getTitle());
+    if (null != ncFile.getTitle())
+      rootElem.setAttribute("title", ncFile.getTitle());
 
-    //if (ncd.getEnhanceMode() != NetcdfDataset.EnhanceMode.None)
-    //  rootElem.setAttribute("enhance", ncd.getEnhanceMode().toString());
-
-    Aggregation agg = ncd.getAggregation();
-    if (agg != null) {
-      String aggDimensionName = agg.getDimensionName();
-      aggCoord = ncd.findVariable(aggDimensionName);
-      //System.out.println("isMetadata="+aggCoord.isMetadata());
-    }
-
-    Group rootGroup = ncd.getRootGroup();
-
-    /* if (ncd.getCoordSysWereAdded()) {
-      String conv = ncd.findAttValueIgnoreCase(null, "Conventions", null);
-      if (conv == null)
-        rootGroup.addAttribute(new Attribute("Conventions", _Coordinate.Convention));
-      else
-        rootGroup.addAttribute(new Attribute("Conventions", conv + ", " + _Coordinate.Convention));
-    } */
-
-    writeGroup(rootElem, rootGroup);
-
-    //if (agg != null) { LOOK ncml3
-    //  rootElem.addContent(writeAggregation(agg));
-    //}
-
-    return doc;
+    return rootElem;
   }
 
-  public static Element writeAttribute(ucar.nc2.Attribute att, String elementName, Namespace ns) {
-    Element attElem = new Element(elementName, ns);
-    attElem.setAttribute("name", att.getShortName());
+  public Element makeGroupElement(Group group) {
+    Element elem = new Element("group", namespace);
+    elem.setAttribute("name", group.getShortName());
 
-    DataType dt = att.getDataType();
-    if ((dt != null) && (dt != DataType.STRING))
-      attElem.setAttribute("type", dt.toString());
-
-    if (att.getLength() == 0) {
-      if (att.isUnsigned())
-        attElem.setAttribute("isUnsigned", "true");
-      return attElem;
+    // enumTypeDef
+    for (EnumTypedef etd : group.getEnumTypedefs()) {
+      elem.addContent(makeEnumTypedefElement(etd));
     }
 
-    if (att.isString()) {
-      StringBuilder buff = new StringBuilder();
-      for (int i = 0; i < att.getLength(); i++) {
-        String sval = att.getStringValue(i);
-        if (i > 0) buff.append(",");
-        buff.append(sval);
-      }
-      attElem.setAttribute("value", Parse.cleanCharacterData(buff.toString()));
-      if (att.getLength() > 1)
-        attElem.setAttribute("separator", ",");
-
-    } else {
-      StringBuilder buff = new StringBuilder();
-      for (int i = 0; i < att.getLength(); i++) {
-        Number val = att.getNumericValue(i);
-        if (i > 0) buff.append(" ");
-        buff.append(val.toString());
-      }
-      attElem.setAttribute("value", buff.toString());
-
-      if (att.isUnsigned())
-        attElem.setAttribute("isUnsigned", "true");
+    // dimensions
+    for (Dimension dim : group.getDimensions()) {
+      elem.addContent(makeDimensionElement(dim));
     }
-    return attElem;
+
+    // regular variables
+    for (Variable var : group.getVariables()) {
+      boolean showValues = writeVariablesPredicate.apply(var);
+      elem.addContent(makeVariableElement(var, showValues));
+    }
+
+    // nested groups
+    for (Group g : group.getGroups()) {
+      Element groupElem = new Element("group", namespace);
+      groupElem.setAttribute("name", g.getShortName());
+      elem.addContent(makeGroupElement(g));
+    }
+
+    // attributes
+    for (Attribute att : group.getAttributes()) {
+      elem.addContent(makeAttributeElement(att));
+    }
+
+    return elem;
   }
 
-  // shared dimensions
-  public static Element writeDimension(Dimension dim, Namespace ns) {
-    Element dimElem = new Element("dimension", ns);
-    dimElem.setAttribute("name", dim.getShortName());
-    if (dim.isVariableLength())
-      dimElem.setAttribute("length", "*");
-    else
-      dimElem.setAttribute("length", Integer.toString(dim.getLength()));
-
-    if (dim.isUnlimited())
-      dimElem.setAttribute("isUnlimited", "true");
-    if (dim.isVariableLength())
-      dimElem.setAttribute("isVariableLength", "true");
-
-    return dimElem;
-  }
-
-     // enum Typedef
-  public static Element writeEnumTypedef(EnumTypedef etd, Namespace ns) {
-    Element typeElem = new Element("enumTypedef", ns);
+  // enum Typedef
+  public Element makeEnumTypedefElement(EnumTypedef etd) {
+    Element typeElem = new Element("enumTypedef", namespace);
     typeElem.setAttribute("name", etd.getShortName());
     typeElem.setAttribute("type", etd.getBaseType().toString());
-    Map<Integer, String> map = etd.getMap();
+
+    // Use a TreeMap so that the key-value pairs are emitted in a consistent order.
+    TreeMap<Integer, String> map = new TreeMap<>(etd.getMap());
+
     for (Map.Entry<Integer, String> entry : map.entrySet()) {
-      typeElem.addContent(new Element("enum", ns)
+      typeElem.addContent(new Element("enum", namespace)
               .setAttribute("key", Integer.toString(entry.getKey()))
               .addContent(entry.getValue()));
     }
@@ -259,46 +358,27 @@ public class NcMLWriter {
     return typeElem;
   }
 
-  private Element writeGroup(Element elem, Group group) {
-
-    // enumTypeDef
-    for (EnumTypedef etd : group.getEnumTypedefs()) {
-      elem.addContent(writeEnumTypedef(etd, ncNS));
+  // Only for shared dimensions.
+  public Element makeDimensionElement(Dimension dim) throws IllegalArgumentException {
+    if (!dim.isShared()) {
+      throw new IllegalArgumentException("Cannot create private dimension: " +
+              "in NcML, <dimension> elements are always shared.");
     }
 
-    // dimensions
-    for (Dimension dim : group.getDimensions()) {
-      elem.addContent(writeDimension(dim, ncNS));
-    }
+    Element dimElem = new Element("dimension", namespace);
+    dimElem.setAttribute("name", dim.getShortName());
+    dimElem.setAttribute("length", Integer.toString(dim.getLength()));
 
-    // attributes
-    for (Attribute att : group.getAttributes()) {
-      elem.addContent(writeAttribute(att, "attribute", ncNS));
-    }
+    if (dim.isUnlimited())
+      dimElem.setAttribute("isUnlimited", "true");
 
-    // regular variables
-    for (Variable var : group.getVariables()) {
-      try {
-        elem.addContent(writeVariable((VariableEnhanced) var));
-      } catch (ClassCastException e) {
-        log.error("var not instanceof VariableEnhanced = " + var.getFullName(), e);
-      }
-    }
-
-    // nested groups
-    for (Group g : group.getGroups()) {
-      Element groupElem = new Element("group", ncNS);
-      groupElem.setAttribute("name", g.getShortName());
-      elem.addContent(writeGroup(groupElem, g));
-    }
-
-    return elem;
+    return dimElem;
   }
 
-  private Element writeVariable(VariableEnhanced var) {
+  public Element makeVariableElement(Variable var, boolean showValues) {
     boolean isStructure = var instanceof Structure;
 
-    Element varElem = new Element("variable", ncNS);
+    Element varElem = new Element("variable", namespace);
     varElem.setAttribute("name", var.getShortName());
 
     StringBuilder buff = new StringBuilder();
@@ -323,56 +403,100 @@ public class NcMLWriter {
         varElem.setAttribute("typedef", var.getEnumTypedef().getShortName());
     }
 
+
     // attributes
     for (Attribute att : var.getAttributes()) {
-      varElem.addContent(writeAttribute(att, "attribute", ncNS));
+      varElem.addContent(makeAttributeElement(att));
     }
-
-    if (var.isMetadata() || (var == aggCoord))
-      varElem.addContent(writeValues(var, ncNS, true));
 
     if (isStructure) {
       Structure s = (Structure) var;
       for (Variable variable : s.getVariables()) {
-        VariableEnhanced nestedV = (VariableEnhanced) variable;
-        varElem.addContent(writeVariable(nestedV));
+        varElem.addContent(makeVariableElement(variable, showValues));
+      }
+    } else if (showValues) {
+      try {
+        varElem.addContent(makeValuesElement(var, true));
+      } catch (IOException e) {
+        String message = String.format("Couldn't read values for %s. Omitting <values> element.", var.getFullName());
+        log.warn(message, e);
       }
     }
 
     return varElem;
   }
 
-  public static Element writeValues(VariableEnhanced v, Namespace ns, boolean allowRegular) {
-    Array a;
-    try {
-      a = v.read();
-    } catch (IOException ioe) {
-      return new Element("values", ns);
+  public Element makeAttributeElement(Attribute attribute) {
+    Element attElem = new Element("attribute", namespace);
+    attElem.setAttribute("name", attribute.getShortName());
+
+    DataType dt = attribute.getDataType();
+    if ((dt != null) && (dt != DataType.STRING))
+      attElem.setAttribute("type", dt.toString());
+
+    if (attribute.getLength() == 0) {
+      if (attribute.isUnsigned())
+        attElem.setAttribute("isUnsigned", "true");
+      return attElem;
     }
-    return writeValues(a, ns, allowRegular);
+
+    if (attribute.isString()) {
+      StringBuilder buff = new StringBuilder();
+      for (int i = 0; i < attribute.getLength(); i++) {
+        String sval = attribute.getStringValue(i);
+        if (i > 0) buff.append("|");
+        buff.append(sval);
+      }
+
+      attElem.setAttribute("value", Parse.cleanCharacterData(buff.toString()));
+      if (attribute.getLength() > 1)
+        attElem.setAttribute("separator", "|");
+    } else {
+      StringBuilder buff = new StringBuilder();
+      for (int i = 0; i < attribute.getLength(); i++) {
+        Number val = attribute.getNumericValue(i);
+        if (i > 0) buff.append(" ");
+        buff.append(val.toString());
+      }
+      attElem.setAttribute("value", buff.toString());
+
+      if (attribute.isUnsigned())
+        attElem.setAttribute("isUnsigned", "true");
+    }
+    return attElem;
   }
 
-  public static Element writeValues(Array a, Namespace ns, boolean allowRegular) {
-    Element elem = new Element("values", ns);
+  /**
+   * Creates a {@code <values>} element from the variable's data.
+   *
+   * @param variable  the variable to read values from
+   * @param allowRegular  {@code true} if regular values should be represented with {@code start}, {@code increment},
+   *     and {@code npts} attributes instead of space-separated Element text. Has no effect if the data isn't regular.
+   * @return  the {@code <values>} element.
+   * @throws IOException  if there was an I/O error when reading the variable's data.
+   */
+  public Element makeValuesElement(Variable variable, boolean allowRegular) throws IOException {
+    Element elem = new Element("values", namespace);
 
-    DataType dtype = a.getDataType();
-    if (dtype == DataType.CHAR) {
+    StringBuilder buff = new StringBuilder();
+    Array a = variable.read();
+
+    if (variable.getDataType() == DataType.CHAR) {
       char[] data = (char[]) a.getStorage();
       elem.setText(new String(data));
-
-    } else if (dtype == DataType.STRING) { // use seperate elements??
-      IndexIterator iter = a.getIndexIterator();
+    } else if (variable.getDataType() == DataType.STRING) {
+      elem.setAttribute("separator", "|");
       int count = 0;
-      Formatter buff = new Formatter();
-      while (iter.hasNext()) {
-        String s = (String) iter.getObjectNext();
-        if (count++ > 0) buff.format(" ");
-        buff.format("\"%s\"", s);
+
+      for (IndexIterator iter = a.getIndexIterator(); iter.hasNext(); ) {
+        if (count++ > 0) {
+          buff.append("|");
+        }
+        buff.append(iter.getObjectNext());
       }
+
       elem.setText(buff.toString());
-
     } else {
-
       //check to see if regular
       if (allowRegular && (a.getRank() == 1) && (a.getSize() > 2)) {
         Index ima = a.getIndex();
@@ -389,19 +513,18 @@ public class NcMLWriter {
         if (isRegular) {
           elem.setAttribute("start", Double.toString(start));
           elem.setAttribute("increment", Double.toString(incr));
-          elem.setAttribute("npts", Long.toString(a.getSize()));
+          elem.setAttribute("npts", Long.toString(variable.getSize()));
           return elem;
         }
       }
 
       // not regular
-      boolean isRealType = (dtype == DataType.DOUBLE) || (dtype == DataType.FLOAT);
+      boolean isRealType = (variable.getDataType() == DataType.DOUBLE) || (variable.getDataType() == DataType.FLOAT);
       IndexIterator iter = a.getIndexIterator();
-      Formatter buff = new Formatter();
-      buff.format("%s", isRealType ? iter.getDoubleNext() : iter.getIntNext());
+      buff.append(isRealType ? iter.getDoubleNext() : iter.getIntNext());
       while (iter.hasNext()) {
-        buff.format(" ");
-        buff.format("%s", isRealType ? iter.getDoubleNext() : iter.getIntNext());
+        buff.append(" ");
+        buff.append(isRealType ? iter.getDoubleNext() : iter.getIntNext());
       }
       elem.setText(buff.toString());
 
@@ -409,5 +532,4 @@ public class NcMLWriter {
 
     return elem;
   }
-
 }

--- a/cdm/src/test/groovy/ucar/nc2/ncml/NcMLWriterSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ncml/NcMLWriterSpec.groovy
@@ -1,0 +1,279 @@
+package ucar.nc2.ncml
+
+import com.google.common.base.Predicate
+import com.google.common.base.Predicates
+import org.jdom2.Element
+import org.jdom2.Namespace
+import org.jdom2.output.Format
+import spock.lang.Shared
+import spock.lang.Specification
+import ucar.ma2.Array
+import ucar.ma2.DataType
+import ucar.nc2.*
+import ucar.nc2.dataset.NetcdfDataset
+
+/**
+ * @author cwardgar
+ * @since 2015/08/05
+ */
+class NcMLWriterSpec extends Specification {
+    @Shared
+    NetcdfFile ncFile
+
+    /* Programmatically creates a NetcdfFile with the following (pseudo) CDL:
+netcdf {
+  types:
+    short enum dessertType { 'pie' = 18, 'donut' = 268, 'cake' = 3284};
+  dimensions:
+    time = UNLIMITED;   // (3 currently)
+  variables:
+    enum dessertType dessert(time=3);
+      :zero = ; // long
+    short time(time=3);
+    char charVar(5);
+    String stringVar(4);
+  group: recordsGroup {
+    variables:
+      Structure {
+        int recordsVar(3);
+      } recordsStruct(*);
+    // group attributes:
+    :stooges = "Moe Howard", "Larry Fine", "Curly Howard";
+  }
+  // global attributes:
+  :primes = 2U, 3U, 5U, 7U, 11U; // int
+}
+data:
+dessert =
+  {18, 268, 3284}
+time =
+  {4, 5, 6}
+charVar = "abcde"
+stringVar = "Frodo Baggins", "Samwise Gamgee", "Meriadoc Brandybuck", "Peregrin Took"
+recordsGroup/recordsStruct = UNREADABLE
+     */
+    def setupSpec() {
+        setup: "NetcdfFile's 0-arg constructor is protected, so must use NetcdfFileSubclass"
+        ncFile = new NetcdfFileSubclass()
+
+        and: "create shared, unlimited Dimension"
+        Dimension timeDim = new Dimension("time", 3, true, true, false)
+        ncFile.addDimension(null, timeDim)
+
+        and: "create EnumTypedef and add it to root group"
+        EnumTypedef dessertType = new EnumTypedef("dessertType", [18: 'pie', 268: 'donut', 3284: 'cake'], DataType.ENUM2)
+        ncFile.getRootGroup().addEnumeration(dessertType)
+
+        and: "create Variable of type dessertType and add it"
+        Variable dessert = new Variable(ncFile, null, null, "dessert", DataType.ENUM2, "time")
+        dessert.enumTypedef = dessertType
+        dessert.addAttribute(new Attribute("zero", DataType.ULONG))  // unsigned, zero-length, LONG attribute
+        short[] dessertStorage = [18, 268, 3284] as short[]
+        dessert.setCachedData(Array.factory(DataType.SHORT, [3] as int[], dessertStorage), true)  // Irregularly-spaced values
+        ncFile.addVariable(null, dessert)
+
+        and: "create 'time' coordinate Variable"
+        Variable time = new Variable(ncFile, null, null, "time", DataType.SHORT, "time")
+        short[] timeStorage = [4, 5, 6] as short[]
+        time.setCachedData(Array.factory(DataType.SHORT, [3] as int[], timeStorage), false)
+        ncFile.addVariable(null, time)
+
+        and: "create char-valued Variable with anonymous Dimension"
+        Variable charVar = new Variable(ncFile, null, null, "charVar", DataType.CHAR, "5")
+        char[] charStorage = ['a', 'b', 'c', 'd', 'e'] as char[]
+        charVar.setCachedData(Array.factory(DataType.CHAR, [5] as int[], charStorage), true)
+        ncFile.addVariable(null, charVar)
+
+        and: "create string-valued Variable"
+        Variable stringVar = new Variable(ncFile, null, null, "stringVar", DataType.STRING, "4")
+        String[] stringStorage = ['Frodo Baggins', 'Samwise Gamgee', 'Meriadoc Brandybuck', 'Peregrin Took'] as String[]
+        stringVar.setCachedData(Array.factory(DataType.STRING, [4] as int[], stringStorage), true)
+        ncFile.addVariable(null, stringVar)
+
+        and: "create Group for records"
+        Group recordsGroup = new Group(ncFile, null, "recordsGroup")
+        ncFile.addGroup(null, recordsGroup)
+
+        and: "create unreadable Structure with variable-length dimension and add it to recordsGroup"
+        // recordsStruct will be unreadable because we don't cache any data for it. In fact, it's not even possible
+        // to cache data for Structures because ArrayStructure.copy() is unsupported, and caching needs that.
+        // Besides, there's no sensible way to represent a n>1-dimensional Structure's values in NcML anyway.
+        Structure recordsStruct = new Structure(ncFile, null, null, "recordsStruct")
+        Dimension numRecords = new Dimension("numRecords", -1, false, false, true)  // Variable-length dim
+        recordsStruct.setDimensions([numRecords])
+        recordsGroup.addVariable(recordsStruct)
+
+        and: "create record Variable and add it to the records Structure"
+        Variable recordsVar = new Variable(ncFile, recordsGroup, recordsStruct, "recordsVar", DataType.INT, "3")
+        recordsStruct.addMemberVariable(recordsVar)
+
+        and: "create group attribute containing multiple string values"
+        Attribute stoogesAttrib = new Attribute("stooges", ['Moe Howard', 'Larry Fine', 'Curly Howard'])
+        recordsGroup.addAttribute(stoogesAttrib)
+
+        and: "create global attribute with multiple unsigned integer values"
+        Attribute primesAttrib = new Attribute("primes", [2, 3, 5, 7, 11], true)
+        ncFile.addAttribute(null, primesAttrib)
+
+        and: "finish"
+        ncFile.finish()
+    }
+
+    @Shared String expectedNcmlResult = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <explicit />
+  <enumTypedef name="dessertType" type="enum2">
+    <enum key="18">pie</enum>
+    <enum key="268">donut</enum>
+    <enum key="3284">cake</enum>
+  </enumTypedef>
+  <dimension name="time" length="3" isUnlimited="true" />
+  <variable name="dessert" shape="time" type="enum2" typedef="dessertType">
+    <attribute name="zero" type="ulong" isUnsigned="true" />
+    <values>18.0 268.0 3284.0</values>
+  </variable>
+  <variable name="time" shape="time" type="short">
+    <values start="4.0" increment="1.0" npts="3" />
+  </variable>
+  <variable name="charVar" shape="5" type="char">
+    <values>abcde</values>
+  </variable>
+  <variable name="stringVar" shape="4" type="String">
+    <values separator="|">Frodo Baggins|Samwise Gamgee|Meriadoc Brandybuck|Peregrin Took</values>
+  </variable>
+  <group name="recordsGroup">
+    <variable name="recordsStruct" shape="*" type="Structure">
+      <variable name="recordsVar" shape="3" type="int" />
+    </variable>
+    <attribute name="stooges" value="Moe Howard|Larry Fine|Curly Howard" separator="|" />
+  </group>
+  <attribute name="primes" type="uint" value="2 3 5 7 11" isUnsigned="true" />
+</netcdf>
+'''
+
+    NcMLWriter ncmlWriter
+    def setup() {
+        ncmlWriter = new NcMLWriter();
+    }
+
+    def "set NetcdfFile properties and exercise namespace and xmlFormat getters/setters"() {
+        setup:
+        NetcdfFile emptyNcFile = new NetcdfFileSubclass()
+        emptyNcFile.setLocation("file:SOME_FILE");
+        emptyNcFile.setId("SOME_ID")
+        emptyNcFile.setTitle("NcMLWriter Test")
+        emptyNcFile.finish()
+
+        when: "set NcMLWriter namespace"
+        // Causes:
+        //     <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" />
+        // to become:
+        //     <netcdf />
+        ncmlWriter.namespace = Namespace.NO_NAMESPACE   // Exercise setter.
+
+        then: "getter returns instance just set"
+        ncmlWriter.namespace == Namespace.NO_NAMESPACE  // Exercise getter.
+
+        when: "set NcMLWriter XMLFormat"
+        // Omits the '<?xml version="1.0" encoding="UTF-8"?>' declaration.
+        Format xmlFormat = Format.rawFormat.setOmitDeclaration(true)
+        ncmlWriter.xmlFormat = xmlFormat   // Exercise setter.
+
+        then: "getter returns instance just set"
+        ncmlWriter.xmlFormat == xmlFormat  // Exercise getter.
+
+        expect:
+        Element netcdfElem = ncmlWriter.makeNetcdfElement(emptyNcFile, null)
+        ncmlWriter.writeToString(netcdfElem) ==
+                '<netcdf location="file:SOME_FILE" id="SOME_ID" title="NcMLWriter Test" />\r\n'
+    }
+
+    def "makeDimensionElement() throws exception for private Dimension"() {
+        when:
+        ncmlWriter.makeDimensionElement(new Dimension("private", 8, false))
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "Cannot create private dimension: in NcML, <dimension> elements are always shared."
+    }
+
+    def "'time' is a coordinate variable"() {
+        expect:
+        NcMLWriter.writeCoordinateVariablesPredicate.apply(ncFile.findVariable("time"))
+    }
+
+    def "'charVar', 'stringVar', and 'dessert' are metadata variables"() {
+        expect:
+        ['charVar', 'stringVar', 'dessert'].every {
+            NcMLWriter.writeMetadataVariablesPredicate.apply(ncFile.findVariable(it))
+        }
+    }
+
+    def "'recordsGroup/recordsStruct' can be selected with WriteVariablesWithNamesPredicate"() {
+        setup:
+        Predicate<Variable> writeVarsPred =
+                new NcMLWriter.WriteVariablesWithNamesPredicate(['recordsGroup/recordsStruct'])
+
+        expect:
+        writeVarsPred.apply(ncFile.findVariable('recordsGroup/recordsStruct'))
+    }
+
+    def "write to String using compound writeVariablesPredicate"() {
+        setup: "configure NcMLWriter"
+        Predicate<Variable> compoundPred = Predicates.or(
+                NcMLWriter.writeCoordinateVariablesPredicate,   // "time"
+                NcMLWriter.writeMetadataVariablesPredicate,     // "charVar", "stringVar", "dessert"
+                new NcMLWriter.WriteVariablesWithNamesPredicate(['recordsGroup/recordsStruct']));
+
+        when: "set NcMLWriter writeVariablesPredicate"
+        ncmlWriter.writeVariablesPredicate = compoundPred   // Exercise setter.
+
+        then: "getter returns instance just set"
+        ncmlWriter.writeVariablesPredicate == compoundPred  // Exercise getter.
+
+        expect: "compoundPred applies to every Variable in ncFile"
+        ncFile.variables.every { ncmlWriter.writeVariablesPredicate.apply(it) }
+
+        and: "generated NcML string will match expectedNcmlResult"
+        Element netcdfElem = ncmlWriter.makeExplicitNetcdfElement(ncFile, null)
+        println ncmlWriter.writeToString(netcdfElem)
+        println "\n\n" + expectedNcmlResult
+        ncmlWriter.writeToString(netcdfElem) == expectedNcmlResult
+    }
+
+    // TODO: This is an integration test and probably runs much slower than the other tests in this class.
+    // How to categorize it and only execute it in certain environments?
+    def "round-trip: write to File and read back in, using NcMLReader"() {
+        setup: "create temporary file to write NcML to"
+        File outFile = File.createTempFile("NcMLWriterSpec", ".ncml")
+
+        and: "configure NcMLWriter"
+        // Don't try to write values 'recordsGroup/recordsStruct' this time; that already failed in previous method.
+        // Also, the NetcdfDataset that NcMLReader returns will try to generate missing values, which we don't want.
+        ncmlWriter.writeVariablesPredicate = Predicates.or(
+                NcMLWriter.writeCoordinateVariablesPredicate,   // "time"
+                NcMLWriter.writeMetadataVariablesPredicate)     // "charVar", "stringVar", "dessert"
+
+        when: "write NcML to file"
+        Element netcdfElem = ncmlWriter.makeExplicitNetcdfElement(ncFile, null)
+        ncmlWriter.writeToFile(netcdfElem, outFile)
+
+        then: "file's content matches expectedNcmlResult"
+        outFile.text == expectedNcmlResult
+
+        when: "read in NcML file and create a NetcdfDataset"
+        NetcdfDataset readerDataset = NcMLReader.readNcML(outFile.toURI().toURL().toString(), null)
+
+        and: "get the NcML representation of the dataset"
+        readerDataset.setLocation(null)  // Leaving this non-null would screw up our comparison.
+        Element readerNetcdfElem = ncmlWriter.makeExplicitNetcdfElement(readerDataset, null)
+
+        then: "it matches expectedNcmlResult"
+        ncmlWriter.writeToString(readerNetcdfElem) == expectedNcmlResult
+
+        cleanup:
+        readerDataset?.close()
+        outFile?.delete()
+    }
+}

--- a/docs/website/netcdf-java/ncml/Aggregation.html
+++ b/docs/website/netcdf-java/ncml/Aggregation.html
@@ -304,7 +304,7 @@ netcdf feb.nc {
 <p>A <em><strong>JoinNew</strong></em> aggregation has to create a new coordinate variable. In the above example, one
   was automatically created with type double, to match the coordValues specified on the netcdf elements. However, it
   has no units or other attributes. To specify attributes on the coordinate system, you can use the following (download
-  <a href="examples/aggNewCoord.ncml">aggNewCoord.ncm):</a></p>
+  <a href="examples/aggNewCoord.ncml">aggNewCoord.ncml</a>):</p>
 <pre>&lt;netcdf xmlns=&quot;http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2&quot;&gt;
 <strong>(1)</strong>&lt;variable name=&quot;time&quot; type=&quot;int&quot; &gt;
      &lt;attribute name=&quot;units&quot; value=&quot;months since 2000-6-16 6:00&quot;/&gt;
@@ -412,7 +412,7 @@ netcdf feb.nc {
 <h3>Extracting date coordinates from the filename</h3>
 
 <p>For the common case that the filename contains date information from which you can derive a time coordinate, you can
-  use the <strong>dateFormatMark</strong> attribute (download <a href="examples/aggDateFormat.ncml">aggDateFormat</a>.ncml
+  use the <strong>dateFormatMark</strong> attribute (download <a href="examples/aggDateFormat.ncml">aggDateFormat.ncml</a>
   and <a href="examples/cg.zip">cg.zip</a>, unzip the latter and place in your data directory). In the ToolsUI
   <strong>NcML Tab</strong>, open <strong>aggDateFormat.ncml</strong> and change the scan location to point to your
   data directory, and then save it <img src="images/saveButt.png" width="31" height="30" alt="">:</p>

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -2,6 +2,10 @@ configure(javaProjects + rootProject) {
     // The jacoco plugin adds the jacocoTestReport task, but only if the java plugin is already applied.
     apply plugin: "jacoco"
 
+    jacoco {
+        toolVersion = '0.7.5.201505241946'  // The latest version as of 2015-06-26.
+    }
+
     tasks.withType(Test).all {
         // Add the execution data that Jacoco generates as a task output.
         outputs.file jacoco.destinationFile

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -115,6 +115,10 @@ libraries["com.eclipsesource.restfuse"] = "com.restfuse:com.eclipsesource.restfu
 
 libraries["httpunit"] = "httpunit:httpunit:1.7"
 
+libraries["groovy-all"] = "org.codehaus.groovy:groovy-all:2.4.1"
+
+libraries["spock-core"] = "org.spockframework:spock-core:1.0-groovy-2.4"
+
 ////////////////////////////////////////// Other //////////////////////////////////////////
 
 libraries["bounce"] = "org.bounce:bounce:0.14"

--- a/legacy/src/main/java/ucar/nc2/dt/point/StationObsDatasetInfo.java
+++ b/legacy/src/main/java/ucar/nc2/dt/point/StationObsDatasetInfo.java
@@ -33,26 +33,31 @@
 
 package ucar.nc2.dt.point;
 
-import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.FeatureType;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-import ucar.nc2.dataset.*;
-import ucar.nc2.units.DateFormatter;
-import ucar.nc2.dt.*;
-import ucar.unidata.geoloc.LatLonRect;
-
-import org.jdom2.output.XMLOutputter;
-import org.jdom2.output.Format;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import ucar.nc2.VariableSimpleIF;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.CoordinateTransform;
+import ucar.nc2.dt.GridCoordSystem;
+import ucar.nc2.dt.StationObsDataset;
+import ucar.nc2.dt.TypedDatasetFactory;
+import ucar.nc2.ncml.NcMLWriter;
+import ucar.nc2.units.DateFormatter;
+import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.util.Parameter;
-
-import java.util.*;
-import java.util.zip.GZIPOutputStream;
-import java.io.OutputStream;
-import java.io.IOException;
-import java.io.FileOutputStream;
-import java.io.File;
 
 /**
  * A helper class to StationObsDataset; creates XML documents.
@@ -293,6 +298,7 @@ public class StationObsDatasetInfo {
   }
 
   private Element writeVariable(VariableSimpleIF v) {
+    NcMLWriter ncmlWriter = new NcMLWriter();
 
     Element varElem = new Element("variable");
     varElem.setAttribute("name", v.getShortName());
@@ -305,7 +311,7 @@ public class StationObsDatasetInfo {
     Iterator atts = v.getAttributes().iterator();
     while (atts.hasNext()) {
       ucar.nc2.Attribute att = (ucar.nc2.Attribute) atts.next();
-      varElem.addContent(ucar.nc2.ncml.NcMLWriter.writeAttribute(att, "attribute", null));
+      varElem.addContent(ncmlWriter.makeAttributeElement(att));
     }
 
     return varElem;

--- a/ui/src/main/java/ucar/nc2/ui/NcmlEditor.java
+++ b/ui/src/main/java/ucar/nc2/ui/NcmlEditor.java
@@ -1,13 +1,30 @@
 package ucar.nc2.ui;
 
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.*;
+import javax.swing.text.PlainDocument;
+
 import org.bounce.text.LineNumberMargin;
 import org.bounce.text.ScrollableEditorPanel;
 import org.bounce.text.xml.XMLDocument;
 import org.bounce.text.xml.XMLEditorKit;
 import org.bounce.text.xml.XMLStyleConstants;
+import org.jdom2.Element;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.write.Nc4ChunkingStrategy;
 import ucar.nc2.ncml.NcMLReader;
 import ucar.nc2.ncml.NcMLWriter;
 import ucar.nc2.ui.dialog.NetcdfOutputChooser;
@@ -17,20 +34,9 @@ import ucar.nc2.ui.widget.IndependentWindow;
 import ucar.nc2.ui.widget.TextHistoryPane;
 import ucar.nc2.util.CancelTask;
 import ucar.nc2.util.IO;
+import ucar.nc2.write.Nc4ChunkingStrategy;
 import ucar.util.prefs.PreferencesExt;
 import ucar.util.prefs.ui.ComboBox;
-
-import javax.swing.*;
-import javax.swing.text.PlainDocument;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.io.*;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Describe
@@ -242,15 +248,13 @@ public class NcmlEditor extends JPanel {
       if (ds == null) {
         editor.setText("Failed to open <" + location + ">");
       } else {
-        result = new NcMLWriter().writeXML(ds);
+        NcMLWriter ncmlWriter = new NcMLWriter();
+        Element netcdfElem = ncmlWriter.makeNetcdfElement(ds, null);
+        result = ncmlWriter.writeToString(netcdfElem);
+
         editor.setText(result);
         editor.setCaretPosition(0);
       }
-
-    } catch (FileNotFoundException ioe) {
-      editor.setText("Failed to open <" + location + ">");
-      err = true;
-
     } catch (Exception e) {
       StringWriter sw = new StringWriter(10000);
       e.printStackTrace();

--- a/ui/src/main/java/ucar/nc2/ui/grid/GridController.java
+++ b/ui/src/main/java/ucar/nc2/ui/grid/GridController.java
@@ -32,33 +32,6 @@
  */
 package ucar.nc2.ui.grid;
 
-import ucar.ma2.Array;
-import ucar.nc2.constants.CDM;
-import ucar.nc2.dataset.CoordinateAxis1D;
-import ucar.nc2.dataset.CoordinateAxis1DTime;
-import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.dt.GridCoordSystem;
-import ucar.nc2.dt.GridDataset;
-import ucar.nc2.dt.GridDatatype;
-import ucar.nc2.dt.grid.GridDatasetInfo;
-import ucar.nc2.ncml.NcMLWriter;
-import ucar.nc2.ui.event.ActionCoordinator;
-import ucar.nc2.ui.event.ActionSourceListener;
-import ucar.nc2.ui.event.ActionValueEvent;
-import ucar.nc2.ui.geoloc.*;
-import ucar.nc2.ui.util.Renderer;
-import ucar.nc2.ui.widget.BAMutil;
-import ucar.nc2.ui.widget.ScaledPanel;
-import ucar.nc2.util.NamedObject;
-import ucar.unidata.geoloc.ProjectionImpl;
-import ucar.unidata.geoloc.ProjectionPointImpl;
-import ucar.unidata.geoloc.ProjectionRect;
-import ucar.util.prefs.PreferencesExt;
-import ucar.util.prefs.ui.Debug;
-
-import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -72,6 +45,41 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.jdom2.Element;
+import ucar.ma2.Array;
+import ucar.nc2.constants.CDM;
+import ucar.nc2.dataset.CoordinateAxis1D;
+import ucar.nc2.dataset.CoordinateAxis1DTime;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dt.GridCoordSystem;
+import ucar.nc2.dt.GridDataset;
+import ucar.nc2.dt.GridDatatype;
+import ucar.nc2.dt.grid.GridDatasetInfo;
+import ucar.nc2.ncml.NcMLWriter;
+import ucar.nc2.ui.event.ActionCoordinator;
+import ucar.nc2.ui.event.ActionSourceListener;
+import ucar.nc2.ui.event.ActionValueEvent;
+import ucar.nc2.ui.geoloc.CursorMoveEvent;
+import ucar.nc2.ui.geoloc.CursorMoveEventListener;
+import ucar.nc2.ui.geoloc.NavigatedPanel;
+import ucar.nc2.ui.geoloc.NewMapAreaEvent;
+import ucar.nc2.ui.geoloc.NewMapAreaListener;
+import ucar.nc2.ui.geoloc.NewProjectionEvent;
+import ucar.nc2.ui.geoloc.NewProjectionListener;
+import ucar.nc2.ui.geoloc.PickEvent;
+import ucar.nc2.ui.geoloc.PickEventListener;
+import ucar.nc2.ui.util.Renderer;
+import ucar.nc2.ui.widget.BAMutil;
+import ucar.nc2.ui.widget.ScaledPanel;
+import ucar.nc2.util.NamedObject;
+import ucar.unidata.geoloc.ProjectionImpl;
+import ucar.unidata.geoloc.ProjectionPointImpl;
+import ucar.unidata.geoloc.ProjectionRect;
+import ucar.util.prefs.PreferencesExt;
+import ucar.util.prefs.ui.Debug;
 
 /**
  * The controller manages the interactions between GRID data and renderers.
@@ -536,12 +544,10 @@ public class GridController {
 
   String getNcML() {
     if (gridDataset == null) return "Null gridset";
-    try {
-      return new NcMLWriter().writeXML( gridDataset.getNetcdfFile());
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-    }
-    return "";
+
+    NcMLWriter ncmlWriter = new NcMLWriter();
+    Element netcdfElement = ncmlWriter.makeNetcdfElement(gridDataset.getNetcdfFile(), null);
+    return ncmlWriter.writeToString(netcdfElement);
   }
 
   NetcdfDataset getNetcdfDataset() { return netcdfDataset; }


### PR DESCRIPTION
I broke the NcMLWriter API with this change set, so I elected to put it on 5.0.0 instead of 4.6.

There were quite a few conflicts when I rebased this onto 5.0.0. Hopefully I resolved them all properly.