### PR TITLE
Fix subdirectory paths of DatasetScan with spaces.

### DIFF
--- a/cdm-test/src/test/java/thredds/catalog/TestInvDatasetScan.java
+++ b/cdm-test/src/test/java/thredds/catalog/TestInvDatasetScan.java
@@ -307,6 +307,70 @@ public class TestInvDatasetScan
     compareCatalogToCatalogDocFile(catalog, expectedCatalogFile, debugShowCatalogs);
   }
 
+  @Test
+  public void testSpaces() throws IOException {
+      File syntheticDatasetDir = TestFileDirUtils.createTempDirectory( "test Top Level Catalog", dsScanTmpDir );
+      createSampleEmptyDataFilesAndDirectories( syntheticDatasetDir, CalendarDate.parseISOformat( null, "2012-05-04T12:23Z").toDate().getTime() );
+      String dsScanDir = syntheticDatasetDir.getPath();
+
+      InvCatalogImpl configCat = null;
+      try
+      {
+        configCat = new InvCatalogImpl( "Test Data Catalog for NetCDF-OPeNDAP Server", "1.0.2", new URI( baseURL) );
+      }
+      catch ( URISyntaxException e )
+      {
+        assertTrue( "Bad URI syntax <" + baseURL + ">: " + e.getMessage(),
+                false);
+      }
+
+      InvService myService = new InvService( serviceName, ServiceType.DODS.toString(),
+              baseURL, null, null );
+      configCat.addService( myService );
+
+      InvDatasetScan me = new InvDatasetScan( configCat, null, dsScanName, "space path", dsScanDir, dsScanFilter,
+              false, "false", false, null, null, null );
+
+      configCat.addDataset( me);
+
+      configCat.finish();
+      String href = me.getXlinkHref();
+
+      assertFalse("HREF should not have spaces", href.contains(" "));
+  }
+
+  @Test
+  public void testDashes() throws IOException {
+    File syntheticDatasetDir = TestFileDirUtils.createTempDirectory( "test-Top-Level-Catalog", dsScanTmpDir );
+    createSampleEmptyDataFilesAndDirectories( syntheticDatasetDir, CalendarDate.parseISOformat( null, "2012-05-04T12:23Z").toDate().getTime() );
+    String dsScanDir = syntheticDatasetDir.getPath();
+
+    InvCatalogImpl configCat = null;
+    try
+    {
+      configCat = new InvCatalogImpl( "Test Data Catalog for NetCDF-OPeNDAP Server", "1.0.2", new URI( baseURL) );
+    }
+    catch ( URISyntaxException e )
+    {
+      assertTrue( "Bad URI syntax <" + baseURL + ">: " + e.getMessage(),
+              false);
+    }
+
+    InvService myService = new InvService( serviceName, ServiceType.DODS.toString(),
+            baseURL, null, null );
+    configCat.addService( myService );
+
+    InvDatasetScan me = new InvDatasetScan( configCat, null, dsScanName, "dashed-path", dsScanDir, dsScanFilter,
+            false, "false", false, null, null, null );
+
+    configCat.addDataset( me);
+
+    configCat.finish();
+    String href = me.getXlinkHref();
+
+    assertTrue("HREF should leave dashes", href.contains("-"));
+  }
+
   // ToDo Get this test working
   //@Test
   public void testAddTimeCoverage()

--- a/cdm/src/main/java/thredds/catalog/InvCatalogRef.java
+++ b/cdm/src/main/java/thredds/catalog/InvCatalogRef.java
@@ -82,7 +82,7 @@ public class InvCatalogRef extends InvDatasetImpl {
    */
   public InvCatalogRef(InvDatasetImpl parent, String name, String href) {
     super(parent, name);
-    this.href = href.trim();
+    setXlinkHref(href);
   }
 
   /**
@@ -94,8 +94,7 @@ public class InvCatalogRef extends InvDatasetImpl {
    * @param useRemoteCatalogService : force catalogRef to go through the remoteCatalogService
    */
   public InvCatalogRef(InvDatasetImpl parent, String name, String href, Boolean useRemoteCatalogService) {
-    super(parent, name);
-    this.href = href.trim();
+    this(parent, name, href);
     this.useRemoteCatalogService = useRemoteCatalogService;
   }
 
@@ -109,7 +108,7 @@ public class InvCatalogRef extends InvDatasetImpl {
   }
 
   public void setXlinkHref(String href) {
-    this.href = href;
+    this.href = href.trim();
     this.uri = null;
   }
 
@@ -119,7 +118,7 @@ public class InvCatalogRef extends InvDatasetImpl {
   public URI getURI() {
     if (uri != null) return uri;
 
-    // may be reletive
+    // may be relative
     try {
       return getParentCatalog().resolveUri(href);
     }

--- a/cdm/src/main/java/thredds/catalog/InvDatasetScan.java
+++ b/cdm/src/main/java/thredds/catalog/InvDatasetScan.java
@@ -41,6 +41,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static ucar.nc2.util.URLnaming.escapePathForURL;
+
 import thredds.catalog.util.DeepCopyUtils;
 import thredds.cataloggen.CatalogBuilder;
 import thredds.cataloggen.CatalogRefExpander;
@@ -85,7 +87,7 @@ public class InvDatasetScan extends InvCatalogRef {
   static public void setCatalogServletName( String catServletName ) { catalogServletName = catServletName; }
   static private String makeHref(String path)
   {
-    return context+( catalogServletName == null ? "" : catalogServletName )+"/"+path+"/catalog.xml";
+    return context + (catalogServletName == null ? "" : catalogServletName) + "/" + escapePathForURL(path) + "/catalog.xml";
   }
 
   ////////////////////////////////////////////////

--- a/cdm/src/main/java/thredds/cataloggen/CollectionLevelScanner.java
+++ b/cdm/src/main/java/thredds/cataloggen/CollectionLevelScanner.java
@@ -36,6 +36,7 @@ package thredds.cataloggen;
 import thredds.catalog.*;
 import thredds.crawlabledataset.*;
 
+import static ucar.nc2.util.URLnaming.escapePathForURL;
 import java.util.*;
 import java.io.IOException;
 
@@ -900,8 +901,7 @@ public class CollectionLevelScanner
       path += "catalog.xml";
     else
       path += "/catalog.xml";
-
-    return path;
+    return escapePathForURL(path);
 //    }
 //    else
 //    {

--- a/cdm/src/main/java/ucar/nc2/util/URLnaming.java
+++ b/cdm/src/main/java/ucar/nc2/util/URLnaming.java
@@ -149,6 +149,14 @@ public class URLnaming {
     return "file:" + location;
   }
 
+  // Escape the characters necessary for a path to be valid for a URL
+  static public String escapePathForURL(String path) {
+    try {
+      return new URI(null, null, path, null).toString();
+    } catch (URISyntaxException e) {
+      return path;
+    }
+  }
   /**
    * This augments URI.resolve(), by also dealing with file: URIs.
    * If baseURi is not a file: scheme, then URI.resolve is called.


### PR DESCRIPTION
Addresses #206. Spaces are not valid for being included in a `URI`; however, many places we were taking disk paths and blindly converting to an "HREF".

This PR addresses this by taking places where we have a path that is converted to an HREF and passing it through `URI`, passing explicitly the path individually so that `URI` will escape it for us. Also adds a test for a couple odd corner cases (spaces need to be escaped, but dashes should not)