### PR TITLE
Radar server fixes

### DIFF
--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -385,10 +385,14 @@ public class RadarServerController {
         }
 
         RadarDataInventory.Query q = di.newQuery();
-        if (!setTimeLimits(q, time, start, end, period, temporal))
-            throw new UnsupportedOperationException("Either a single time " +
-                    "argument, temporal=all, or a combination of time_start, " +
-                    "time_end, and time_duration must be provided.");
+        try {
+            if (!setTimeLimits(q, time, start, end, period, temporal))
+                throw new UnsupportedOperationException("Either a single time " +
+                        "argument, temporal=all, or a combination of time_start, " +
+                        "time_end, and time_duration must be provided.");
+        } catch (ParseException e) {
+            throw new UnsupportedOperationException("Invalid time string passed: " + e.getMessage());
+        }
         StringBuilder queryString = new StringBuilder();
         addQueryElement(queryString, "time", time);
         addQueryElement(queryString, "time_start", start);


### PR DESCRIPTION
Fixes a large performance problem when querying from the large collection on AWS S3. Also improve the message when an invalid time query string is submitted.

It turns out that even though there are only ~8000 days in the AWS collection, even taking 50 ms to query what's in each one of those totals ~400 sec -> 7 minutes. Easy fix is to prune the collection of directories at each step--this is easily done now (as opposed to during initial implementation) given that we can get an appropriate time range at each directory level. This does impose the requirement that directory levels are a proper hierarchy (i.e. **NOT** /month/day/year).