### PR TITLE
Support for RadarServer crawling S3 (via S3fs)

### DIFF
--- a/docker/tds-base/.gitignore
+++ b/docker/tds-base/.gitignore
@@ -1,2 +1,3 @@
 *.jar
 *.war
+config.zip

--- a/docker/tds-base/Dockerfile
+++ b/docker/tds-base/Dockerfile
@@ -45,7 +45,7 @@ COPY tomcat-files/bash_logout /usr/local/tomcat/.bash_logout
 #
 # Copy thredds.war
 #
-COPY thredds.war /usr/local/tomcat/webapps/thredds##04.06.03-SNAPSHOT.war
+COPY thredds.war /usr/local/tomcat/webapps/thredds##04.06.04-SNAPSHOT.war
 
 #
 # Change owner of tomcat directory to user and group tomcat

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -31,7 +31,8 @@ public class RadarDataInventory {
     private EnumMap<DirType, Set<String>> items;
     private Path collectionDir;
     private DirectoryStructure structure;
-    private String fileTimeRegex, fileTimeFmt, dataFormat;
+    private String fileTimeFmt, dataFormat;
+    private java.util.regex.Pattern fileTimeRegex;
     private boolean dirty;
     private CalendarDate lastUpdate;
     private int maxCrawlItems;
@@ -239,7 +240,7 @@ public class RadarDataInventory {
     }
 
     public void addFileTime(String regex, String fmt) {
-        fileTimeRegex = regex;
+        fileTimeRegex = java.util.regex.Pattern.compile(regex);
         fileTimeFmt = fmt;
     }
 
@@ -482,8 +483,7 @@ public class RadarDataInventory {
             for(Path p : filteredResults) {
                 try(DirectoryStream<Path> dirStream = Files.newDirectoryStream(p)) {
                     for (Path f: dirStream) {
-                        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(fileTimeRegex);
-                        java.util.regex.Matcher regexMatcher = pattern.matcher(f.toString());
+                        java.util.regex.Matcher regexMatcher = fileTimeRegex.matcher(f.toString());
                         if (!regexMatcher.find()) continue;
 
                         try {

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -262,7 +262,7 @@ public class RadarDataInventory {
         int crawled = 0;
         try(DirectoryStream<Path> dirStream = Files.newDirectoryStream(start)) {
             for (Path p : dirStream) {
-                if (p.toFile().isDirectory()) {
+                if (Files.isDirectory(p)) {
                     String item = p.getFileName().toString();
                     values.add(item);
                     // Try to grab station info from some file
@@ -443,7 +443,7 @@ public class RadarDataInventory {
                         for (Object next: queryItem) {
                             for (Path p : results) {
                                 Path nextPath = p.resolve(next.toString());
-                                if (nextPath.toFile().exists())
+                                if (Files.exists(nextPath))
                                     newResults.add(nextPath);
                             }
                         }

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -156,10 +156,9 @@ public class RadarDataInventory {
 
             public Date getDate(Path path) {
                 Path relPath = base.relativize(path);
-                String[] parts = relPath.toString().split(sep);
                 StringBuilder sb = new StringBuilder("");
                 for (Integer l: levels) {
-                    sb.append(parts[l]);
+                    sb.append(relPath.getName(l));
                 }
                 try {
                     SimpleDateFormat fmt = getFormat();
@@ -171,14 +170,12 @@ public class RadarDataInventory {
         }
 
         private Path base;
-        private String sep;
 
         private List<DirEntry> order;
         private List<Integer> keyIndices;
 
         public DirectoryStructure(Path dir) {
             base = dir;
-            sep = System.getProperty("file.separator");
             order = new ArrayList<>();
             keyIndices = new ArrayList<>();
         }
@@ -193,10 +190,9 @@ public class RadarDataInventory {
         // Get a key for a path based on station/var
         public String getKey(Path path) {
             Path relPath = base.relativize(path);
-            String[] parts = relPath.toString().split(sep);
             StringBuilder sb = new StringBuilder("");
             for (int ind: keyIndices) {
-                sb.append(parts[ind]);
+                sb.append(relPath.getName(ind));
             }
             return sb.toString();
         }

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -42,12 +42,12 @@ public class RadarDataInventory {
     private DateRange timeCoverage;
     private RadarServerConfig.RadarConfigEntry.GeoInfo geoCoverage;
 
-    public RadarDataInventory(Path datasetRoot) {
+    public RadarDataInventory(Path datasetRoot, int numCrawl) {
         items = new EnumMap<>(DirType.class);
         collectionDir = datasetRoot;
         structure = new DirectoryStructure(collectionDir);
         dirty = true;
-        maxCrawlItems = 5;
+        maxCrawlItems = numCrawl;
         stations = new StationList();
         nearestWindow = CalendarPeriod.of(1, CalendarPeriod.Field.Hour);
     }

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -534,39 +534,4 @@ public class RadarDataInventory {
             return filteredFiles;
         }
     }
-
-    public static void main(String[] args) throws IOException {
-        for (String name : args) {
-            File baseDir = new File(name);
-            if (baseDir.isDirectory()) {
-                RadarDataInventory dw = new RadarDataInventory(baseDir.toPath());
-                dw.addVariableDir();
-                dw.addStationDir();
-                dw.addDateDir("yyyyMMdd");
-
-                System.out.println("Stations:");
-                for (Object res : dw.listItems(DirType.Station))
-                    System.out.println("\t" + res);
-
-                System.out.println("Variables:");
-                for (Object res : dw.listItems(DirType.Variable))
-                    System.out.println("\t" + res);
-
-                System.out.println("Dates:");
-                for (Object res : dw.listItems(DirType.Date))
-                    System.out.println("\t" + res);
-
-                Query q = dw.newQuery();
-                q.addVariable("N0Q");
-                q.addStation("TLX");
-                q.addDateRange(CalendarDateRange.of(CalendarDate.of(null, 2014,
-                                6, 24, 0, 0, 0),
-                        CalendarDate.of(null, 2014, 6, 25, 0, 0, 0)));
-
-                System.out.println("Results of query:");
-                for (Query.QueryResultItem i : q.results())
-                    System.out.println("File: " + i.file.toString());
-            }
-        }
-    }
 }

--- a/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarDataInventory.java
@@ -7,7 +7,6 @@ import ucar.nc2.time.*;
 import ucar.nc2.units.DateRange;
 import ucar.unidata.geoloc.EarthLocation;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -35,7 +34,7 @@ public class RadarDataInventory {
     private String fileTimeRegex, fileTimeFmt, dataFormat;
     private boolean dirty;
     private CalendarDate lastUpdate;
-    private int maxCrawlItems, maxCrawlDepth;
+    private int maxCrawlItems;
     private StationList stations;
     private CalendarPeriod nearestWindow, rangeAdjustment;
     private String name, description;
@@ -48,7 +47,6 @@ public class RadarDataInventory {
         structure = new DirectoryStructure(collectionDir);
         dirty = true;
         maxCrawlItems = 5;
-        maxCrawlDepth = 3;
         stations = new StationList();
         nearestWindow = CalendarPeriod.of(1, CalendarPeriod.Field.Hour);
     }
@@ -124,6 +122,7 @@ public class RadarDataInventory {
     }
 
     public static class DirectoryStructure {
+        int maxCrawlDepth = 1;
         private static class DirEntry {
             public DirType type;
             public String fmt;
@@ -182,6 +181,7 @@ public class RadarDataInventory {
 
         public void addSubDir(DirType type, String fmt) {
             if (type == DirType.Station || type == DirType.Variable) {
+                maxCrawlDepth = order.size() + 1;
                 keyIndices.add(order.size());
             }
             order.add(new DirEntry(type, fmt));
@@ -246,7 +246,7 @@ public class RadarDataInventory {
     private void findItems(Path start, int level) {
         // Add each entry from this level to the appropriate item box
         // and recurse
-        if (level >= structure.order.size() || level >= maxCrawlDepth)
+        if (level >= structure.order.size() || level >= structure.maxCrawlDepth)
             return;
 
         DirectoryStructure.DirEntry entry = structure.order.get(level);

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
@@ -90,6 +90,12 @@ public class RadarServerConfig {
         // Otherwise, use the default.
         if(location.contains(":")) {
             URI uri = URI.create(location);
+
+            // Fix parsing of s3:// (note two '/') style paths
+            if (uri.getPath().isEmpty()) {
+                uri = URI.create(location.replace("//", "///"));
+            }
+
             location = uri.getPath();
             fs = getFS(uri);
         } else {

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
@@ -44,6 +44,12 @@ public class RadarServerConfig {
                 conf.dateParseRegex = collection.getAttributeValue("dateRegex");
                 conf.dateFmt = collection.getAttributeValue("dateFormat");
                 conf.layout = collection.getAttributeValue("layout");
+                String crawlItems = collection.getAttributeValue("crawlItems");
+                if (crawlItems != null) {
+                    conf.crawlItems = Integer.parseInt(crawlItems);
+                } else {
+                    conf.crawlItems = 5;
+                }
 
                 Element meta = dataset.getChild("metadata", catNS);
                 conf.name = dataset.getAttributeValue("name");
@@ -83,8 +89,7 @@ public class RadarServerConfig {
         // If we're given an actual URI, use that to find the file system.
         // Otherwise, use the default.
         if(location.contains(":")) {
-            URI uri;
-            uri = URI.create(location);
+            URI uri = URI.create(location);
             location = uri.getPath();
             fs = getFS(uri);
         } else {
@@ -214,6 +219,7 @@ public class RadarServerConfig {
         public String dateParseRegex, dateFmt, layout;
         public DateRange timeCoverage;
         public GeoInfo  spatialCoverage;
+        public int crawlItems;
         public List<VarInfo> vars;
 
         static public class GeoInfo {

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
@@ -41,7 +41,7 @@ public class RadarServerConfig {
                 Element meta = dataset.getChild("metadata", catNS);
                 conf.name = dataset.getAttributeValue("name");
                 conf.urlPath = dataset.getAttributeValue("path");
-                conf.diskPath = dataset.getAttributeValue("location");
+                conf.dataPath = dataset.getAttributeValue("location");
                 conf.dataFormat = meta.getChild("dataFormat", catNS).getValue();
                 conf.stationFile = meta.getChild("stationFile", catNS).getAttributeValue("path");
                 conf.doc = meta.getChild("documentation", catNS).getValue();
@@ -152,7 +152,7 @@ public class RadarServerConfig {
     }
 
     static public class RadarConfigEntry {
-        public String name, urlPath, diskPath, dataFormat, stationFile, doc;
+        public String name, urlPath, dataPath, dataFormat, stationFile, doc;
         public String dateParseRegex, dateFmt, layout;
         public DateRange timeCoverage;
         public GeoInfo  spatialCoverage;

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
@@ -12,13 +12,20 @@ import ucar.nc2.units.TimeDuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Handle configuration for the Radar Server
  */
 public class RadarServerConfig {
+    static ConcurrentHashMap<String, FileSystemProvider> fsproviders = new ConcurrentHashMap<>();
+
     static public List<RadarConfigEntry> readXML(String filename) {
         List<RadarConfigEntry> configs = new ArrayList<>();
 
@@ -41,7 +48,7 @@ public class RadarServerConfig {
                 Element meta = dataset.getChild("metadata", catNS);
                 conf.name = dataset.getAttributeValue("name");
                 conf.urlPath = dataset.getAttributeValue("path");
-                conf.dataPath = dataset.getAttributeValue("location");
+                conf.dataPath = getPath(dataset.getAttributeValue("location"));
                 conf.dataFormat = meta.getChild("dataFormat", catNS).getValue();
                 conf.stationFile = meta.getChild("stationFile", catNS).getAttributeValue("path");
                 conf.doc = meta.getChild("documentation", catNS).getValue();
@@ -68,6 +75,56 @@ public class RadarServerConfig {
         }
 
         return configs;
+    }
+
+    private static Path getPath(String location) throws IOException {
+        FileSystem fs;
+
+        // If we're given an actual URI, use that to find the file system.
+        // Otherwise, use the default.
+        if(location.contains(":")) {
+            URI uri;
+            uri = URI.create(location);
+            location = uri.getPath();
+            fs = getFS(uri);
+        } else {
+            fs = FileSystems.getDefault();
+        }
+        return fs.getPath(location);
+    }
+
+    private static FileSystem getFS(URI uri) throws IOException {
+        FileSystem fs;
+
+        try {
+            fs = getProvider(uri).getFileSystem(uri);
+        } catch (ProviderNotFoundException e) {
+            System.out.println("Provider not found: " + e.getMessage());
+            System.out.println("Using default file system.");
+            fs = FileSystems.getDefault();
+        }
+        return fs;
+    }
+
+    // This is to work around the fact that when we *get* a filesystem, we
+    // cannot pass in the class loader. This results in custom providers (say
+    // S3) not being found. However, the filesystem already exists, so the
+    // filesystem can't be re-created either.
+    private static FileSystemProvider getProvider(URI uri) throws IOException {
+        if(fsproviders.containsKey(uri.getScheme())) {
+            return fsproviders.get(uri.getScheme());
+        } else {
+            FileSystem fs;
+            try {
+                fs = FileSystems.newFileSystem(uri,
+                        new HashMap<String, Object>(),
+                        Thread.currentThread().getContextClassLoader());
+            } catch (FileSystemAlreadyExistsException e) {
+                fs = FileSystems.getFileSystem(uri);
+            }
+            fsproviders.put(uri.getScheme(), fs.provider());
+            return fs.provider();
+        }
     }
 
     protected static RadarConfigEntry.GeoInfo readGeospatialCoverage(Element gcElem) {
@@ -152,7 +209,8 @@ public class RadarServerConfig {
     }
 
     static public class RadarConfigEntry {
-        public String name, urlPath, dataPath, dataFormat, stationFile, doc;
+        public Path dataPath;
+        public String name, urlPath, dataFormat, stationFile, doc;
         public String dateParseRegex, dateFmt, layout;
         public DateRange timeCoverage;
         public GeoInfo  spatialCoverage;

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -125,7 +125,7 @@ public class RadarServerController {
         String contentPath = tdsContext.getContentDirectory().getPath();
         List<RadarServerConfig.RadarConfigEntry> configs = RadarServerConfig.readXML(contentPath + "/radar/radarCollections.xml");
         for (RadarServerConfig.RadarConfigEntry conf : configs) {
-            RadarDataInventory di = new RadarDataInventory(Paths.get(conf.diskPath));
+            RadarDataInventory di = new RadarDataInventory(Paths.get(conf.dataPath));
             di.setName(conf.name);
             di.setDescription(conf.doc);
 

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -124,7 +124,8 @@ public class RadarServerController {
         String contentPath = tdsContext.getContentDirectory().getPath();
         List<RadarServerConfig.RadarConfigEntry> configs = RadarServerConfig.readXML(contentPath + "/radar/radarCollections.xml");
         for (RadarServerConfig.RadarConfigEntry conf : configs) {
-            RadarDataInventory di = new RadarDataInventory(conf.dataPath);
+            RadarDataInventory di = new RadarDataInventory(conf.dataPath,
+                    conf.crawlItems);
             di.setName(conf.name);
             di.setDescription(conf.doc);
 

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -13,7 +13,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.*;
 import java.lang.UnsupportedOperationException;
 import java.text.ParseException;
 import java.util.*;
@@ -125,7 +124,7 @@ public class RadarServerController {
         String contentPath = tdsContext.getContentDirectory().getPath();
         List<RadarServerConfig.RadarConfigEntry> configs = RadarServerConfig.readXML(contentPath + "/radar/radarCollections.xml");
         for (RadarServerConfig.RadarConfigEntry conf : configs) {
-            RadarDataInventory di = new RadarDataInventory(Paths.get(conf.dataPath));
+            RadarDataInventory di = new RadarDataInventory(conf.dataPath);
             di.setName(conf.name);
             di.setDescription(conf.doc);
 


### PR DESCRIPTION
So here are the changes I've made to allow the RadarServer to crawl/query a collection of radar data on S3 (provided the radarCollections.xml file is properly configured). The support for S3 is using the s3fs library (from the fork here: https://github.com/Upplication/Amazon-S3-FileSystem-NIO2).

As it turns out, by having the S3 support implemented through a java NIO2 FileSystem (and Path, etc.), there are no S3 specific changes in the code. The biggest change was to try to find the appropriate `FileSystem` to use based on the passed in location from the configuration file (other changes to make sure I use s3fs-supported parts of the NIO2 API). The last commit in the PR currently modifies our dependencies to include s3fs and adds the appropriate class to `META-INF/services`, but I'm not sure now this is the right way to go for a runtime dependency that's only needed if we want radarServer to hit S3. I also have the amazon credentials in an `amazon.properties` located in `WEB-INF` on my local repo; it's possible to pass these as environment variables.

So open questions:
- [x] Is there a way to drop in the jar (and add the services file) alongside our normal TDS install (i.e. can we eliminate the need to put s3fs dependency in our codebase) ?
- [x] What's the right way to set up the amazon credentials? Should we have them added to `setenv.sh`?

Once we decide these I'll be sure to create documentation (in asciidoc of course) to allow others to set this up.