### PR TITLE
Fix collection update during the catalog reinitialization

### DIFF
--- a/cdm/src/main/java/thredds/inventory/CollectionUpdater.java
+++ b/cdm/src/main/java/thredds/inventory/CollectionUpdater.java
@@ -74,15 +74,19 @@ public enum CollectionUpdater {
   }
 
   private CollectionUpdater() {
-    try {
-      scheduler = StdSchedulerFactory.getDefaultScheduler();
-      scheduler.start();
-      // scheduler.getListenerManager().addSchedulerListener(new MySchedListener());
-    } catch (Throwable e) {
-      failed = true;
-      throw new RuntimeException("quartz scheduler failed to initialize", e);
-    }
+	  start();
   }
+  
+  private void start() {
+	    try {
+	        scheduler = StdSchedulerFactory.getDefaultScheduler();
+	        scheduler.start();
+	        // scheduler.getListenerManager().addSchedulerListener(new MySchedListener());
+	      } catch (Throwable e) {
+	        failed = true;
+	        throw new RuntimeException("quartz scheduler failed to initialize", e);
+	      }
+	  }
 
   public org.quartz.Scheduler getScheduler() {
     return scheduler;
@@ -192,6 +196,11 @@ public enum CollectionUpdater {
       }
     }
 
+  }
+  
+  public void reinit() {
+	  shutdown();
+	  start();
   }
 
   public void shutdown() {

--- a/tds/src/main/java/thredds/core/DataRootHandler.java
+++ b/tds/src/main/java/thredds/core/DataRootHandler.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
 
 import thredds.client.catalog.*;
 import thredds.filesystem.MFileOS7;
+import thredds.inventory.CollectionUpdater;
 import thredds.inventory.MFile;
 import thredds.server.admin.DebugController;
 import thredds.server.catalog.*;
@@ -217,6 +218,8 @@ public final class DataRootHandler implements InitializingBean {
     //idHash = new HashSet<>();
 
     DatasetHandler.reinit(); // NcML datasets
+	// Shutdown and start the collection schedule
+    CollectionUpdater.INSTANCE.reinit();
     ccManager = new ConfigCatalogManager();
     ccManager.initCatalogs();
 

--- a/tds/src/main/java/thredds/servlet/DataRootHandler.java
+++ b/tds/src/main/java/thredds/servlet/DataRootHandler.java
@@ -67,6 +67,7 @@ import thredds.cataloggen.ProxyDatasetHandler;
 import thredds.crawlabledataset.CrawlableDataset;
 import thredds.crawlabledataset.CrawlableDatasetDods;
 import thredds.crawlabledataset.CrawlableDatasetFile;
+import thredds.inventory.CollectionUpdater;
 import thredds.server.admin.DebugController;
 import thredds.server.config.AllowableService;
 import thredds.server.config.TdsContext;
@@ -260,6 +261,8 @@ public final class DataRootHandler implements InitializingBean {
     idHash = new HashSet<>();
 
     DatasetHandler.reinit(); // NcML datasets
+	// Shutdown and start the collection schedule
+    CollectionUpdater.INSTANCE.reinit();
     initCatalogs();
 
     isReinit = false;


### PR DESCRIPTION
Re-initialize the catalog through the "Reinitialize" option (/thredds/admin/debug?catalogs/reinit) doesn't manage correctly the job and trigger scheduler, because the job and triggers are already sheduled.  Example of warn and error displayed in the fc.collection.log files:

```
2015-10-09T11:37:24.531 +0200 WARN  - scheduler failed to add updateJob for UpdateCollection.hf_radar_ibiza-scb_codarssproc001_L1_agg. Another Job exists with that identification.
2015-10-09T11:37:24.532 +0200 ERROR - scheduleJob failed to schedule cron Job
org.quartz.ObjectAlreadyExistsException: Unable to store Trigger with name: 'hf_radar_ibiza-scb_codarssproc001_L1_agg' and group: 'rescan', because one already exists with this identification.
```

In order to fix this issue a new method has been implemented to reinitialize the scheduler when the DataRootHandler.reinit() is called. We haven't modified the TDM because we don't use it, and it is likely that some modification are needed.

Best regards,

Kristian