### PR TITLE
Removed bufferSize from PointFeature iterators

### DIFF
--- a/bufr/src/main/java/ucar/nc2/ft/point/bufr/BufrFeatureDatasetFactory.java
+++ b/bufr/src/main/java/ucar/nc2/ft/point/bufr/BufrFeatureDatasetFactory.java
@@ -222,7 +222,7 @@ public class BufrFeatureDatasetFactory implements FeatureDatasetFactory {
         }
 
         @Override
-        public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+        public PointFeatureIterator getPointFeatureIterator() throws IOException {
           return new BufrStationIterator(obs.getStructureIterator(), null);
         }
 
@@ -279,6 +279,7 @@ public class BufrFeatureDatasetFactory implements FeatureDatasetFactory {
 
       // flatten into a PointFeatureCollection
       // if empty, may return null
+      @Override
       public PointFeatureCollection flatten(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
         return new BufrPointFeatureCollection(boundingBox, dateRange);
       }
@@ -300,7 +301,7 @@ public class BufrFeatureDatasetFactory implements FeatureDatasetFactory {
         }
 
         @Override
-        public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+        public PointFeatureIterator getPointFeatureIterator() throws IOException {
           return new BufrRecordIterator(obs.getStructureIterator(), filter);
         }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestMiscPointFeature.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestMiscPointFeature.java
@@ -124,7 +124,7 @@ public class TestMiscPointFeature {
         System.out.printf("stnInfo=%s%n", sdata.getScalarString(m));
       }
 
-      PointFeatureCollectionIterator iter = sc.getPointFeatureCollectionIterator(-1);
+      PointFeatureCollectionIterator iter = sc.getPointFeatureCollectionIterator();
       while (iter.hasNext()) {
         PointFeatureCollection pfc = iter.next();
         assert pfc instanceof StationTimeSeriesFeatureImpl : pfc.getClass().getName();
@@ -137,7 +137,7 @@ public class TestMiscPointFeature {
       }
 
       PointFeatureCollection pfc = sc.flatten(null, (CalendarDateRange) null, null);
-      PointFeatureIterator iter2 = pfc.getPointFeatureIterator(-1);
+      PointFeatureIterator iter2 = pfc.getPointFeatureIterator();
       while (iter2.hasNext()) {
         PointFeature pf = iter2.next();
         assert pf instanceof StationPointFeature;

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestPointDatasets.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestPointDatasets.java
@@ -33,6 +33,19 @@
 
 package ucar.nc2.ft.point;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,7 +57,22 @@ import ucar.ma2.StructureMembers;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.ft.*;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDataset;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCCC;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.ProfileFeature;
+import ucar.nc2.ft.ProfileFeatureCollection;
+import ucar.nc2.ft.StationProfileFeature;
+import ucar.nc2.ft.StationProfileFeatureCollection;
+import ucar.nc2.ft.StationTimeSeriesFeature;
+import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
+import ucar.nc2.ft.TrajectoryProfileFeature;
+import ucar.nc2.ft.TrajectoryProfileFeatureCollection;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
@@ -55,11 +83,6 @@ import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.test.util.NeedsCdmUnitTest;
 import ucar.unidata.test.util.TestDir;
 import ucar.unidata.util.StringUtil2;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.*;
 
 /**
  * Test PointFeatureTypes.
@@ -602,11 +625,11 @@ public class TestPointDatasets {
   static void showStructureData(PointFeatureCCC ccc) throws IOException {
     PrintWriter pw = new PrintWriter(System.out);
 
-    IOIterator<PointFeatureCC> iter = ccc.getCollectionIterator(-1);
+    IOIterator<PointFeatureCC> iter = ccc.getCollectionIterator();
     while (iter.hasNext()) {
       PointFeatureCC cc = iter.next();
       System.out.printf(" 1.hashCode=%d %n", cc.hashCode());
-      IOIterator<PointFeatureCollection> iter2 = cc.getCollectionIterator(-1);
+      IOIterator<PointFeatureCollection> iter2 = cc.getCollectionIterator();
       while (iter2.hasNext()) {
         PointFeatureCollection pfc = iter2.next();
         System.out.printf("  2.hashcode%d %n", pfc.hashCode());

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/writer/TestCFPointWriterMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/writer/TestCFPointWriterMisc.java
@@ -33,6 +33,11 @@
 
 package ucar.nc2.ft.point.writer;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Formatter;
+import java.util.List;
+
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,17 +46,21 @@ import ucar.ma2.StructureData;
 import ucar.ma2.StructureMembers;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFileWriter;
-import ucar.nc2.Variable;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.ft.*;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDataset;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureCollectionIterator;
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.ft.ProfileFeature;
+import ucar.nc2.ft.ProfileFeatureCollection;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.unidata.test.util.NeedsCdmUnitTest;
 import ucar.unidata.test.util.TestDir;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Formatter;
-import java.util.List;
 
 /**
  * misc tests involving CFPointWriter
@@ -94,13 +103,13 @@ public class TestCFPointWriterMisc {
        assert fc1 instanceof ProfileFeatureCollection;
 
        ProfileFeatureCollection profileCollection = (ProfileFeatureCollection) fc1;
-       PointFeatureCollectionIterator iter = profileCollection.getPointFeatureCollectionIterator(-1);
+       PointFeatureCollectionIterator iter = profileCollection.getPointFeatureCollectionIterator();
         while (iter.hasNext()) {
           PointFeatureCollection pfc = iter.next();
           assert pfc instanceof ProfileFeature : pfc.getClass().getName();
           ProfileFeature profile = (ProfileFeature) pfc;
 
-          PointFeatureIterator inner = profile.getPointFeatureIterator(-1);
+          PointFeatureIterator inner = profile.getPointFeatureIterator();
           while (inner.hasNext()) {
             PointFeature pf = inner.next();
             StructureData sdata = pf.getFeatureData();
@@ -118,13 +127,13 @@ public class TestCFPointWriterMisc {
          assert fc2 instanceof ProfileFeatureCollection;
          ProfileFeatureCollection profileCollection2 = (ProfileFeatureCollection) fc2;
 
-         PointFeatureCollectionIterator iter2 = profileCollection2.getPointFeatureCollectionIterator(-1);
+         PointFeatureCollectionIterator iter2 = profileCollection2.getPointFeatureCollectionIterator();
          while (iter2.hasNext()) {
            PointFeatureCollection pfc = iter2.next();
            assert pfc instanceof ProfileFeature : pfc.getClass().getName();
            ProfileFeature profile = (ProfileFeature) pfc;
 
-           PointFeatureIterator inner = profile.getPointFeatureIterator(-1);
+           PointFeatureIterator inner = profile.getPointFeatureIterator();
            while (inner.hasNext()) {
              PointFeature pf = inner.next();
              StructureData sdata = pf.getFeatureData();

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCC.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCC.java
@@ -46,9 +46,8 @@ public interface PointFeatureCC extends DsgFeatureCollection {
   /**
    * General way to handle iterations on all classes that implement this interface.
    * Generally, one uses class specific foreach
-   * @param bufferSize hint on how much memory to use, -1 for default
    * @return Iterator over PointFeatureCollection which may throw an IOException
    * @throws java.io.IOException
    */
-  IOIterator<PointFeatureCollection> getCollectionIterator(int bufferSize) throws java.io.IOException;
+  IOIterator<PointFeatureCollection> getCollectionIterator() throws java.io.IOException;
 }

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCCC.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCCC.java
@@ -46,10 +46,8 @@ public interface PointFeatureCCC extends DsgFeatureCollection {
   /**
    * General way to handle iterations on all classes that implement this interface.
    * Generally, use class specific foreach
-   * @param bufferSize hint on how much memory to use, -1 for default
    * @return Iterator over PointFeatureCC which may throw an IOException
    * @throws java.io.IOException
    */
-  IOIterator<PointFeatureCC> getCollectionIterator(int bufferSize) throws java.io.IOException;
-
+  IOIterator<PointFeatureCC> getCollectionIterator() throws java.io.IOException;
 }

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCCIterator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCCIterator.java
@@ -67,15 +67,6 @@ public interface PointFeatureCCIterator extends Closeable, IOIterator<PointFeatu
   PointFeatureCC next() throws java.io.IOException;
 
   /**
-   * Hint to use this much memory in buffering the iteration.
-   * No guarentee that it will be used by the implementation.
-   * @param bytes amount of memory in bytes
-   */
-  default void setBufferSize( int bytes) {
-    //do nothing
-  }
-
-  /**
    * Make sure that the iterator is complete, and recover resources.
    * You must complete the iteration (until hasNext() returns false) or call close().
    * may be called more than once.

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollection.java
@@ -32,12 +32,10 @@
  */
 package ucar.nc2.ft;
 
-import ucar.ma2.StructureData;
-import ucar.nc2.time.CalendarDateRange;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
+import javax.annotation.Nullable;
+
+import ucar.nc2.time.CalendarDateRange;
 
 /**
  * A collection of PointFeatures.
@@ -96,11 +94,10 @@ public interface PointFeatureCollection extends DsgFeatureCollection, Iterable<P
 
   /**
     * Get an iterator over the PointFeatures of this collection. call PointFeatureIterator.finish() when done
-    * @param bufferSize how many bytes can be used to buffer data, use -1 to use default.
     * @return iterator over the PointFeatures of this collection
     * @throws IOException on read error
     * @deprecated use foreach
     */
-   PointFeatureIterator getPointFeatureIterator(int bufferSize) throws java.io.IOException;
+   PointFeatureIterator getPointFeatureIterator() throws java.io.IOException;
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollectionIterator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollectionIterator.java
@@ -82,15 +82,6 @@ public interface PointFeatureCollectionIterator extends Closeable, IOIterator<Po
   }
 
   /**
-   * Hint to use this much memory in buffering the iteration.
-   * No guarantee that it will be used by the implementation.
-   * @param bytes amount of memory in bytes
-   */
-  default void setBufferSize(int bytes)  {
-    // doan do nuthin
-  }
-
-  /**
    * A filter on PointFeatureCollection.
    */
   interface Filter {

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureIterator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureIterator.java
@@ -75,15 +75,6 @@ public interface PointFeatureIterator extends Closeable, Iterator<PointFeature> 
    * It may be called more than once (idempotent).
    */
   void close();
-  
-  /**
-   * Hint to use this much memory in buffering the iteration.
-   * No guarentee that it will be used by the implementation.
-   * @param bytes amount of memory in bytes
-   */
-  default void setBufferSize( int bytes) {
-    // nothing
-  }
 
   /**
    * A filter on PointFeatures

--- a/cdm/src/main/java/ucar/nc2/ft/ProfileFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/ProfileFeatureCollection.java
@@ -33,10 +33,10 @@
 
 package ucar.nc2.ft;
 
+import java.io.IOException;
+
 import ucar.nc2.time.CalendarDateRange;
 import ucar.unidata.geoloc.LatLonRect;
-
-import java.io.IOException;
 
 /**
  * A collection of ProfileFeature.
@@ -85,6 +85,6 @@ public interface ProfileFeatureCollection extends PointFeatureCC, Iterable<Profi
   /**
    * @deprecated use foreach
    */
-  PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws java.io.IOException;
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/StationProfileFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/StationProfileFeature.java
@@ -32,14 +32,14 @@
  */
 package ucar.nc2.ft;
 
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nonnull;
+
 import ucar.ma2.StructureData;
 import ucar.nc2.ft.point.StationFeature;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Time series of ProfileFeature at named locations.
@@ -115,7 +115,7 @@ public interface StationProfileFeature extends StationFeature, PointFeatureCC, I
   /**
    * @deprecated use foreach
    */
-  PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws java.io.IOException;
 
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/StationProfileFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/StationProfileFeatureCollection.java
@@ -32,13 +32,12 @@
  */
 package ucar.nc2.ft;
 
+import java.io.IOException;
+import java.util.List;
+
 import ucar.nc2.ft.point.StationFeature;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.unidata.geoloc.LatLonRect;
-import ucar.unidata.geoloc.Station;
-
-import java.util.List;
-import java.io.IOException;
 
 /**
  * A collection of StationProfileFeatures
@@ -90,7 +89,7 @@ public interface StationProfileFeatureCollection extends PointFeatureCCC, Iterab
   /**
    * @deprecated use foreach
    */
-  PointFeatureCCIterator getNestedPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCCIterator getNestedPointFeatureCollectionIterator() throws java.io.IOException;
 
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/StationTimeSeriesFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/StationTimeSeriesFeatureCollection.java
@@ -32,13 +32,13 @@
  */
 package ucar.nc2.ft;
 
+import java.io.IOException;
+import java.util.List;
+
+import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.ft.point.StationFeature;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.unidata.geoloc.LatLonRect;
-import ucar.nc2.VariableSimpleIF;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * A collection of StationTimeSeriesFeature.
@@ -115,6 +115,6 @@ public interface StationTimeSeriesFeatureCollection extends PointFeatureCC, Iter
   /**
    * @deprecated use foreach
    */
-  PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws java.io.IOException;
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/TrajectoryFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/TrajectoryFeatureCollection.java
@@ -33,10 +33,9 @@
 
 package ucar.nc2.ft;
 
-import ucar.unidata.geoloc.LatLonRect;
-
 import java.io.IOException;
-import java.util.Iterator;
+
+import ucar.unidata.geoloc.LatLonRect;
 
 /**
  * A collection of TrajectoryFeatures
@@ -77,7 +76,7 @@ public interface TrajectoryFeatureCollection extends PointFeatureCC, Iterable<Tr
   /**
    * @deprecated use foreach
    */
-  PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws java.io.IOException;
 
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeature.java
@@ -33,10 +33,10 @@
 
 package ucar.nc2.ft;
 
-import ucar.ma2.StructureData;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import ucar.ma2.StructureData;
 
 /**
  * A collection of profiles which originate along a trajectory.
@@ -90,7 +90,7 @@ public interface TrajectoryProfileFeature extends PointFeatureCC, Iterable<Profi
   /**
    * @deprecated use foreach
    */
-  PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws java.io.IOException;
 
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeatureCollection.java
@@ -72,6 +72,6 @@ public interface TrajectoryProfileFeatureCollection extends PointFeatureCCC, Ite
   /**
    * @deprecated use foreach
    */
-  PointFeatureCCIterator getNestedPointFeatureCollectionIterator(int bufferSize) throws java.io.IOException;
+  PointFeatureCCIterator getNestedPointFeatureCollectionIterator() throws java.io.IOException;
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/DsgCollectionHelper.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/DsgCollectionHelper.java
@@ -33,14 +33,18 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCCC;
+import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.util.IOIterator;
 import ucar.unidata.geoloc.LatLonRect;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
 
 /**
  * Helper class for DsgFeatureCollection
@@ -102,7 +106,7 @@ public class DsgCollectionHelper {
   private CollectionInfo calcBounds(PointFeatureCC pfcc) throws IOException {
 
     CollectionInfo result = null;
-    IOIterator<PointFeatureCollection> iter = pfcc.getCollectionIterator(-1);
+    IOIterator<PointFeatureCollection> iter = pfcc.getCollectionIterator();
 
     while (iter.hasNext()) {
       PointFeatureCollection pfc = iter.next();
@@ -119,7 +123,7 @@ public class DsgCollectionHelper {
   private CollectionInfo calcBounds(PointFeatureCCC pfccc) throws IOException {
 
     CollectionInfo result = null;
-    IOIterator<PointFeatureCC> iter = pfccc.getCollectionIterator(-1);
+    IOIterator<PointFeatureCC> iter = pfccc.getCollectionIterator();
 
     while (iter.hasNext()) {
       PointFeatureCC pfcc = iter.next();

--- a/cdm/src/main/java/ucar/nc2/ft/point/FlattenedDatasetPointCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/FlattenedDatasetPointCollection.java
@@ -53,10 +53,8 @@ public class FlattenedDatasetPointCollection extends PointCollectionImpl {
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
-        PointFeatureIterator iter = new FlattenedDatasetPointIterator(fdPoint);
-        iter.setBufferSize(bufferSize);
-        return iter;
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
+        return new FlattenedDatasetPointIterator(fdPoint);
     }
 
 
@@ -115,7 +113,7 @@ public class FlattenedDatasetPointCollection extends PointCollectionImpl {
             }
 
             while (pfcIterHasNext()) {
-                this.pfIter = pfcIter.next().getPointFeatureIterator(-1);
+                this.pfIter = pfcIter.next().getPointFeatureIterator();
                 if (pfIter.hasNext()) {
                     return true;
                 }
@@ -143,7 +141,7 @@ public class FlattenedDatasetPointCollection extends PointCollectionImpl {
             }
 
             while (pfccIter != null && pfccIter.hasNext()) {
-                pfcIter = pfccIter.next().getCollectionIterator(-1);
+                pfcIter = pfccIter.next().getCollectionIterator();
                 if (pfcIter.hasNext()) {
                     return true;
                 }
@@ -179,11 +177,11 @@ public class FlattenedDatasetPointCollection extends PointCollectionImpl {
 
             DsgFeatureCollection dsgFeatCol = dsgFeatColIter.next();
             if (dsgFeatCol instanceof PointFeatureCollection) {
-                pfIter = ((PointFeatureCollection) dsgFeatCol).getPointFeatureIterator(-1);
+                pfIter = ((PointFeatureCollection) dsgFeatCol).getPointFeatureIterator();
             } else if (dsgFeatCol instanceof PointFeatureCC) {
-                pfcIter = ((PointFeatureCC) dsgFeatCol).getCollectionIterator(-1);
+                pfcIter = ((PointFeatureCC) dsgFeatCol).getCollectionIterator();
             } else if (dsgFeatCol instanceof PointFeatureCCC) {
-                pfccIter = ((PointFeatureCCC) dsgFeatCol).getCollectionIterator(-1);
+                pfccIter = ((PointFeatureCCC) dsgFeatCol).getCollectionIterator();
             } else {
                 throw new AssertionError("CAN'T HAPPEN: FeatureDatasetPoint.getPointFeatureCollectionList() " +
                         "only contains PointFeatureCollection, PointFeatureCC, or PointFeatureCCC.");

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
@@ -70,7 +70,7 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
   @Override
   public Iterator<PointFeature> iterator() {
     try {
-      return getPointFeatureIterator(-1);
+      return getPointFeatureIterator();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -91,8 +91,8 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
-      return new PointIteratorFiltered(from.getPointFeatureIterator(bufferSize), filter_bb, filter_date);
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
+      return new PointIteratorFiltered(from.getPointFeatureIterator(), filter_bb, filter_date);
     }
   }
 
@@ -101,21 +101,25 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
 
   protected PointFeatureIterator localIterator;
 
+  @Override
   public boolean hasNext() throws IOException {
     if (localIterator == null) resetIteration();
     return localIterator.hasNext();
   }
 
+  @Override
   public void finish() {
     if (localIterator != null)
       localIterator.close();
   }
 
+  @Override
   public PointFeature next() throws IOException {
     return localIterator.next();
   }
 
+  @Override
   public void resetIteration() throws IOException {
-    localIterator = getPointFeatureIterator(-1);
+    localIterator = getPointFeatureIterator();
   }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionIteratorFiltered.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionIteratorFiltered.java
@@ -32,10 +32,10 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.PointFeatureCollectionIterator;
-import ucar.nc2.ft.PointFeatureCollection;
-
 import java.io.IOException;
+
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureCollectionIterator;
 
 /**
  * Filter a PointFeatureCollectionIterator
@@ -55,10 +55,7 @@ public class PointCollectionIteratorFiltered implements PointFeatureCollectionIt
     this.filter = filter;
   }
 
-  public void setBufferSize(int bytes) {
-    pfciter.setBufferSize(bytes);
-  }
-
+  @Override
   public boolean hasNext() throws IOException {
     if (done) return false;
 
@@ -66,10 +63,12 @@ public class PointCollectionIteratorFiltered implements PointFeatureCollectionIt
     return (pointFeatureCollection != null);
   }
 
+  @Override
   public PointFeatureCollection next() throws IOException {
     return done ? null : pointFeatureCollection;
   }
 
+  @Override
   public void close() {
     pfciter.close();
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointDatasetImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointDatasetImpl.java
@@ -32,16 +32,17 @@
  */
 package ucar.nc2.ft.point;
 
-import com.beust.jcommander.internal.Lists;
-import ucar.nc2.Variable;
-import ucar.nc2.ft.*;
-import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.time.CalendarDateRange;
-import ucar.nc2.constants.FeatureType;
-import ucar.unidata.geoloc.LatLonRect;
-
 import java.io.IOException;
 import java.util.List;
+
+import com.beust.jcommander.internal.Lists;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDatasetImpl;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.time.CalendarDateRange;
+import ucar.unidata.geoloc.LatLonRect;
 
 /**
  * Implementation of PointFeatureDataset.
@@ -124,6 +125,7 @@ public class PointDatasetImpl extends FeatureDatasetImpl implements FeatureDatas
     }
   }
 
+  @Override
   public void calcBounds(java.util.Formatter sf) {
     for (DsgFeatureCollection pfc : collectionList) {
       try {

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureCCImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureCCImpl.java
@@ -32,14 +32,15 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
-import ucar.nc2.time.CalendarDateRange;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.unidata.geoloc.LatLonRect;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
 
 /**
  * Abstract superclass for singly nested NestedPointFeatureCollection, such as Station, Profile, and Trajectory.
@@ -83,8 +84,8 @@ public abstract class PointFeatureCCImpl extends DsgCollectionImpl implements Po
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
-      return new PointIteratorFlatten( from.getCollectionIterator(bufferSize), filter_bb, filter_date);
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
+      return new PointIteratorFlatten( from.getCollectionIterator(), filter_bb, filter_date);
     }
   }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureCCIteratorFiltered.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureCCIteratorFiltered.java
@@ -32,11 +32,11 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.PointFeatureCCIterator;
-import ucar.nc2.ft.PointFeatureCC;
-import ucar.nc2.util.IOIterator;
-
 import java.io.IOException;
+
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCCIterator;
+import ucar.nc2.util.IOIterator;
 
 /**
  * Implement NestedPointFeatureCollectionIterator interface
@@ -56,16 +56,14 @@ public class PointFeatureCCIteratorFiltered implements PointFeatureCCIterator, I
     this.filter = filter;
   }
 
-  public void setBufferSize(int bytes) {
-    npfciter.setBufferSize(bytes);
-  }
-
+  @Override
   public boolean hasNext() throws IOException {
     if (done) return false;
     pointFeatureCollection = nextFilteredPointFeatureCollection();
     return (pointFeatureCollection != null);
   }
 
+  @Override
   public PointFeatureCC next() throws IOException {
     return done ? null : pointFeatureCollection;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointFeatureImpl.java
@@ -99,6 +99,7 @@ public abstract class PointFeatureImpl implements PointFeature, Comparable<Point
     return timeUnit.makeCalendarDate(getNominalTime());
   }
 
+  @Override
   public int compareTo(@Nonnull PointFeature other) {
     if (obsTime < other.getObservationTime()) return -1;
     if (obsTime > other.getObservationTime()) return 1;

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorAdapter.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorAdapter.java
@@ -77,14 +77,4 @@ public class PointIteratorAdapter extends PointIteratorAbstract {
     public void close() {
         finishCalcBounds();  // Method is idempotent.
     }
-
-    /**
-     * Does nothing in this implementation.
-     *
-     * @param bytes amount of memory in bytes
-     */
-    @Override
-    public void setBufferSize(int bytes) {
-        // No-op
-    }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorEmpty.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorEmpty.java
@@ -43,14 +43,17 @@ import ucar.nc2.ft.PointFeature;
  */
 public class PointIteratorEmpty extends PointIteratorAbstract {
 
+  @Override
   public boolean hasNext() {
     return false;
   }
 
+  @Override
   public PointFeature next() {
     return null;
   }
 
+  @Override
   public void close() {
   }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFiltered.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFiltered.java
@@ -112,11 +112,6 @@ public class PointIteratorFiltered extends PointIteratorAbstract {
         finishCalcBounds();
     }
 
-    @Override
-    public void setBufferSize(int bufferSize) {
-        origIter.setBufferSize(bufferSize);
-    }
-
     /**
      * Returns the next point that satisfies the filter, or {@code null} if no such point exists.
      *

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFlatten.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFlatten.java
@@ -70,11 +70,7 @@ public class PointIteratorFlatten extends PointIteratorAbstract {
       this.filter = new PointIteratorFiltered.SpaceAndTimeFilter(filter_bb, filter_date);
   }
 
-  // LOOK
-  public void setBufferSize(int bytes) {
-    //collectionIter.setBufferSize(bytes);
-  }
-
+  @Override
   public void close() {
     if (finished) return;
     if (pfiter != null) pfiter.close();
@@ -83,6 +79,7 @@ public class PointIteratorFlatten extends PointIteratorAbstract {
     finished = true;
   }
 
+  @Override
   public boolean hasNext() {
     try {
       pointFeature = nextFilteredDataPoint();
@@ -95,7 +92,7 @@ public class PointIteratorFlatten extends PointIteratorAbstract {
       }
 
       currCollection = feature;
-      pfiter = feature.getPointFeatureIterator(-1);
+      pfiter = feature.getPointFeatureIterator();
       return hasNext();
 
     } catch (IOException ioe) {
@@ -103,6 +100,7 @@ public class PointIteratorFlatten extends PointIteratorAbstract {
     }
   }
 
+  @Override
   public PointFeature next() {
     if (pointFeature == null) return null;
     calcBounds(pointFeature);

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFromStructureData.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorFromStructureData.java
@@ -32,11 +32,12 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
+import java.io.IOException;
+
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
-
-import java.io.IOException;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureIterator;
 
 /**
  * A PointFeatureIterator which uses a StructureDataIterator to iterate over members of a Structure,
@@ -69,6 +70,7 @@ public abstract class PointIteratorFromStructureData extends PointIteratorAbstra
     this.filter = filter;
   }
 
+  @Override
   public boolean hasNext() {
     try {
       while (true) {
@@ -93,16 +95,14 @@ public abstract class PointIteratorFromStructureData extends PointIteratorAbstra
     }
   }
 
+  @Override
   public PointFeature next() {
     if (feature == null) return null;
     calcBounds(feature);
     return feature;
   }
 
-  public void setBufferSize(int bytes) {
-    structIter.setBufferSize(bytes);
-  }
-
+  @Override
   public void close() {
     if (finished) return;
     finishCalcBounds();
@@ -113,5 +113,4 @@ public abstract class PointIteratorFromStructureData extends PointIteratorAbstra
   private StructureData nextStructureData() throws IOException {
     return structIter.hasNext() ? structIter.next() : null;
   }
-
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorMultidim.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointIteratorMultidim.java
@@ -32,13 +32,18 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.PointFeatureIterator;
-import ucar.nc2.ft.PointFeature;
-import ucar.nc2.Variable;
-import ucar.ma2.*;
-
 import java.io.IOException;
 import java.util.List;
+
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Section;
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataW;
+import ucar.ma2.StructureMembers;
+import ucar.nc2.Variable;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureIterator;
 
 /**
  * A PointFeatureIterator using the "multidimensional representation".
@@ -78,6 +83,7 @@ public abstract class PointIteratorMultidim implements PointFeatureIterator {
     }
   }
 
+  @Override
   public boolean hasNext() {
     while (count < npts) {
       StructureData sdata = nextStructureData();
@@ -90,6 +96,7 @@ public abstract class PointIteratorMultidim implements PointFeatureIterator {
     return false;
   }
 
+  @Override
   public PointFeature next() {
     return feature;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/ProfileFeatureImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/ProfileFeatureImpl.java
@@ -32,13 +32,13 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.ProfileFeature;
+import javax.annotation.Nonnull;
+
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.ProfileFeature;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonPointImpl;
-
-import javax.annotation.Nonnull;
 
 /**
  * Abstract superclass for implementations of ProfileFeature.
@@ -60,6 +60,7 @@ public abstract class ProfileFeatureImpl extends PointCollectionImpl implements 
     }
   }
 
+  @Override
   @Nonnull
   public LatLonPoint getLatLon() {
     return latlonPoint;

--- a/cdm/src/main/java/ucar/nc2/ft/point/SectionCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/SectionCollectionImpl.java
@@ -32,11 +32,13 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.time.CalendarDateUnit;
-
 import java.io.IOException;
+
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeatureCCIterator;
+import ucar.nc2.ft.TrajectoryProfileFeature;
+import ucar.nc2.ft.TrajectoryProfileFeatureCollection;
+import ucar.nc2.time.CalendarDateUnit;
 
 /**
  * Superclass for implementations of SectionFeatureCollection: series of profiles along a trajectory
@@ -56,17 +58,20 @@ public abstract class SectionCollectionImpl extends PointFeatureCCCImpl implemen
   // deprecated
   protected PointFeatureCCIterator localIterator;
 
+  @Override
   public boolean hasNext() throws IOException {
      if (localIterator == null) resetIteration();
      return localIterator.hasNext();
    }
 
+   @Override
    public TrajectoryProfileFeature next() throws IOException {
      return (TrajectoryProfileFeature) localIterator.next();
    }
 
+   @Override
    public void resetIteration() throws IOException {
-     localIterator = getNestedPointFeatureCollectionIterator(-1);
+     localIterator = getNestedPointFeatureCollectionIterator();
    }
 
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/SectionFeatureImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/SectionFeatureImpl.java
@@ -32,14 +32,14 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.TrajectoryProfileFeature;
-import ucar.nc2.ft.ProfileFeature;
-import ucar.nc2.ft.PointFeatureCollectionIterator;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.time.CalendarDateUnit;
-
 import java.io.IOException;
 import java.util.Iterator;
+
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeatureCollectionIterator;
+import ucar.nc2.ft.ProfileFeature;
+import ucar.nc2.ft.TrajectoryProfileFeature;
+import ucar.nc2.time.CalendarDateUnit;
 
 /**
  * Abstract superclass for implementations of SectionFeature.
@@ -61,7 +61,7 @@ public abstract class SectionFeatureImpl extends PointFeatureCCImpl implements T
   @Override
   public Iterator<ProfileFeature> iterator() {
     try {
-      PointFeatureCollectionIterator pfIterator = getPointFeatureCollectionIterator(-1);
+      PointFeatureCollectionIterator pfIterator = getPointFeatureCollectionIterator();
       return new CollectionIteratorAdapter<>(pfIterator);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -73,17 +73,20 @@ public abstract class SectionFeatureImpl extends PointFeatureCCImpl implements T
 
   protected PointFeatureCollectionIterator localIterator;
 
+  @Override
   public boolean hasNext() throws IOException {
     if (localIterator == null) resetIteration();
     return localIterator.hasNext();
   }
 
+  @Override
   public ProfileFeature next() throws IOException {
     return (ProfileFeature) localIterator.next();
   }
 
+  @Override
   public void resetIteration() throws IOException {
-    localIterator = getPointFeatureCollectionIterator(-1);
+    localIterator = getPointFeatureCollectionIterator();
   }
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/SortingStationPointFeatureCache.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/SortingStationPointFeatureCache.java
@@ -75,7 +75,7 @@ public class SortingStationPointFeatureCache {
     // fdPoint remains open.
     public void addAll(FeatureDatasetPoint fdPoint) throws IOException {
         try (PointFeatureIterator pointFeatIter =
-                new FlattenedDatasetPointCollection(fdPoint).getPointFeatureIterator(-1)) {
+                new FlattenedDatasetPointCollection(fdPoint).getPointFeatureIterator()) {
             while (pointFeatIter.hasNext()) {
                 StationPointFeature pointFeat = (StationPointFeature) pointFeatIter.next();
                 add(pointFeat);

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
@@ -32,18 +32,21 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCCIterator;
+import ucar.nc2.ft.StationProfileFeature;
+import ucar.nc2.ft.StationProfileFeatureCollection;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.util.IOIterator;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Station;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.io.IOException;
 
 /**
  * Abstract superclass for StationProfileFeatureCollection
@@ -157,17 +160,19 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
       this.stations = stations;
     }
 
+    @Override
     protected StationHelper createStationHelper() throws IOException {
       return from.getStationHelper().subset(stations);
     }
 
-    public PointFeatureCCIterator getNestedPointFeatureCollectionIterator(int bufferSize) throws IOException {
-      return new PointFeatureCCIteratorFiltered( from.getNestedPointFeatureCollectionIterator(bufferSize), new Filter());
+    @Override
+    public PointFeatureCCIterator getNestedPointFeatureCollectionIterator() throws IOException {
+      return new PointFeatureCCIteratorFiltered( from.getNestedPointFeatureCollectionIterator(), new Filter());
     }
 
     @Override
-    public IOIterator<PointFeatureCC> getCollectionIterator(int bufferSize) throws IOException {
-      return new NestedCollectionIOIteratorAdapter<>(getNestedPointFeatureCollectionIterator(-1));
+    public IOIterator<PointFeatureCC> getCollectionIterator() throws IOException {
+      return new NestedCollectionIOIteratorAdapter<>(getNestedPointFeatureCollectionIterator());
     }
 
     private class Filter implements PointFeatureCCIterator.Filter {
@@ -211,7 +216,7 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
   @Override
   public Iterator<StationProfileFeature> iterator() {
     try {
-      PointFeatureCCIterator pfIterator = getNestedPointFeatureCollectionIterator(-1);
+      PointFeatureCCIterator pfIterator = getNestedPointFeatureCollectionIterator();
       return new NestedCollectionIteratorAdapter<>(pfIterator);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -222,17 +227,20 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
   // deprecated
   protected PointFeatureCCIterator localIterator;
 
+  @Override
   public boolean hasNext() throws IOException {
     if (localIterator == null) resetIteration();
     return localIterator.hasNext();
   }
 
+  @Override
   public StationProfileFeature next() throws IOException {
     return (StationProfileFeature) localIterator.next();
   }
 
+  @Override
   public void resetIteration() throws IOException {
-    localIterator = getNestedPointFeatureCollectionIterator(-1);
+    localIterator = getNestedPointFeatureCollectionIterator();
   }
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationProfileFeatureImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationProfileFeatureImpl.java
@@ -32,23 +32,26 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.ma2.StructureData;
-import ucar.nc2.ft.*;
-import ucar.nc2.time.CalendarDate;
-import ucar.nc2.time.CalendarDateRange;
-import ucar.nc2.time.CalendarDateUnit;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.util.IOIterator;
-import ucar.unidata.geoloc.LatLonPoint;
-import ucar.unidata.geoloc.StationImpl;
-import ucar.unidata.geoloc.Station;
-import ucar.unidata.geoloc.LatLonRect;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nonnull;
+
+import ucar.ma2.StructureData;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureCollectionIterator;
+import ucar.nc2.ft.ProfileFeature;
+import ucar.nc2.ft.StationProfileFeature;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateRange;
+import ucar.nc2.time.CalendarDateUnit;
+import ucar.nc2.util.IOIterator;
+import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.LatLonRect;
+import ucar.unidata.geoloc.Station;
+import ucar.unidata.geoloc.StationImpl;
 
 /**
  * Abstract superclass for implementations of StationProfileFeature.
@@ -126,7 +129,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
   }
 
   @Override
-  public int compareTo(Station so) {
+  public int compareTo(@Nonnull Station so) {
     return station.getName().compareTo(so.getName());
   }
 
@@ -156,6 +159,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
       return from.getFeatureData();
     }
 
+    @Override
     public List<CalendarDate> getTimes() throws IOException {
       List<CalendarDate> result = new ArrayList<>();
       for (ProfileFeature pf : this) {
@@ -171,16 +175,17 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
     }
 
     @Override // new way
-    public IOIterator<PointFeatureCollection> getCollectionIterator(int bufferSize) throws IOException {
-      return new PointCollectionIteratorFiltered( from.getPointFeatureCollectionIterator(bufferSize), new DateFilter());
+    public IOIterator<PointFeatureCollection> getCollectionIterator() throws IOException {
+      return new PointCollectionIteratorFiltered( from.getPointFeatureCollectionIterator(), new DateFilter());
     }
 
     @Override // old way
-    public PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws IOException {
-      return new PointCollectionIteratorFiltered( from.getPointFeatureCollectionIterator(bufferSize), new DateFilter());
+    public PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws IOException {
+      return new PointCollectionIteratorFiltered( from.getPointFeatureCollectionIterator(), new DateFilter());
     }
 
     private class DateFilter implements PointFeatureCollectionIterator.Filter {
+      @Override
       public boolean filter(PointFeatureCollection pointFeatureCollection) {
         ProfileFeature profileFeature = (ProfileFeature) pointFeatureCollection;
         return dateRange.includes(profileFeature.getTime());
@@ -190,6 +195,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
 
   /////////////////////////////////////////////////////////////////////////////////////
 
+  @Override
   public Iterator<ProfileFeature> iterator() {
     return new ProfileFeatureIterator();
   }
@@ -199,7 +205,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
 
     public ProfileFeatureIterator() {
       try {
-        this.pfIterator = getPointFeatureCollectionIterator(-1);
+        this.pfIterator = getPointFeatureCollectionIterator();
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -242,7 +248,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
 
   @Override
   public void resetIteration() throws IOException {
-    localIterator = getPointFeatureCollectionIterator(-1);
+    localIterator = getPointFeatureCollectionIterator();
   }
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
@@ -33,13 +33,11 @@
 
 package ucar.nc2.ft.point;
 
-import ucar.nc2.time.CalendarDateRange;
-import ucar.unidata.geoloc.LatLonRect;
-import ucar.nc2.ft.PointFeatureIterator;
-import ucar.nc2.ft.PointFeatureCollection;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.time.CalendarDateRange;
 
 /**
  * A flattened StationTimeSeriesCollection.
@@ -61,8 +59,8 @@ public class StationTimeSeriesCollectionFlattened extends PointCollectionImpl {
 
   @Override
   @Nonnull
-  public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
-    return new PointIteratorFlatten( from.getPointFeatureCollectionIterator(bufferSize), null, this.getCalendarDateRange());
+  public PointFeatureIterator getPointFeatureIterator() throws IOException {
+    return new PointIteratorFlatten( from.getPointFeatureCollectionIterator(), null, this.getCalendarDateRange());
   }
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
@@ -32,18 +32,22 @@
  */
 package ucar.nc2.ft.point;
 
-import ucar.nc2.ft.*;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.time.CalendarDateRange;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import ucar.nc2.VariableSimpleIF;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureCollectionIterator;
+import ucar.nc2.ft.StationTimeSeriesFeature;
+import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
+import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.util.IOIterator;
 import ucar.unidata.geoloc.LatLonRect;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Iterator;
-import java.io.IOException;
 
 /**
  * Abstract superclass for implementations of StationFeatureCollection.
@@ -207,7 +211,7 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
   @Override
   public Iterator<StationTimeSeriesFeature> iterator() {
     try {
-      PointFeatureCollectionIterator pfIterator = getPointFeatureCollectionIterator(-1);
+      PointFeatureCollectionIterator pfIterator = getPointFeatureCollectionIterator();
       return new CollectionIteratorAdapter<>(pfIterator);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -215,12 +219,12 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
   }
 
   @Override
-  public IOIterator<PointFeatureCollection> getCollectionIterator(int bufferSize) throws IOException {
+  public IOIterator<PointFeatureCollection> getCollectionIterator() throws IOException {
     return new StationIterator();
   }
 
   @Override
-  public PointFeatureCollectionIterator getPointFeatureCollectionIterator(int bufferSize) throws IOException {
+  public PointFeatureCollectionIterator getPointFeatureCollectionIterator() throws IOException {
     return new StationIterator();
   }
 
@@ -281,6 +285,6 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
 
   @Override
   public void resetIteration() throws IOException {
-    localIterator = getPointFeatureCollectionIterator(-1);
+    localIterator = getPointFeatureCollectionIterator();
   }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesFeatureImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesFeatureImpl.java
@@ -122,7 +122,8 @@ public abstract class StationTimeSeriesFeatureImpl extends PointCollectionImpl i
     return new StationFeatureSubset(this, dateRange);
   }
 
-  public int compareTo(Station so) {
+  @Override
+  public int compareTo(@Nonnull Station so) {
     return name.compareTo(so.getName());
   }
 
@@ -155,8 +156,8 @@ public abstract class StationTimeSeriesFeatureImpl extends PointCollectionImpl i
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
-      return new PointIteratorFiltered(from.getPointFeatureIterator(bufferSize), null, filter_date);
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
+      return new PointIteratorFiltered(from.getPointFeatureIterator(), null, filter_date);
     }
 
     @Nonnull

--- a/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeDatasetFactory.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeDatasetFactory.java
@@ -32,20 +32,25 @@
  */
 package ucar.nc2.ft.point.collection;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Formatter;
+import java.util.List;
+
 import thredds.inventory.MFileCollectionManager;
 import thredds.inventory.TimedCollection;
 import ucar.nc2.Attribute;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.ft.*;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDataset;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeatureCC;
+import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.point.PointDatasetImpl;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.unidata.geoloc.LatLonRect;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Formatter;
-import java.util.List;
 
 /**
  * Factory for point feature dataset collections (CompositePointDataset).
@@ -139,6 +144,7 @@ public class CompositeDatasetFactory {
     return dataVariables;
   }
 
+    @Override
     public List<Attribute> getGlobalAttributes() {
       if (globalAttributes == null) {
         if (pfc instanceof CompositePointCollection)

--- a/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositePointCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositePointCollection.java
@@ -32,22 +32,27 @@
  */
 package ucar.nc2.ft.point.collection;
 
+import java.io.IOException;
+import java.util.Formatter;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nonnull;
+
 import thredds.inventory.TimedCollection;
 import ucar.nc2.Attribute;
+import ucar.nc2.VariableSimpleIF;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.point.PointCollectionImpl;
 import ucar.nc2.ft.point.PointIteratorAbstract;
-import ucar.nc2.ft.*;
 import ucar.nc2.time.CalendarDateRange;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.unidata.geoloc.LatLonRect;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.List;
-import java.util.Iterator;
-import java.util.Formatter;
 
 /**
  * PointCollection composed of other PointCollections
@@ -105,7 +110,8 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
     }
   }
 
-  public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+  @Override
+  public PointFeatureIterator getPointFeatureIterator() throws IOException {
     return new CompositePointFeatureIterator();
   }
 
@@ -116,7 +122,6 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
 
   private class CompositePointFeatureIterator extends PointIteratorAbstract {
     private boolean finished = false;
-    private int bufferSize = -1;
     private Iterator<TimedCollection.Dataset> iter;
     private FeatureDatasetPoint currentDataset;
     private PointFeatureIterator pfIter = null;
@@ -138,9 +143,10 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
 
       List<DsgFeatureCollection> fcList = currentDataset.getPointFeatureCollectionList();
       PointFeatureCollection pc = (PointFeatureCollection) fcList.get(0);
-      return pc.getPointFeatureIterator(bufferSize);
+      return pc.getPointFeatureIterator();
     }
 
+    @Override
     public boolean hasNext() {
       try {
         if (pfIter == null) {
@@ -167,10 +173,12 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
       }
     }
 
+    @Override
     public PointFeature next() {
       return pfIter.next();
     }
 
+    @Override
     public void close() {
       if (finished) return;
 
@@ -186,10 +194,6 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
         }
 
       finished = true;
-    }
-
-    public void setBufferSize(int bytes) {
-      bufferSize = bytes;
     }
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeStationCollectionFlattened.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeStationCollectionFlattened.java
@@ -32,23 +32,28 @@
  */
 package ucar.nc2.ft.point.collection;
 
-import thredds.inventory.TimedCollection;
-import ucar.nc2.ft.point.PointCollectionImpl;
-import ucar.nc2.ft.point.PointIteratorAbstract;
-import ucar.nc2.ft.*;
-import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.ft.point.StationFeature;
-import ucar.nc2.time.CalendarDateRange;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.time.CalendarDateUnit;
-import ucar.unidata.geoloc.LatLonRect;
-import ucar.unidata.geoloc.Station;
-
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Formatter;
 import java.util.Iterator;
-import java.io.IOException;
+import java.util.List;
+
+import thredds.inventory.TimedCollection;
+import ucar.nc2.VariableSimpleIF;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureCollection;
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
+import ucar.nc2.ft.point.PointCollectionImpl;
+import ucar.nc2.ft.point.PointIteratorAbstract;
+import ucar.nc2.ft.point.StationFeature;
+import ucar.nc2.time.CalendarDateRange;
+import ucar.nc2.time.CalendarDateUnit;
+import ucar.unidata.geoloc.LatLonRect;
 
 /**
  * CompositeStationCollection that has been flattened into a PointCollection
@@ -85,13 +90,13 @@ public class CompositeStationCollectionFlattened extends PointCollectionImpl {
     this.stnCollections = stnCollections;
   }
 
-  public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+  @Override
+  public PointFeatureIterator getPointFeatureIterator() throws IOException {
     return new PointIterator();
   }
 
   private class PointIterator extends PointIteratorAbstract {
     private boolean finished = false;
-    private int bufferSize = -1;
     private Iterator<TimedCollection.Dataset> iter;
     private FeatureDatasetPoint currentDataset;
     private PointFeatureIterator pfIter = null;
@@ -132,9 +137,10 @@ public class CompositeStationCollectionFlattened extends PointCollectionImpl {
         pc = stnCollection.flatten(names, dateRange, null);
       }
 
-      return pc.getPointFeatureIterator(bufferSize);
+      return pc.getPointFeatureIterator();
     }
 
+    @Override
     public boolean hasNext() {
       try {
         if (pfIter == null) {
@@ -160,12 +166,14 @@ public class CompositeStationCollectionFlattened extends PointCollectionImpl {
       }
     }
 
+    @Override
     public PointFeature next() {
       PointFeature pf =  pfIter.next();
       calcBounds(pf);
       return pf;
     }
 
+    @Override
     public void close() {
       if (finished) return;
 
@@ -183,10 +191,6 @@ public class CompositeStationCollectionFlattened extends PointCollectionImpl {
         }
 
       finished = true;
-    }
-
-    public void setBufferSize(int bytes) {
-      bufferSize = bytes;
     }
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/PointCollectionStreamAbstract.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/PointCollectionStreamAbstract.java
@@ -56,7 +56,7 @@ public abstract class PointCollectionStreamAbstract extends PointCollectionImpl 
     public abstract InputStream getInputStream() throws IOException;
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
         InputStream in = getInputStream();
         boolean leaveStreamOpen = false;
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/PointIteratorStream.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/PointIteratorStream.java
@@ -65,6 +65,7 @@ public class PointIteratorStream extends PointIteratorAbstract {
     if (!info.isComplete()) setCalculateBounds(info);
   }
 
+  @Override
   public void close() {
     if (finished) return;
     if (in != null)
@@ -78,6 +79,7 @@ public class PointIteratorStream extends PointIteratorAbstract {
     finished = true;
   }
 
+  @Override
   public boolean hasNext() {
     if (finished) return false;
 
@@ -119,14 +121,11 @@ public class PointIteratorStream extends PointIteratorAbstract {
     }
   }
 
+  @Override
   public PointFeature next() {
     if (null == pf) return null;
     calcBounds(pf);
     return pf;
   }
-
-  public void setBufferSize(int bytes) {
-  }
-
 }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/PointStream.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/PointStream.java
@@ -242,6 +242,7 @@ public class PointStream {
       ArrayStructureBB.setOffsets(sm);
     }
 
+    @Override
     public PointFeature make(DsgFeatureCollection dsg, byte[] rawBytes) throws InvalidProtocolBufferException {
       PointStreamProto.PointFeature pfp = PointStreamProto.PointFeature.parseFrom(rawBytes);
       PointStreamProto.Location locp = pfp.getLoc();
@@ -285,7 +286,7 @@ public class PointStream {
     String name = outFile.getCanonicalPath();
     String timeUnitString = pointFeatCol.getTimeUnit().getUdUnit();
     String altUnits = pointFeatCol.getAltUnits();
-    PointFeatureIterator pointFeatIter = pointFeatCol.getPointFeatureIterator(-1);
+    PointFeatureIterator pointFeatIter = pointFeatCol.getPointFeatureIterator();
 
     try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outFile))) {
       return write(out, pointFeatIter, name, timeUnitString, altUnits);

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
@@ -37,13 +37,17 @@ import java.io.InputStream;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import ucar.ma2.StructureData;
-import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.StationTimeSeriesFeature;
 import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
-import ucar.nc2.ft.point.*;
+import ucar.nc2.ft.point.PointIteratorEmpty;
+import ucar.nc2.ft.point.StationFeature;
+import ucar.nc2.ft.point.StationHelper;
+import ucar.nc2.ft.point.StationTimeSeriesCollectionImpl;
+import ucar.nc2.ft.point.StationTimeSeriesFeatureImpl;
 import ucar.nc2.stream.CdmRemote;
 import ucar.nc2.stream.NcStream;
 import ucar.nc2.time.CalendarDateRange;
@@ -217,7 +221,7 @@ public class StationCollectionStream extends StationTimeSeriesCollectionImpl {
 
     // an iterator over the observations for this station
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
       String query = PointDatasetRemote.makeQuery("stn=" + s.getName(), null, getInfo().getCalendarDateRange(this.getTimeUnit()));
 
       InputStream in = null;

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinArray.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinArray.java
@@ -33,13 +33,13 @@
 
 package ucar.nc2.ft.point.standard;
 
+import java.io.IOException;
+
+import ucar.ma2.Array;
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataFactory;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.VariableDS;
-import ucar.ma2.StructureData;
-import ucar.ma2.Array;
-import ucar.ma2.StructureDataFactory;
-
-import java.io.IOException;
 
 /**
  * Join data from an element of an Array, whose index is passed in as cursor.recnum[0].
@@ -78,11 +78,13 @@ public class JoinArray implements Join {
     }
   }
 
+  @Override
   public Variable getExtraVariable() {
     return v;
   }
 
 
+  @Override
   public StructureData getJoinData(Cursor cursor) {
     int recnum = -1;
     switch (type) {
@@ -105,6 +107,7 @@ public class JoinArray implements Join {
     return StructureDataFactory.make(v.getShortName(), data.getObject(recnum));
   }
 
+  @Override
   public VariableDS findVariable(String varName) {
     return (varName.equals(v.getFullName())) ? v : null;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinMuiltdimStructure.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinMuiltdimStructure.java
@@ -33,13 +33,13 @@
 
 package ucar.nc2.ft.point.standard;
 
-import ucar.nc2.Variable;
-import ucar.nc2.dataset.VariableDS;
-import ucar.nc2.dataset.StructureDS;
+import java.io.IOException;
+
 import ucar.ma2.ArrayStructure;
 import ucar.ma2.StructureData;
-
-import java.io.IOException;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.StructureDS;
+import ucar.nc2.dataset.VariableDS;
 
 /**
  * Join data from a row of a Structure, whose index is passed in as recnum[0] / dimLen
@@ -68,15 +68,18 @@ public class JoinMuiltdimStructure implements Join {
     }
   }
 
+  @Override
   public StructureData getJoinData(Cursor cursor) {
     int recnum = cursor.recnum[0] / dimLength;
     return parentData.getStructureData(recnum);
   }
 
+  @Override
   public VariableDS findVariable(String axisName) {
     return (VariableDS) parentStructure.findVariable(axisName);
   }
 
+  @Override
   public Variable getExtraVariable() {
     return null;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinParentIndex.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/JoinParentIndex.java
@@ -33,13 +33,13 @@
 
 package ucar.nc2.ft.point.standard;
 
+import java.io.IOException;
+
 import ucar.ma2.ArrayStructure;
 import ucar.ma2.StructureData;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.StructureDS;
 import ucar.nc2.dataset.VariableDS;
-
-import java.io.IOException;
 
 /**
  * Join data from a row of a Structure, whose index is passed in as the value of a member variable of the
@@ -69,16 +69,19 @@ public class JoinParentIndex implements Join {
     }
   }
 
+  @Override
   public StructureData getJoinData(Cursor cursor) {
     StructureData sdata = cursor.tableData[0]; // LOOK ??
     int index = sdata.getScalarInt(parentIndex);
     return parentData.getStructureData(index);
   }
 
+  @Override
   public VariableDS findVariable(String axisName) {
     return (VariableDS) parentStructure.findVariable(axisName);
   }
 
+  @Override
   public Variable getExtraVariable() {
     return null;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/NestedTable.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/NestedTable.java
@@ -33,24 +33,31 @@
 
 package ucar.nc2.ft.point.standard;
 
-import ucar.nc2.*;
-import ucar.nc2.dataset.CoordinateAxis;
-import ucar.nc2.ft.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.List;
+
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataFactory;
+import ucar.ma2.StructureDataIterator;
 import ucar.ma2.StructureDataIteratorLimited;
+import ucar.ma2.StructureMembers;
+import ucar.nc2.Variable;
+import ucar.nc2.VariableSimpleIF;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.VariableDS;
+import ucar.nc2.ft.FeatureDatasetFactoryManager;
 import ucar.nc2.ft.point.StationFeature;
 import ucar.nc2.ft.point.StationFeatureImpl;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateFormatter;
 import ucar.nc2.time.CalendarDateUnit;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.dataset.VariableDS;
-import ucar.ma2.*;
 import ucar.unidata.geoloc.EarthLocation;
 import ucar.unidata.geoloc.EarthLocationImpl;
-
-import java.util.*;
-import java.io.IOException;
 
 /**
  * Implements "nested table" views of point feature datasets.
@@ -255,6 +262,7 @@ public class NestedTable {
       this.coordVar = v;
     }
 
+    @Override
     public String getCoordValueString(StructureData sdata) {
       if (coordVar.getDataType().isString())
         return sdata.getScalarString(memberName);
@@ -264,10 +272,12 @@ public class NestedTable {
         return Double.toString(sdata.convertScalarDouble(memberName));
     }
 
+    @Override
     public String getUnitsString() {
       return coordVar.getUnitsString();
     }
 
+    @Override
     public boolean isString() {
       return coordVar.getDataType().isString();
     }
@@ -284,14 +294,17 @@ public class NestedTable {
       }
     }
 
+    @Override
     public double getCoordValue(StructureData sdata) {
       return sdata.convertScalarDouble(memberName);
     }
 
+    @Override
     public boolean isInt() {
       return coordVar.getDataType().isIntegral();
     }
 
+    @Override
     public long getCoordValueLong(StructureData sdata) {
       return sdata.convertScalarLong(memberName);
     }
@@ -307,6 +320,7 @@ public class NestedTable {
       this.varTop = v;
     }
 
+    @Override
     public double getCoordValue(StructureData sdata) {
       try {
         return varTop.readScalarDouble();
@@ -315,18 +329,22 @@ public class NestedTable {
       }
     }
 
+    @Override
     public String getUnitsString() {
       return varTop.getUnitsString();
     }
 
+    @Override
     public boolean isString() {
       return varTop.getDataType().isString();
     }
 
+    @Override
     public boolean isInt() {
       return varTop.getDataType().isIntegral();
     }
 
+    @Override
     public long getCoordValueLong(StructureData sdata) {
       try {
         return varTop.readScalarLong();
@@ -335,6 +353,7 @@ public class NestedTable {
       }
     }
 
+    @Override
     public String getCoordValueString(StructureData sdata) {
       try {
         return varTop.readScalarString();
@@ -343,6 +362,7 @@ public class NestedTable {
       }
     }
 
+    @Override
     public boolean isMissing(StructureData sdata) {
       if (isString()) return false;
       double val = getCoordValue(sdata);
@@ -360,33 +380,40 @@ public class NestedTable {
       this.sdata = sdata;
     }
 
+    @Override
     public double getCoordValue(StructureData ignore) {
       return sdata.convertScalarDouble(memberName);
     }
 
+    @Override
     public String getCoordValueString(StructureData ignore) {
       return sdata.getScalarString(memberName);
     }
 
+    @Override
     public String getUnitsString() {
       StructureMembers.Member m = sdata.findMember(memberName);
       return m.getUnitsString();
     }
 
+    @Override
     public boolean isString() {
       StructureMembers.Member m = sdata.findMember(memberName);
       return m.getDataType().isString();
     }
 
+    @Override
     public boolean isInt() {
       StructureMembers.Member m = sdata.findMember(memberName);
       return m.getDataType().isIntegral();
     }
 
+    @Override
     public long getCoordValueLong(StructureData sdata) {
       return sdata.convertScalarLong(memberName);
     }
 
+    @Override
     public boolean isMissing(StructureData sdata) {
       return false;
     }
@@ -404,30 +431,37 @@ public class NestedTable {
       this.value = value;
     }
 
+    @Override
     public double getCoordValue(StructureData sdata) {
       return Double.parseDouble(value);
     }
 
+    @Override
     public long getCoordValueLong(StructureData sdata) {
       return Long.parseLong(value);
     }
 
+    @Override
     public String getCoordValueString(StructureData sdata) {
       return value;
     }
 
+    @Override
     public String getUnitsString() {
       return units;
     }
 
+    @Override
     public boolean isString() {
       return true;
     }
 
+    @Override
     public boolean isInt() {
       return false;
     }
 
+    @Override
     public boolean isMissing(StructureData sdata) {
       return false;
     }
@@ -648,14 +682,14 @@ public class NestedTable {
 
   //// Point
 
-  public StructureDataIterator getObsDataIterator(Cursor cursor, int bufferSize) throws IOException {
-    return root.getStructureDataIterator(cursor, bufferSize);
+  public StructureDataIterator getObsDataIterator(Cursor cursor) throws IOException {
+    return root.getStructureDataIterator(cursor);
   }
 
   //// Station or Station_Profile
-  public StructureDataIterator getStationDataIterator(int bufferSize) throws IOException {
+  public StructureDataIterator getStationDataIterator() throws IOException {
     Table stationTable = root;
-    StructureDataIterator siter = stationTable.getStructureDataIterator(null, bufferSize);
+    StructureDataIterator siter = stationTable.getStructureDataIterator(null);
 
     if (stationTable.limit != null) {
       Variable limitV = ds.findVariable(stationTable.limit);
@@ -667,16 +701,16 @@ public class NestedTable {
   }
 
   //// Trajectory, Profile, Section
-  public StructureDataIterator getRootFeatureDataIterator(int bufferSize) throws IOException {
-    return root.getStructureDataIterator(null, bufferSize);
+  public StructureDataIterator getRootFeatureDataIterator() throws IOException {
+    return root.getStructureDataIterator(null);
   }
 
-  public StructureDataIterator getLeafFeatureDataIterator(Cursor cursor, int bufferSize) throws IOException {
-    return leaf.getStructureDataIterator(cursor, bufferSize);
+  public StructureDataIterator getLeafFeatureDataIterator(Cursor cursor) throws IOException {
+    return leaf.getStructureDataIterator(cursor);
   }
 
-  public StructureDataIterator getMiddleFeatureDataIterator(Cursor cursor, int bufferSize) throws IOException {
-    return leaf.parent.getStructureDataIterator(cursor, bufferSize);  // the middle table
+  public StructureDataIterator getMiddleFeatureDataIterator(Cursor cursor) throws IOException {
+    return leaf.parent.getStructureDataIterator(cursor);  // the middle table
   }
 
   // also called from StandardPointFeatureIterator

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
@@ -33,18 +33,20 @@
 
 package ucar.nc2.ft.point.standard;
 
-import ucar.nc2.ft.*;
-import ucar.nc2.ft.point.*;
-import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.dataset.CoordinateAxis;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.constants.AxisType;
-import ucar.nc2.time.CalendarDateUnit;
-
-import java.util.List;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Formatter;
-import java.io.IOException;
+import java.util.List;
+
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.ft.DsgFeatureCollection;
+import ucar.nc2.ft.FeatureDataset;
+import ucar.nc2.ft.FeatureDatasetFactory;
+import ucar.nc2.ft.point.PointDatasetImpl;
+import ucar.nc2.time.CalendarDateUnit;
 
 /**
  * Standard handler for Point obs dataset based on a NetcdfDataset object.
@@ -77,6 +79,7 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
    * @return if successful, return non-null. This object is then passed back into open(), so analysis can be reused.
    * @throws IOException
    */
+  @Override
   public Object isMine(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) throws IOException {
     if (wantFeatureType == null) wantFeatureType = FeatureType.ANY_POINT;
     if (wantFeatureType != FeatureType.ANY_POINT) {
@@ -121,6 +124,7 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
     return analyser;
   }
 
+  @Override
   public FeatureDataset open(FeatureType wantFeatureType, NetcdfDataset ncd, Object analyser, ucar.nc2.util.CancelTask task, Formatter errlog) throws IOException {
     if (analyser == null)
       analyser = TableAnalyzer.factory(null, wantFeatureType, ncd);
@@ -128,6 +132,7 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
     return new PointDatasetStandard(wantFeatureType, (TableAnalyzer) analyser, ncd, errlog);
   }
 
+  @Override
   public FeatureType[] getFeatureTypes() {
     return new FeatureType[]{FeatureType.ANY_POINT};
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointCollectionImpl.java
@@ -33,11 +33,11 @@
 
 package ucar.nc2.ft.point.standard;
 
-import ucar.nc2.ft.point.PointCollectionImpl;
-import ucar.nc2.ft.PointFeatureIterator;
-import ucar.nc2.time.CalendarDateUnit;
-
 import java.io.IOException;
+
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.ft.point.PointCollectionImpl;
+import ucar.nc2.time.CalendarDateUnit;
 
 /**
  * Implementation of PointFeatureCollection using a NestedTable
@@ -53,11 +53,12 @@ public class StandardPointCollectionImpl extends PointCollectionImpl {
     this.extras = ft.getExtras();
   }
 
-  public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+  @Override
+  public PointFeatureIterator getPointFeatureIterator() throws IOException {
     // only one Cursor object needed - it will be used for each iteration with different structData's
     Cursor tableData = new Cursor(ft.getNumberOfLevels());
 
-    return new StandardPointFeatureIterator(this, ft, timeUnit, ft.getObsDataIterator(tableData, bufferSize), tableData);
+    return new StandardPointFeatureIterator(this, ft, timeUnit, ft.getObsDataIterator(tableData), tableData);
   }
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointFeatureIterator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointFeatureIterator.java
@@ -69,6 +69,7 @@ public class StandardPointFeatureIterator extends PointIteratorFromStructureData
     if (!info.isComplete()) setCalculateBounds(info);
   }
 
+  @Override
   protected PointFeature makeFeature(int recnum, StructureData sdata) throws IOException {
     cursor.recnum[0] = recnum;
     cursor.tableData[0] = sdata; // always in the first position

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardStationCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardStationCollectionImpl.java
@@ -33,17 +33,18 @@
 
 package ucar.nc2.ft.point.standard;
 
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataIterator;
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.ft.StationTimeSeriesFeature;
 import ucar.nc2.ft.point.StationFeature;
+import ucar.nc2.ft.point.StationHelper;
 import ucar.nc2.ft.point.StationTimeSeriesCollectionImpl;
 import ucar.nc2.ft.point.StationTimeSeriesFeatureImpl;
-import ucar.nc2.ft.point.StationHelper;
-import ucar.nc2.ft.*;
 import ucar.nc2.time.CalendarDateUnit;
-import ucar.ma2.StructureDataIterator;
-import ucar.ma2.StructureData;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
 
 /**
  * Object Heirarchy for StationFeatureCollection:
@@ -82,7 +83,7 @@ public class StandardStationCollectionImpl extends StationTimeSeriesCollectionIm
   protected StationHelper createStationHelper() throws IOException {
     StationHelper stationHelper = new StationHelper();
 
-    try (StructureDataIterator siter = ft.getStationDataIterator(-1)) {
+    try (StructureDataIterator siter = ft.getStationDataIterator()) {
       while (siter.hasNext()) {
         StructureData stationData = siter.next();
         StationTimeSeriesFeature stfs = makeStation(stationData, siter.getCurrentRecno());
@@ -108,14 +109,14 @@ public class StandardStationCollectionImpl extends StationTimeSeriesCollectionIm
     // an iterator over the observations for this station
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
       Cursor cursor = new Cursor(ft.getNumberOfLevels());
       cursor.recnum[1] = recnum;
       cursor.tableData[1] = stationData;
       cursor.currentIndex = 1;
       ft.addParentJoin(cursor); // there may be parent joins
 
-      StructureDataIterator obsIter = ft.getLeafFeatureDataIterator(cursor, bufferSize);
+      StructureDataIterator obsIter = ft.getLeafFeatureDataIterator(cursor);
       return new StandardPointFeatureIterator(this, ft, timeUnit, obsIter, cursor);
     }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
@@ -33,6 +33,18 @@
 
 package ucar.nc2.ft.point.standard;
 
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -47,11 +59,24 @@ import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.ft.FeatureDatasetFactoryManager;
-import ucar.nc2.ft.point.standard.plug.*;
-
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.util.*;
+import ucar.nc2.ft.point.standard.plug.BuoyShipSynop;
+import ucar.nc2.ft.point.standard.plug.CFpointObs;
+import ucar.nc2.ft.point.standard.plug.CFpointObsExt;
+import ucar.nc2.ft.point.standard.plug.CdmDirect;
+import ucar.nc2.ft.point.standard.plug.Cosmic;
+import ucar.nc2.ft.point.standard.plug.FslRaob;
+import ucar.nc2.ft.point.standard.plug.FslWindProfiler;
+import ucar.nc2.ft.point.standard.plug.GempakCdm;
+import ucar.nc2.ft.point.standard.plug.Iridl;
+import ucar.nc2.ft.point.standard.plug.Jason;
+import ucar.nc2.ft.point.standard.plug.Madis;
+import ucar.nc2.ft.point.standard.plug.MadisAcars;
+import ucar.nc2.ft.point.standard.plug.NdbcCoards;
+import ucar.nc2.ft.point.standard.plug.Nldn;
+import ucar.nc2.ft.point.standard.plug.RafNimbus;
+import ucar.nc2.ft.point.standard.plug.SimpleTrajectory;
+import ucar.nc2.ft.point.standard.plug.Suomi;
+import ucar.nc2.ft.point.standard.plug.UnidataPointObs;
 
 /**
  * Analyzes the coordinate systems of a dataset to try to identify the Feature Type and the
@@ -75,6 +100,7 @@ public class TableAnalyzer {
     registerAnalyzer(CDM.CF_EXTENDED, CFpointObsExt.class, null);
 
     registerAnalyzer("CF-1.", CFpointObs.class, new ConventionNameOk() {
+      @Override
       public boolean isMatch(String convName, String wantName) {
         return convName.startsWith(wantName); //  && !convName.equals("CF-1.0"); // throw 1.0 to default analyser
       }

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/TableConfigurerImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/TableConfigurerImpl.java
@@ -48,18 +48,22 @@ import ucar.nc2.constants.CF;
  */
 public abstract class TableConfigurerImpl implements TableConfigurer {
 
+  @Override
   public String getConvName() {
     return convName;
   }
 
+  @Override
   public void setConvName(String convName) {
     this.convName = convName;
   }
 
+  @Override
   public String getConvUsed() {
     return convUsed;
   }
 
+  @Override
   public void setConvUsed(String convUsed) {
     this.convUsed = convUsed;
   }
@@ -91,6 +95,7 @@ public abstract class TableConfigurerImpl implements TableConfigurer {
 
   protected String matchAxisTypeAndDimension(NetcdfDataset ds, AxisType type, final Dimension outer, final Dimension inner) {
     Variable var = CoordSysEvaluator.findCoordByType(ds, type, new CoordSysEvaluator.Predicate() {
+      @Override
       public boolean match(CoordinateAxis axis) {
         return ((axis.getRank() == 2) && outer.equals(axis.getDimension(0)) && inner.equals(axis.getDimension(1)));
       }
@@ -101,6 +106,7 @@ public abstract class TableConfigurerImpl implements TableConfigurer {
 
   protected String matchAxisTypeAndDimension(NetcdfDataset ds, AxisType type, final Dimension outer, final Dimension middle, final Dimension inner) {
     Variable var = CoordSysEvaluator.findCoordByType(ds, type, new CoordSysEvaluator.Predicate() {
+      @Override
       public boolean match(CoordinateAxis axis) {
         return ((axis.getRank() == 3) && outer.equals(axis.getDimension(0)) && middle.equals(axis.getDimension(1)) && inner.equals(axis.getDimension(2)));
       }

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
@@ -33,22 +33,40 @@
  */
 package ucar.nc2.ft2.coverage.writer;
 
-import ucar.ma2.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import ucar.ma2.Array;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.StructureData;
+import ucar.ma2.StructureDataScalar;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.VariableSimpleImpl;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.ft.*;
-import ucar.nc2.ft.point.*;
-import ucar.nc2.ft2.coverage.*;
+import ucar.nc2.ft.FeatureDatasetPoint;
+import ucar.nc2.ft.PointFeature;
+import ucar.nc2.ft.PointFeatureIterator;
+import ucar.nc2.ft.point.PointFeatureImpl;
+import ucar.nc2.ft.point.PointIteratorAbstract;
+import ucar.nc2.ft.point.StationFeature;
+import ucar.nc2.ft.point.StationHelper;
+import ucar.nc2.ft.point.StationPointFeature;
+import ucar.nc2.ft.point.StationTimeSeriesCollectionImpl;
+import ucar.nc2.ft.point.StationTimeSeriesFeatureImpl;
+import ucar.nc2.ft2.coverage.Coverage;
+import ucar.nc2.ft2.coverage.CoverageCollection;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis1D;
+import ucar.nc2.ft2.coverage.CoverageCoordSys;
+import ucar.nc2.ft2.coverage.GeoReferencedArray;
+import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.util.StringUtil2;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Write DSG CF-1.6 file from a Coverage Dataset
@@ -155,7 +173,7 @@ public class CoverageAsPoint {
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
       return new TimeseriesIterator();
     }
 

--- a/cdm/src/test/groovy/ucar/nc2/ft/point/FlattenedDatasetPointCollectionSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft/point/FlattenedDatasetPointCollectionSpec.groovy
@@ -59,7 +59,7 @@ class FlattenedDatasetPointCollectionSpec extends Specification {
         flattenedDatasetCol.altUnits == null
 
         when: "get empty collection's iterator"
-        def flattenedDatasetIter = flattenedDatasetCol.getPointFeatureIterator(-1)
+        def flattenedDatasetIter = flattenedDatasetCol.getPointFeatureIterator()
 
         then: "iterator is empty"
         !flattenedDatasetIter.hasNext()
@@ -169,7 +169,7 @@ class FlattenedDatasetPointCollectionSpec extends Specification {
         flattenedDatasetCol.calendarDateRange == null
 
         when: "get the iterator and enable bounds calculation"
-        PointIteratorAbstract flattenedPointIter = flattenedDatasetCol.getPointFeatureIterator(-1) as PointIteratorAbstract
+        PointIteratorAbstract flattenedPointIter = flattenedDatasetCol.getPointFeatureIterator() as PointIteratorAbstract
         flattenedPointIter.calculateBounds = flattenedDatasetCol.info
 
         and: "iterate over the collection"

--- a/cdm/src/test/groovy/ucar/nc2/ft/point/PointIteratorFilteredSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft/point/PointIteratorFilteredSpec.groovy
@@ -40,7 +40,7 @@ class PointIteratorFilteredSpec extends Specification {
 
         and: "filtered point iterator"
         PointFeatureCollection flattenedDatasetCol = new FlattenedDatasetPointCollection(fdPoint);
-        PointFeatureIterator pointIterOrig = flattenedDatasetCol.getPointFeatureIterator(-1);
+        PointFeatureIterator pointIterOrig = flattenedDatasetCol.getPointFeatureIterator();
         PointFeatureIterator pointIterFiltered = new PointIteratorFiltered(pointIterOrig, filter_bb, filter_date);
 
         expect:

--- a/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
@@ -35,7 +35,7 @@ public class PointTestUtil {
     }
 
     public static void writeFeatureCollection(PointFeatureCollection pointFeatColl) throws IOException {
-        PointFeatureIterator iter = pointFeatColl.getPointFeatureIterator(-1);
+        PointFeatureIterator iter = pointFeatColl.getPointFeatureIterator();
         while (iter.hasNext()) {
             PointFeature pointFeat = iter.next();
             StructureData data = pointFeat.getFeatureData();
@@ -59,7 +59,7 @@ public class PointTestUtil {
         // We must do this comparison first because some PointFeatureCollection implementations, e.g.
         // PointCollectionStreamAbstract, won't have final values for getTimeUnit() and getAltUnits() until
         // getPointFeatureIterator() is called.
-        if (!equals(featCol1.getPointFeatureIterator(-1), featCol2.getPointFeatureIterator(-1))) {
+        if (!equals(featCol1.getPointFeatureIterator(), featCol2.getPointFeatureIterator())) {
             return false;
         }
 

--- a/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCC.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCC.java
@@ -28,7 +28,7 @@ public class SimplePointFeatureCC extends PointFeatureCCImpl {
     }
 
     @Override
-    public IOIterator<PointFeatureCollection> getCollectionIterator(int bufferSize) throws IOException {
+    public IOIterator<PointFeatureCollection> getCollectionIterator() throws IOException {
         return new IOIterator<PointFeatureCollection>() {
             private final Iterator<PointFeatureCollection> pfcIter = pointFeatCols.iterator();
 

--- a/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCCC.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCCC.java
@@ -28,7 +28,7 @@ public class SimplePointFeatureCCC extends PointFeatureCCCImpl {
     }
 
     @Override
-    public IOIterator<PointFeatureCC> getCollectionIterator(int bufferSize) throws IOException {
+    public IOIterator<PointFeatureCC> getCollectionIterator() throws IOException {
         return new IOIterator<PointFeatureCC>() {
             private final Iterator<PointFeatureCC> pfccIter = pointFeatCCs.iterator();
 

--- a/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCollection.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/SimplePointFeatureCollection.java
@@ -25,7 +25,7 @@ public class SimplePointFeatureCollection extends PointCollectionImpl {
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
         return new PointIteratorAdapter(pointFeats.iterator());
     }
 }

--- a/cdm/src/test/java/ucar/nc2/ft/point/SortingStationPointFeatureCacheTest.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/SortingStationPointFeatureCacheTest.java
@@ -109,7 +109,7 @@ public class SortingStationPointFeatureCacheTest {
             cache.addAll(fdInput);
 
             PointFeatureIterator pointIterExpected =
-                    new FlattenedDatasetPointCollection(fdExpected).getPointFeatureIterator(-1);
+                    new FlattenedDatasetPointCollection(fdExpected).getPointFeatureIterator();
             PointFeatureIterator pointIterActual = cache.getPointFeatureIterator();
             Assert.assertTrue(PointTestUtil.equals(pointIterExpected, pointIterActual));
         }

--- a/docs/website/tds/UpgradingTo5.adoc
+++ b/docs/website/tds/UpgradingTo5.adoc
@@ -178,6 +178,8 @@ instead of the exact comparison done by `equals(Array, Array)`.
   from _PointFeature.getFeatureCollection()_
 * In *PointFeatureIterator* and subclasses, methods _setCalculateBounds(), getDateRange(), getCalendarDateRange(), getBoundingBox(),
   getSize()_ have been removed. That information is obtained from the DsgFeatureCollection.
+* In `PointFeatureIterator` and subclasses, `setBufferSize()` bas been removed.
+* In `PointFeatureCollection` and subclasses, `getPointFeatureIterator()` no longer accepts a `bufferSize` argument.
 
 === Coverage Feature Datasets (ucar.nc2.ft2.coverage)
 

--- a/tds/src/main/java/thredds/server/ncss/view/dsg/station/AbstractStationSubsetWriter.java
+++ b/tds/src/main/java/thredds/server/ncss/view/dsg/station/AbstractStationSubsetWriter.java
@@ -32,10 +32,14 @@
  */
 package thredds.server.ncss.view.dsg.station;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
 import thredds.server.ncss.exception.FeaturesNotFoundException;
 import thredds.server.ncss.exception.NcssException;
 import thredds.server.ncss.view.dsg.DsgSubsetWriter;
-import ucar.nc2.ft.point.PointIteratorFiltered;
 import ucar.ma2.StructureData;
 import ucar.nc2.ft.DsgFeatureCollection;
 import ucar.nc2.ft.FeatureDatasetPoint;
@@ -43,9 +47,10 @@ import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.StationTimeSeriesFeature;
 import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
+import ucar.nc2.ft.point.PointIteratorFiltered;
 import ucar.nc2.ft.point.StationFeature;
-import ucar.nc2.ft.point.StationTimeSeriesFeatureImpl;
 import ucar.nc2.ft.point.StationPointFeature;
+import ucar.nc2.ft.point.StationTimeSeriesFeatureImpl;
 import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
@@ -53,11 +58,6 @@ import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Station;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by cwardgar on 2014/05/20.
@@ -189,12 +189,12 @@ public abstract class AbstractStationSubsetWriter extends DsgSubsetWriter {
     }
 
     @Override
-    public PointFeatureIterator getPointFeatureIterator(int bufferSize) throws IOException {
+    public PointFeatureIterator getPointFeatureIterator() throws IOException {
       if (closestTime == null) {
-        return stationFeat.getPointFeatureIterator(bufferSize);
+        return stationFeat.getPointFeatureIterator();
       } else {
         return new PointIteratorFiltered(
-                stationFeat.getPointFeatureIterator(bufferSize), new TimeFilter(closestTime));
+                stationFeat.getPointFeatureIterator(), new TimeFilter(closestTime));
       }
     }
   }

--- a/ui/src/main/java/ucar/nc2/ui/PointFeatureDatasetViewer.java
+++ b/ui/src/main/java/ucar/nc2/ui/PointFeatureDatasetViewer.java
@@ -502,7 +502,7 @@ public class PointFeatureDatasetViewer extends JPanel {
     List<PointObsBean> pointBeans = new ArrayList<>();
     int count = 0;
 
-    try (PointFeatureIterator iter = pointCollection.getPointFeatureIterator(-1)) {
+    try (PointFeatureIterator iter = pointCollection.getPointFeatureIterator()) {
       while (iter.hasNext() && (count++ < maxCount)) {
         PointFeature pob = iter.next();
         pointBeans.add(new PointObsBean(count++, pob));


### PR DESCRIPTION
A whole lot of code is devoted to propagating `bufferSize` through the point stack, but in practice, we're not actually taking advantage of it. In fact, if you look through the diff, you'll notice that every single time we specify a `bufferSize` value (e.g. `pointFeatureCollection.getPointFeatureIterator(-1)`), we always use `-1`, the default.

So it seems like nobody's using this feature, not even us. Furthermore, the preferred way to iterate over a `PointFeatureCollection` now is to use the for-each construct, wherein you can't specify a `bufferSize` anyway.

I'd really like to get rid of this cruft if I can. @JohnLCaron Is there any reason to keep it around?