### PR TITLE
* Fix for Github issues #191 and #223

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
@@ -1,30 +1,24 @@
 package ucar.nc2.jni.netcdf;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
-import ucar.nc2.Dimension;
-import ucar.nc2.EnumTypedef;
-import ucar.nc2.FileWriter2;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.NetcdfFileSubclass;
-import ucar.nc2.NetcdfFileWriter;
-import ucar.nc2.Variable;
+import ucar.nc2.*;
+import ucar.nc2.NCdumpW.WantValues;
 import ucar.nc2.util.CompareNetcdf2;
+import ucar.nc2.util.UnitTestCommon;
 import ucar.nc2.write.Nc4ChunkingStrategyNone;
 import ucar.unidata.test.util.NeedsCdmUnitTest;
 import ucar.unidata.test.util.TestDir;
+
+import java.io.*;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Test copying files to netcdf4 with FileWriter2.
@@ -34,187 +28,208 @@ import ucar.unidata.test.util.TestDir;
  * @since 7/27/12
  */
 public class TestNc4IospWriting {
-  int countNotOK = 0;
+    int countNotOK = 0;
 
-  @Before
-  public void setLibrary() {
-    // Ignore this class's tests if NetCDF-4 isn't present.
-    // We're using @Before because it shows these tests as being ignored.
-    // @BeforeClass shows them as *non-existent*, which is not what we want.
-    Assume.assumeTrue("NetCDF-4 C library not present.", Nc4Iosp.isClibraryPresent());
-  }
-
-  // @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void problem() throws IOException {
-    copyFile("Q:/cdmUnitTest/formats/netcdf4/files/xma022032.nc5", "C:/temp/xma022032.nc5", NetcdfFileWriter.Version
-            .netcdf4);
-    //copyFile("C:/dev/github/thredds/cdm/src/test/data/testWriteRecord.nc", "C:/temp/testWriteRecord.classic.nc3", NetcdfFileWriter.Version.netcdf3c);
-  }
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeNetcdf4Files() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/files/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeNetcdf4Compound() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/compound/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  // enum not ready
-
-  //@Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeHdf5Samples() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/samples/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  //@Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeHdf5Support() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/support/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  // @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeNetcdf4Tst() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/tst/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeNetcdf4Zender() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/zender/", new MyFileFilter(), new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  //@Test
-  @Category(NeedsCdmUnitTest.class)
-  public void readAllHDF5() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/", null, new MyAct(), true);
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void writeAllNetcdf3() throws IOException {
-    int count = 0;
-    count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf3/", null, new MyAct());
-    System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
-  }
-
-  private class MyAct implements TestDir.Act {
-    public int doAct(String datasetIn) throws IOException {
-      File fin = new File(datasetIn);
-      String datasetOut = tempDir + fin.getName();
-
-      if (!copyFile(datasetIn, datasetOut, NetcdfFileWriter.Version.netcdf4))
-        countNotOK++;
-      return 1;
+    @Before
+    public void setLibrary() {
+        // Ignore this class's tests if NetCDF-4 isn't present.
+        // We're using @Before because it shows these tests as being ignored.
+        // @BeforeClass shows them as *non-existent*, which is not what we want.
+        Assume.assumeTrue("NetCDF-4 C library not present.", Nc4Iosp.isClibraryPresent());
     }
-  }
 
-  private class MyFileFilter implements FileFilter {
-
-    @Override
-    public boolean accept(File pathname) {
-      if (pathname.getName().equals("tst_opaque_data.nc4")) return false;
-      if (pathname.getName().equals("tst_opaques.nc4")) return false;
-      return true;
+    // @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void problem() throws IOException {
+        copyFile("Q:/cdmUnitTest/formats/netcdf4/files/xma022032.nc5", "C:/temp/xma022032.nc5", NetcdfFileWriter.Version
+                .netcdf4);
+        //copyFile("C:/dev/github/thredds/cdm/src/test/data/testWriteRecord.nc", "C:/temp/testWriteRecord.classic.nc3", NetcdfFileWriter.Version.netcdf3c);
     }
-  }
 
-
-  private String tempDir = TestDir.temporaryLocalDataDir; // "C:/temp/";
-  private boolean copyFile(String datasetIn, String datasetOut, NetcdfFileWriter.Version version) throws IOException {
-
-     System.out.printf("TestNc4IospWriting copy %s to %s%n", datasetIn, datasetOut);
-     NetcdfFile ncfileIn = ucar.nc2.NetcdfFile.open(datasetIn, null);
-     FileWriter2 writer2 = new FileWriter2(ncfileIn, datasetOut, version, null);
-     NetcdfFile ncfileOut = writer2.write();
-     compare(ncfileIn, ncfileOut, true, false, true);
-     ncfileIn.close();
-     ncfileOut.close();
-     // System.out.println("NetcdfFile written = " + ncfileOut);
-     return true;
-   }
-
-  private boolean compare(NetcdfFile nc1, NetcdfFile nc2, boolean showCompare, boolean showEach, boolean compareData) throws IOException {
-    Formatter f= new Formatter();
-    CompareNetcdf2 tc = new CompareNetcdf2(f, showCompare, showEach, compareData);
-    boolean ok = tc.compare(nc1, nc2, new CompareNetcdf2.Netcdf4ObjectFilter(), showCompare, showEach, compareData);
-    System.out.printf(" %s compare %s to %s ok = %s%n", ok ? "" : "***", nc1.getLocation(), nc2.getLocation(), ok);
-    if (!ok) System.out.printf(" %s%n", f);
-    return ok;
-  }
-
-
-  /////////////////////////////////////////////////
-
-  // Demonstrates GitHub issue #191. Unignore when we have a fix in place.
-  @Test
-  @Ignore
-  public void writeEnumType() throws IOException {
-    // NetcdfFile's 0-arg constructor is protected, so must use NetcdfFileSubclass
-    NetcdfFile ncFile = new NetcdfFileSubclass();
-
-    // Create shared, unlimited Dimension
-    Dimension timeDim = new Dimension("time", 3, true, true, false);
-    ncFile.addDimension(null, timeDim);
-
-    // Create a map from integers to strings.
-    Map<Integer, String> enumMap = new HashMap<>();
-    enumMap.put(18, "pie");
-    enumMap.put(268, "donut");
-    enumMap.put(3284, "cake");
-
-    // Create EnumTypedef and add it to root group.
-    EnumTypedef dessertType = new EnumTypedef("dessertType", enumMap, DataType.ENUM2);
-    ncFile.getRootGroup().addEnumeration(dessertType);
-
-    // Create Variable of type dessertType.
-    Variable dessert = new Variable(ncFile, null, null, "dessert", DataType.ENUM2, "time");
-    dessert.setEnumTypedef(dessertType);
-
-    // Add data to dessert variable.
-    short[] dessertStorage = new short[] {18, 268, 3284};
-    dessert.setCachedData(Array.factory(DataType.SHORT, new int[]{3}, dessertStorage), true);
-
-    // Add the variable to the root group and finish ncFile
-    ncFile.addVariable(null, dessert);
-    ncFile.finish();
-
-
-    /*
-    Try to write ncFile out as NetCDF-4. It will fail with:
-        java.io.IOException: ret=-45 err='NetCDF: Not a valid data type or _FillValue type mismatch' on
-            enum UNKNOWN dessert(time=0);
-     */
-    File outFile = File.createTempFile("writeEnumType", ".nc");
-    try {
-      FileWriter2 writer = new FileWriter2(
-              ncFile, outFile.getAbsolutePath(), NetcdfFileWriter.Version.netcdf4, new Nc4ChunkingStrategyNone());
-      writer.write();
-    } finally {
-      if (outFile != null) {
-        outFile.delete();
-      }
+    @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeNetcdf4Files() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/files/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
     }
-  }
+
+    @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeNetcdf4Compound() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/compound/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    // enum not ready
+
+    //@Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeHdf5Samples() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/samples/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    //@Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeHdf5Support() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/support/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    // @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeNetcdf4Tst() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/tst/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+
+    @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeNetcdf4Zender() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf4/zender/", new MyFileFilter(), new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    //@Test
+    @Category(NeedsCdmUnitTest.class)
+    public void readAllHDF5() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/hdf5/", null, new MyAct(), true);
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    @Test
+    @Category(NeedsCdmUnitTest.class)
+    public void writeAllNetcdf3() throws IOException {
+        int count = 0;
+        count += TestDir.actOnAll(TestDir.cdmUnitTestDir + "formats/netcdf3/", null, new MyAct());
+        System.out.printf("***READ %d files FAIL = %d%n", count, countNotOK);
+    }
+
+    private class MyAct implements TestDir.Act {
+        public int doAct(String datasetIn) throws IOException
+        {
+            File fin = new File(datasetIn);
+            String datasetOut = tempDir + fin.getName();
+
+            if(!copyFile(datasetIn, datasetOut, NetcdfFileWriter.Version.netcdf4))
+                countNotOK++;
+            return 1;
+        }
+    }
+
+    private class MyFileFilter implements FileFilter {
+        @Override
+        public boolean accept(File pathname)
+        {
+            if(pathname.getName().equals("tst_opaque_data.nc4")) return false;
+            if(pathname.getName().equals("tst_opaques.nc4")) return false;
+            return true;
+        }
+    }
+
+
+    private String tempDir = TestDir.temporaryLocalDataDir; // "C:/temp/";
+
+    private boolean copyFile(String datasetIn, String datasetOut, NetcdfFileWriter.Version version) throws IOException {
+
+        System.out.printf("TestNc4IospWriting copy %s to %s%n", datasetIn, datasetOut);
+        NetcdfFile ncfileIn = ucar.nc2.NetcdfFile.open(datasetIn, null);
+        FileWriter2 writer2 = new FileWriter2(ncfileIn, datasetOut, version, null);
+        NetcdfFile ncfileOut = writer2.write();
+        compare(ncfileIn, ncfileOut, true, false, true);
+        ncfileIn.close();
+        ncfileOut.close();
+        // System.out.println("NetcdfFile written = " + ncfileOut);
+        return true;
+    }
+
+    private boolean compare(NetcdfFile nc1, NetcdfFile nc2, boolean showCompare, boolean showEach, boolean compareData) throws IOException {
+        Formatter f = new Formatter();
+        CompareNetcdf2 tc = new CompareNetcdf2(f, showCompare, showEach, compareData);
+        boolean ok = tc.compare(nc1, nc2, new CompareNetcdf2.Netcdf4ObjectFilter(), showCompare, showEach, compareData);
+        System.out.printf(" %s compare %s to %s ok = %s%n", ok ? "" : "***", nc1.getLocation(), nc2.getLocation(), ok);
+        if(!ok) System.out.printf(" %s%n", f);
+        return ok;
+    }
+
+
+    /////////////////////////////////////////////////
+
+    // Demonstrates GitHub issue #191. Unignore when we have a fix in place.
+    @Test
+    public void writeEnumType() throws IOException {
+        // NetcdfFile's 0-arg constructor is protected, so must use NetcdfFileSubclass
+        NetcdfFile ncFile = new NetcdfFileSubclass();
+
+        // Create shared, unlimited Dimension
+        Dimension timeDim = new Dimension("time", 3, true, true, false);
+        ncFile.addDimension(null, timeDim);
+
+        // Create a map from integers to strings.
+        Map<Integer, String> enumMap = new HashMap<>();
+        enumMap.put(18, "pie");
+        enumMap.put(268, "donut");
+        enumMap.put(3284, "cake");
+
+        // Create EnumTypedef and add it to root group.
+        EnumTypedef dessertType = new EnumTypedef("dessertType", enumMap, DataType.ENUM2);
+        ncFile.getRootGroup().addEnumeration(dessertType);
+
+        // Create Variable of type dessertType.
+        Variable dessert = new Variable(ncFile, null, null, "dessert", DataType.ENUM2, "time");
+        dessert.setEnumTypedef(dessertType);
+
+        // Add data to dessert variable.
+        short[] dessertStorage = new short[]{18, 268, 3284};
+        dessert.setCachedData(Array.factory(DataType.SHORT, new int[]{3}, dessertStorage), true);
+
+        // Add the variable to the root group and finish ncFile
+        ncFile.addVariable(null, dessert);
+        ncFile.finish();
+        ncFile.setLocation("writeEnumType");
+
+
+        File outFile = File.createTempFile("writeEnumType", ".nc");
+        //File outFile = new File("f:/git/thredds/writeEnumType.nc"); outFile.delete();
+        try {
+            FileWriter2 writer = new FileWriter2(
+                    ncFile, outFile.getAbsolutePath(), NetcdfFileWriter.Version.netcdf4, new Nc4ChunkingStrategyNone());
+            String mem = null;
+            String disk = null;
+            try (NetcdfFile ncFileOut = writer.write()) {
+                ncFileOut.setLocation("writeEnumType");
+                // For debugging. Delete this entire try block when done.
+                Writer out = new StringWriter();
+                NCdumpW.print(ncFile, out, WantValues.all, false, false, null, null);
+                out.close();
+                mem = out.toString();
+                out = new StringWriter();
+                NCdumpW.print(ncFileOut, out, WantValues.all, false, false, null, null);
+                out.close();
+                disk = out.toString();
+                System.out.println("-------------------In memory-------------------");
+                System.out.print(mem);
+                System.out.println("-------------------On disk-------------------");
+                System.out.print(disk);
+            }
+            String diffs = UnitTestCommon.compare("TestNc4IospWriting.writeEnumType", mem, disk);
+            if(diffs != null) {
+                System.out.println("-------------------Diffs-------------------");
+                System.err.println(diffs);
+                System.out.println("---------------------------------------------");
+            }
+            Assert.assertTrue("Differences", diffs == null);
+        } finally {
+            ncFile.close();
+            outFile.delete();
+        }
+    }
 }

--- a/cdm/src/main/java/ucar/ma2/Array.java
+++ b/cdm/src/main/java/ucar/ma2/Array.java
@@ -745,6 +745,17 @@ public abstract class Array {
     throw new UnsupportedOperationException();
   }
 
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    throw new UnsupportedOperationException();
+  }
+
+  public ByteBuffer getDataAsByteBuffer(int capacity, ByteOrder order) {
+    ByteBuffer bb = ByteBuffer.allocate(capacity);
+    if(order != null) bb.order(order);
+    return bb;
+  }
+
+
   /**
    * Create an Array from a ByteBuffer
    *

--- a/cdm/src/main/java/ucar/ma2/ArrayByte.java
+++ b/cdm/src/main/java/ucar/ma2/ArrayByte.java
@@ -33,6 +33,7 @@
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Concrete implementation of Array specialized for bytes.
@@ -135,7 +136,9 @@ public class ArrayByte extends Array {
   }
 
   @Override
-  public ByteBuffer getDataAsByteBuffer() {
+  public ByteBuffer getDataAsByteBuffer() {return getDataAsByteBuffer(null);}
+
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {// order irrelevant here
     return ByteBuffer.wrap((byte[]) get1DJavaArray(byte.class));
   }
 

--- a/cdm/src/main/java/ucar/ma2/ArrayInt.java
+++ b/cdm/src/main/java/ucar/ma2/ArrayInt.java
@@ -33,6 +33,7 @@
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
 /**
@@ -139,8 +140,10 @@ public class ArrayInt extends Array {
       ja[i] = iter.getIntNext();
   }
 
-  public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int) (4 * getSize())); // default big-endian
+  public ByteBuffer getDataAsByteBuffer() {return getDataAsByteBuffer(null);}
+
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    ByteBuffer bb = super.getDataAsByteBuffer((int) (4 * getSize()),order);
     IntBuffer ib = bb.asIntBuffer();
     ib.put((int[]) get1DJavaArray(int.class)); // make sure its in canonical order
     return bb;

--- a/cdm/src/main/java/ucar/ma2/ArrayLong.java
+++ b/cdm/src/main/java/ucar/ma2/ArrayLong.java
@@ -33,6 +33,7 @@
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 
 /**
@@ -122,11 +123,13 @@ public class ArrayLong extends Array {
       ja[i] = iter.getLongNext();
   }
 
-  public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int)(8*getSize()));
-    LongBuffer ib = bb.asLongBuffer();
-    ib.put( (long[]) get1DJavaArray(long.class)); // make sure its in canonical order
-    return bb;
+    public ByteBuffer getDataAsByteBuffer() {return getDataAsByteBuffer(null);}
+
+    public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+        ByteBuffer bb = super.getDataAsByteBuffer((int) (8 * getSize()),order);
+        LongBuffer ib = bb.asLongBuffer();
+        ib.put( (long[]) get1DJavaArray(long.class)); // make sure its in canonical order
+        return bb;
   }
 
  /** Return the element class type */

--- a/cdm/src/main/java/ucar/ma2/ArrayShort.java
+++ b/cdm/src/main/java/ucar/ma2/ArrayShort.java
@@ -33,6 +33,7 @@
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
 
 /**
@@ -138,10 +139,13 @@ public class ArrayShort extends Array {
       ja[i] = iter.getShortNext();
   }
 
-  public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int) (2 * getSize()));
-    ShortBuffer ib = bb.asShortBuffer();
-    ib.put((short[]) get1DJavaArray(short.class)); // make sure its in canonical order
+  public ByteBuffer getDataAsByteBuffer() {return getDataAsByteBuffer(null);}
+
+    public ByteBuffer getDataAsByteBuffer(ByteOrder order)
+    {
+      ByteBuffer bb = super.getDataAsByteBuffer((int) (2 * getSize()),order);
+      ShortBuffer ib = bb.asShortBuffer();
+      ib.put((short[]) get1DJavaArray(short.class)); // make sure its in canonical order
     return bb;
   }
 

--- a/cdm/src/main/java/ucar/nc2/CDMNode.java
+++ b/cdm/src/main/java/ucar/nc2/CDMNode.java
@@ -1,34 +1,34 @@
 /*
- * Copyright 1998-2014 University Corporation for Atmospheric Research/Unidata
+ * Copyright 1998-2015 John Caron and University Corporation for Atmospheric Research/Unidata
  *
- *   Portions of this software were developed by the Unidata Program at the
- *   University Corporation for Atmospheric Research.
+ *  Portions of this software were developed by the Unidata Program at the
+ *  University Corporation for Atmospheric Research.
  *
- *   Access and use of this software shall impose the following obligations
- *   and understandings on the user. The user is granted the right, without
- *   any fee or cost, to use, copy, modify, alter, enhance and distribute
- *   this software, and any derivative works thereof, and its supporting
- *   documentation for any purpose whatsoever, provided that this entire
- *   notice appears in all copies of the software, derivative works and
- *   supporting documentation.  Further, UCAR requests that the user credit
- *   UCAR/Unidata in any publications that result from the use of this
- *   software or in any product that includes this software. The names UCAR
- *   and/or Unidata, however, may not be used in any advertising or publicity
- *   to endorse or promote any products or commercial entity unless specific
- *   written permission is obtained from UCAR/Unidata. The user also
- *   understands that UCAR/Unidata is not obligated to provide the user with
- *   any support, consulting, training or assistance of any kind with regard
- *   to the use, operation and performance of this software nor to provide
- *   the user with any updates, revisions, new versions or "bug fixes."
+ *  Access and use of this software shall impose the following obligations
+ *  and understandings on the user. The user is granted the right, without
+ *  any fee or cost, to use, copy, modify, alter, enhance and distribute
+ *  this software, and any derivative works thereof, and its supporting
+ *  documentation for any purpose whatsoever, provided that this entire
+ *  notice appears in all copies of the software, derivative works and
+ *  supporting documentation.  Further, UCAR requests that the user credit
+ *  UCAR/Unidata in any publications that result from the use of this
+ *  software or in any product that includes this software. The names UCAR
+ *  and/or Unidata, however, may not be used in any advertising or publicity
+ *  to endorse or promote any products or commercial entity unless specific
+ *  written permission is obtained from UCAR/Unidata. The user also
+ *  understands that UCAR/Unidata is not obligated to provide the user with
+ *  any support, consulting, training or assistance of any kind with regard
+ *  to the use, operation and performance of this software nor to provide
+ *  the user with any updates, revisions, new versions or "bug fixes."
  *
- *   THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *   DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *   INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *   FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *   NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *   WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ *  THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+ *  INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+ *  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+ *  WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 package ucar.nc2;
 
@@ -36,13 +36,16 @@ import ucar.nc2.dataset.StructureDS;
 import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.util.Indent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Define a superclass for all the CDM node classes: Group, Dimension, etc.
  * Define the sort of the node {@link CDMSort} so that we can
  * 1. do true switching on node type
  * 2. avoid use of instanceof
  * 3. Use container classes that have more than one kind of node
- * <p/>
+ * <p>
  * Also move various common fields and methods to here.
  *
  * @author Heimbigner
@@ -51,11 +54,14 @@ import ucar.nc2.util.Indent;
 public abstract class CDMNode
 {
 
-    CDMSort sort = null;
-    Group group = null;
-    Structure parentstruct = null;
-    boolean immutable = false;
-    String shortName = null;
+    protected CDMSort sort = null;
+    protected Group group = null;
+    protected Structure parentstruct = null;
+    protected boolean immutable = false;
+    protected String shortName = null;
+
+    protected Map<String, Object> annotations = new HashMap<>();
+
     //String fullName = null; // uses backslash escaping
 
     // HACK: sadly, because of the existing class structure,
@@ -66,7 +72,7 @@ public abstract class CDMNode
     // may contain group information separated
     // by forward slash.
 
-    String dodsname = null;
+    protected String dodsname = null;
 
     //////////////////////////////////////////////////
     // Constructors
@@ -313,11 +319,11 @@ public abstract class CDMNode
         if(!(node instanceof Variable))
             return node;
         Variable inner = (Variable) node;
-        for(;;) {
+        for(; ; ) {
             if(inner instanceof VariableDS) {
                 VariableDS vds = (VariableDS) inner;
                 inner = vds.getOriginalVariable();
-                if(inner == null)  {
+                if(inner == null) {
                     inner = vds;
                     break;
                 }
@@ -331,6 +337,24 @@ public abstract class CDMNode
             } else break; // base case we have straight Variable or Stucture
         }
         return inner;
+    }
+
+    public Map<String, Object> getAnnotations()
+    {
+        return annotations;
+    }
+
+    public Object getAnnotation(String key)
+    {
+        return annotations.get(key);
+    }
+
+    public Object annotate(String key, Object value)
+    {
+        Object old = annotations.get(key);
+        if(key != null && value != null)
+            annotations.put(key,value);
+        return old;
     }
 
 }

--- a/cdm/src/main/java/ucar/nc2/FileWriter2.java
+++ b/cdm/src/main/java/ucar/nc2/FileWriter2.java
@@ -327,6 +327,10 @@ public class FileWriter2 {
       Variable v;
       if (newType == DataType.STRUCTURE) {
         v = writer.addStructure(newGroup, (Structure) oldVar, oldVar.getShortName(), dims);
+      } else if(newType.isEnum()) {
+        EnumTypedef en = oldVar.getEnumTypedef();
+        v = writer.addVariable(newGroup, oldVar.getShortName(), newType, dims);
+        v.setEnumTypedef(en);
       } else {
         v = writer.addVariable(newGroup, oldVar.getShortName(), newType, dims);
       }

--- a/cdm/src/test/java/ucar/nc2/util/UnitTestCommon.java
+++ b/cdm/src/test/java/ucar/nc2/util/UnitTestCommon.java
@@ -224,7 +224,7 @@ public class UnitTestCommon
         System.out.println(sep.toString());
     }
 
-    public String compare(String tag, String baseline, String s)
+    static public String compare(String tag, String baseline, String s)
     {
         try {
             // Diff the two print results

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
@@ -63,6 +63,7 @@ public interface Nc4prototypes extends Library {
   static public final int NC_NOWRITE = 0;
   static public final int NC_WRITE = 1;
 
+  static public final int NC_NAT = 0;	/* Not-A-Type */
   static public final int NC_BYTE = 1;	/* signed 1 byte integer */
   static public final int NC_CHAR =	2;	/* ISO/ASCII character */
   static public final int NC_SHORT =	3;	/* signed 2 byte integer */
@@ -272,6 +273,13 @@ public interface Nc4prototypes extends Library {
   int nc_def_compound(int ncid, SizeT size, String name, IntByReference typeidp);
   int nc_insert_compound(int ncid, int typeid, String name, SizeT offset, int field_typeid);
   int nc_insert_array_compound(int ncid, int typeid, String name, SizeT offset, int field_typeid, int ndims, int[] dim_sizes);
+
+ /* Create an enum type. Provide a base type and a name. At the moment
+  * only ints are accepted as base types. */
+ int nc_def_enum(int ncid, int base_typeid, String name, IntByReference typeidp);
+ /* Insert a named value into an enum type. The value must fit within
+  * the size of the enum type, the name size must be <= NC_MAX_NAME. */
+ int nc_insert_enum(int ncid, int enumid, String name, IntByReference value);
 
   /* Rename a group */
   int nc_rename_grp(int grpid, String name);

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Netcd4Clibrary.txt
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Netcd4Clibrary.txt
@@ -213,7 +213,7 @@ public interface Netcd4Clibrary extends Library {
 
   /* Insert a named value into an enum type. The value must fit within
    * the size of the enum type, the name size must be <= NC_MAX_NAME. */
-  int nc_insert_enum(int ncid, int xtype, String name, void*value);
+  int nc_insert_enum(int ncid, int xtype, String name, IntByReference valuep);
 
   /* Get information about an enum type: it's name, base type and the
    * number of members defined. */

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/SizeT.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/SizeT.java
@@ -47,4 +47,5 @@ import com.sun.jna.Native;
 public class SizeT extends IntegerType {
   public SizeT() { this(0); }
   public SizeT(long value) { super(Native.SIZE_T_SIZE, value, true); }
+  public String toString() { return String.format("%ld",super.longValue());}
 }


### PR DESCRIPTION
* Fix for Github issue #191
Several related fixes needed.
1. The EnumTypedef needed to store the typeid.
2. Needed to cause enum types to be created in the netcdf4 file.
3. The call to write the enum data needed to get the correct typeid.
4. Fix endian problem because getDataAsByteBuffer does not properly
   handle endian order.
   - This required some mods to ucar.ma2.ArrayXXX.java
5. Modify TestNc4IospWriting.java to capture and textually compare
   the internal CDM file with the externally written netcdf file.

* Fix for Github issue #223
  Remove reference to mbari.org since it is no longer accessible.
