### PR TITLE
Unicode NetCDF Object Names - non-English letter as first character

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/TestWriteMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestWriteMisc.java
@@ -38,12 +38,12 @@ public class TestWriteMisc {
     NetcdfFileWriter fileWriter = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, TestLocal.temporaryDataDir + "objnames.nc");
     Dimension[] dim = new Dimension[1];
     int aSize = 8;
-    dim[0] = setDimension(fileWriter, "ñ", "blah", aSize);
+    dim[0] = setDimension(fileWriter, "ñÁÉ", "blah", aSize);
     Variable v = fileWriter.addVariable(null, "áéíóú", DataType.FLOAT, Arrays.asList(dim));
     fileWriter.addVariableAttribute(v, new Attribute("_FillValue", -9999));
     fileWriter.addVariableAttribute(v, new Attribute(CDM.MISSING_VALUE, -9999));
-    System.out.println("Did not throw exception");
-    fileWriter.create();  // throws error missing native C
+    System.out.println("Did not throw exception - good");
+    fileWriter.create();
     System.out.println("Writing netcdf <=");
     int[] shape = new int[]{aSize};
     float[] floatStorage = new float[aSize];

--- a/cdm-test/src/test/java/ucar/nc2/TestWriteMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestWriteMisc.java
@@ -29,6 +29,33 @@ public class TestWriteMisc {
  >     Band2:valid_range = 0s, 254s; // short
  */
 
+
+
+  // test object naming
+  @Test
+  public void testObjectNaming() throws IOException, InvalidRangeException {
+    System.out.println("Using ñáéíóú in netcdf <=");
+    NetcdfFileWriter fileWriter = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, TestLocal.temporaryDataDir + "objnames.nc");
+    Dimension[] dim = new Dimension[1];
+    int aSize = 8;
+    dim[0] = setDimension(fileWriter, "ñ", "blah", aSize);
+    Variable v = fileWriter.addVariable(null, "áéíóú", DataType.FLOAT, Arrays.asList(dim));
+    fileWriter.addVariableAttribute(v, new Attribute("_FillValue", -9999));
+    fileWriter.addVariableAttribute(v, new Attribute(CDM.MISSING_VALUE, -9999));
+    System.out.println("Did not throw exception");
+    fileWriter.create();  // throws error missing native C
+    System.out.println("Writing netcdf <=");
+    int[] shape = new int[]{aSize};
+    float[] floatStorage = new float[aSize];
+    Array floatArray = Array.factory(float.class, shape, floatStorage);
+    int[] origin = new int[]{0};
+    fileWriter.write(v, origin, floatArray);
+    fileWriter.close();
+    System.out.println("Done <=");
+  }
+
+
+
   @Test
   public void testUnsignedAttribute() throws IOException, InvalidRangeException {
      String filename = TestLocal.temporaryDataDir + "testUnsignedAttribute2.nc";

--- a/cdm/src/main/java/ucar/nc2/iosp/netcdf3/N3iosp.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/netcdf3/N3iosp.java
@@ -229,7 +229,7 @@ public String NC_check_name(String name) {
     return sb.toString();
   }
 
-  static private final Pattern objectNamePattern = Pattern.compile("[a-zA-Z0-9_][^\\x00-\\x1F\\x2F\\x7F]*");
+  static private final Pattern objectNamePattern = Pattern.compile("[\\p{L}0-9_][^\\x00-\\x1F\\x2F\\x7F]*");
 
    /**
     * Determine if the given name can be used for a Dimension, Attribute, or Variable name.


### PR DESCRIPTION


[Documentation on identifier/object names](http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/CDM/Identifiers.html) states:
"The first character of a name must be alphanumeric, a multi-byte UTF-8 character, or `_` (reserved for special names with meaning to implementations, such as the `_FillValue` attribute)."
By regular expression
  `([a-zA-Z0-9_]|{MUTF8})([^\x00-\x1F\x2F/\x7F]|{MUTF8})*`

However, the regular expression used in `N3iosp.isValidNetcdfObjectName` (called from `NetcdfFileWriter.isValidObjectName`) is more strict than what is documented - first character is *English*-letter/decimal-digit/underbar.
  `[a-zA-Z0-9_][^\\x00-\\x1F\\x2F\\x7F]*`

Proposed regex - changes only the character class for the first character:
  `[\\p{L}0-9_][^\\x00-\\x1F\\x2F\\x7F]*`
