### PR TITLE
S3URI now returns a stable file name for its S3Object (Fixes #255)

### DIFF
--- a/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
@@ -93,7 +93,7 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
     @Override
     public File getFile() {
         try {
-            return threddsS3Client.saveObjectToFile(s3uri, s3uri.createTempFile());
+            return threddsS3Client.saveObjectToFile(s3uri, s3uri.getTempFile());
         } catch (IOException e) {
             logger.error(String.format("Could not save S3 object '%s' to file.", s3uri), e);
             return null;

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/S3URI.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/S3URI.java
@@ -1,8 +1,7 @@
 package thredds.crawlabledataset.s3;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+
 import com.google.common.base.Preconditions;
 
 /**
@@ -18,6 +17,7 @@ import com.google.common.base.Preconditions;
 public class S3URI {
     public static final String S3_PREFIX = "s3://";
     public static final String S3_DELIMITER = "/";
+    public static final File S3ObjectTempDir = new File(System.getProperty("java.io.tmpdir"), "S3Objects");
 
     private final String bucket, key;
 
@@ -187,18 +187,16 @@ public class S3URI {
     }
 
     /**
-     * Creates an empty file in the default temporary-file directory that is scheduled for deletion upon virtual
-     * machine termination. Note that a <b>new</b> file is created <i>each</i> time this method is called.
-     * The file name will have a prefix of "S3Object", a suffix of {@code getBaseName()}, and a random string of
-     * characters between.
+     * Gets a temporary file to which the content of the S3Object that this URI points to can be downloaded.
+     * The path of the file is {@code ${java.io.tmpdir}/S3Objects/${hashCode()}/${getBaseName()}}.
+     * This method does not cause the file to be created; we're just returning a suitable path.
      *
-     * @return the path to the newly created file that did not exist before this method was invoked
-     * @throws IOException  if an I/O error occurs or the temporary-file directory does not exist
+     * @return a temporary file to which the content of the S3Object that this URI points to can be downloaded.
      */
-    public File createTempFile() throws IOException {
-        File file = Files.createTempFile("S3Object", getBaseName()).toFile();
-        file.deleteOnExit();
-        return file;
+    public File getTempFile() {
+        // To avoid collisions of files with the same name, create a parent dir named after the S3URI's hashCode().
+        File parentDir = new File(S3ObjectTempDir, String.valueOf(hashCode()));
+        return new File(parentDir, getBaseName());
     }
 
     //////////////////////////////////////// Object ////////////////////////////////////////

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
@@ -89,6 +89,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
         try {
             s3Client.getObject(new GetObjectRequest(s3uri.getBucket(), s3uri.getKey()), file);
             logger.info(String.format("Downloaded S3 object '%s' to '%s'", s3uri, file));
+            file.deleteOnExit();
             return file;
         } catch (IllegalArgumentException e) {  // Thrown by getObject() when key == null.
             logger.debug(e.getMessage());

--- a/cdm/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
+++ b/cdm/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
@@ -54,7 +54,7 @@ class CachingThreddsS3ClientSpec extends Specification {
     def "saveObjectToFile - missing key"() {
         setup: "create URI"
         S3URI s3uri = new S3URI("s3://bucket/missing-key")
-        File file = s3uri.createTempFile();
+        File file = s3uri.getTempFile();
 
         when: "caching client's saveObjectToFile() is called twice"
         cachingThreddsS3Client.saveObjectToFile(s3uri, file)
@@ -73,7 +73,7 @@ class CachingThreddsS3ClientSpec extends Specification {
     def "saveObjectToFile - redownloading cached file"() {
         setup: "create URI and File"
         S3URI s3uri = new S3URI("s3://bucket/dataset.nc")
-        File file = s3uri.createTempFile();
+        File file = createTempFile s3uri
 
         when: "caching client's saveObjectToFile() is called twice"
         cachingThreddsS3Client.saveObjectToFile(s3uri, file)
@@ -108,8 +108,8 @@ class CachingThreddsS3ClientSpec extends Specification {
     def "saveObjectToFile - download object to 2 different files"() {
         setup: "create URI and Files"
         S3URI s3uri = new S3URI("s3://bucket/dataset.nc")
-        File file1 = s3uri.createTempFile();
-        File file2 = s3uri.createTempFile();
+        File file1 = File.createTempFile("file1", ".nc")
+        File file2 = File.createTempFile("file2", ".nc")
 
         when: "caching client's saveObjectToFile() is called once with file1 and once with file2"
         cachingThreddsS3Client.saveObjectToFile(s3uri, file1)
@@ -139,9 +139,9 @@ class CachingThreddsS3ClientSpec extends Specification {
         S3URI s3uri3 = new S3URI("s3://bucket/dataset3.nc")
 
         and: "create temp files"
-        File file1 = s3uri1.createTempFile()
-        File file2 = s3uri2.createTempFile()
-        File file3 = s3uri3.createTempFile()
+        File file1 = createTempFile s3uri1
+        File file2 = createTempFile s3uri2
+        File file3 = createTempFile s3uri3
 
         and: "mocking client's saveObjectToFile() is stubbed to return file1, file2, and file3 in order"
         mockThreddsS3Client.saveObjectToFile(_, _) >>> [file1, file2, file3]
@@ -163,5 +163,12 @@ class CachingThreddsS3ClientSpec extends Specification {
         !file1.exists()
         !file2.exists()
         !file3.exists()
+    }
+
+    File createTempFile(S3URI s3URI) {
+        File file = s3URI.tempFile
+        file.parentFile.mkdirs()
+        file.createNewFile()
+        file
     }
 }

--- a/cdm/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
+++ b/cdm/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
@@ -125,6 +125,6 @@ class ThreddsS3ClientImplSpec extends Specification {
         expect: "existent bucket and key"
         threddsS3Client.getObjectMetadata(s3uri).contentType == 'fake'
         threddsS3Client.listObjects(s3uri) == null
-        threddsS3Client.saveObjectToFile(s3uri, s3uri.createTempFile()).name.endsWith('dataset.nc')
+        threddsS3Client.saveObjectToFile(s3uri, s3uri.getTempFile()).name.endsWith('dataset.nc')
     }
 }


### PR DESCRIPTION
* S3URI.createTempFile() renamed to getTempFile() to clarify that it's no longer physically creating the file.
* Tests updated to jive with that change.