### PR TITLE
Adds code highlighting to all adoc files

### DIFF
--- a/docs/website/netcdf-java/CDM/AttributeConventions.adoc
+++ b/docs/website/netcdf-java/CDM/AttributeConventions.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM Attributes
 ==============
 

--- a/docs/website/netcdf-java/CDM/CFdiff.adoc
+++ b/docs/website/netcdf-java/CDM/CFdiff.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM/CF Differences
 ==================
 

--- a/docs/website/netcdf-java/CDM/CFraggedArray.adoc
+++ b/docs/website/netcdf-java/CDM/CFraggedArray.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == 8.3 Ragged Arrays
 
 To save space in the netCDF file, it may be desirable to eliminate

--- a/docs/website/netcdf-java/CDM/CalendarDateTime.adoc
+++ b/docs/website/netcdf-java/CDM/CalendarDateTime.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CalendarDateTime
 ================
 

--- a/docs/website/netcdf-java/CDM/ClientCatalogs.adoc
+++ b/docs/website/netcdf-java/CDM/ClientCatalogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Client Catalogs
 ===============
 

--- a/docs/website/netcdf-java/CDM/CoordinateSystemsNeeded.adoc
+++ b/docs/website/netcdf-java/CDM/CoordinateSystemsNeeded.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CoordinateSystemsNeed
 =====================
 

--- a/docs/website/netcdf-java/CDM/DataType.adoc
+++ b/docs/website/netcdf-java/CDM/DataType.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CDM Data Types
 
 This document explains how CDM data types are mapped into Netcdf-Java objects for version 5.0+. An IOSP chooses

--- a/docs/website/netcdf-java/CDM/Identifiers.adoc
+++ b/docs/website/netcdf-java/CDM/Identifiers.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM Object Names
 ================
 

--- a/docs/website/netcdf-java/CDM/Netcdf4.adoc
+++ b/docs/website/netcdf-java/CDM/Netcdf4.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM/Netcdf4 Mapping
 ===================
 

--- a/docs/website/netcdf-java/CDM/Netcdf4CompoundAttributes.adoc
+++ b/docs/website/netcdf-java/CDM/Netcdf4CompoundAttributes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Netcdf4 Compound Attributes
 ===========================
 

--- a/docs/website/netcdf-java/CDM/Opendap.adoc
+++ b/docs/website/netcdf-java/CDM/Opendap.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM/OPeNDAP
 ===========
 

--- a/docs/website/netcdf-java/CDM/SectionSpec.adoc
+++ b/docs/website/netcdf-java/CDM/SectionSpec.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM Section Spec
 ================
 

--- a/docs/website/netcdf-java/CDM/ThreddsCatalogs.adoc
+++ b/docs/website/netcdf-java/CDM/ThreddsCatalogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS Catalogs
 ================
 

--- a/docs/website/netcdf-java/CDM/Time.adoc
+++ b/docs/website/netcdf-java/CDM/Time.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CalendarDateTime
 ================
 

--- a/docs/website/netcdf-java/CDM/VariableLengthData.adoc
+++ b/docs/website/netcdf-java/CDM/VariableLengthData.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Variable Length Data
 
 == Variable Length Data

--- a/docs/website/netcdf-java/CDM/index.adoc
+++ b/docs/website/netcdf-java/CDM/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Common Data Model
 
 == Overview

--- a/docs/website/netcdf-java/NetcdfUsers.adoc
+++ b/docs/website/netcdf-java/NetcdfUsers.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Netcdf Users
 ============
 

--- a/docs/website/netcdf-java/documentation.adoc
+++ b/docs/website/netcdf-java/documentation.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 :tdsDocs: ../tds/reference
 
 = image:netcdfBig.gif[image] NetCDF-Java Library

--- a/docs/website/netcdf-java/index.adoc
+++ b/docs/website/netcdf-java/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Unidata | NetCDF Java
 =====================
 

--- a/docs/website/netcdf-java/internal/Cache.adoc
+++ b/docs/website/netcdf-java/internal/Cache.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/netcdf-java/internal/DataReading.adoc
+++ b/docs/website/netcdf-java/internal/DataReading.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Data Reading
 ============
 

--- a/docs/website/netcdf-java/internal/EncodingCdmDataProto.adoc
+++ b/docs/website/netcdf-java/internal/EncodingCdmDataProto.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Encoding CDM Data in protobuf
 
 == design goals

--- a/docs/website/netcdf-java/internal/GribNotes.adoc
+++ b/docs/website/netcdf-java/internal/GribNotes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/netcdf-java/internal/transition4.adoc
+++ b/docs/website/netcdf-java/internal/transition4.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Transition to 4.0
 =================
 

--- a/docs/website/netcdf-java/metadata/DataDiscoveryAttConvention-Issues-ToDo.adoc
+++ b/docs/website/netcdf-java/metadata/DataDiscoveryAttConvention-Issues-ToDo.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 ncACDD - Issues/ToDo
 ====================
 :author: Ethan Davis

--- a/docs/website/netcdf-java/metadata/DataDiscoveryAttConvention.adoc
+++ b/docs/website/netcdf-java/metadata/DataDiscoveryAttConvention.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Dataset Discovery NetCDF Attribute Convention
 =============================================
 :author: Ethan Davis

--- a/docs/website/netcdf-java/metadata/ncACDD-metadataMappings.adoc
+++ b/docs/website/netcdf-java/metadata/ncACDD-metadataMappings.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Metadata Mappings
 =================
 :author: Ethan Davis

--- a/docs/website/netcdf-java/ncml/Aggregation.adoc
+++ b/docs/website/netcdf-java/ncml/Aggregation.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Aggregating netCDF files with netCDF Datasets
 =============================================
 

--- a/docs/website/netcdf-java/ncml/AnnotatedSchema4.adoc
+++ b/docs/website/netcdf-java/ncml/AnnotatedSchema4.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NcML Schema
 ===========
 

--- a/docs/website/netcdf-java/ncml/Cookbook.adoc
+++ b/docs/website/netcdf-java/ncml/Cookbook.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NcML Cookbook
 =============
 

--- a/docs/website/netcdf-java/ncml/FmrcAggregation.adoc
+++ b/docs/website/netcdf-java/ncml/FmrcAggregation.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 FMRC Aggregation
 ================
 

--- a/docs/website/netcdf-java/ncml/Formica.adoc
+++ b/docs/website/netcdf-java/ncml/Formica.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/netcdf-java/ncml/LogicalView.adoc
+++ b/docs/website/netcdf-java/ncml/LogicalView.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/netcdf-java/ncml/Tutorial.adoc
+++ b/docs/website/netcdf-java/ncml/Tutorial.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NcML Tutorial - Basic
 =====================
 

--- a/docs/website/netcdf-java/ncml/faq.adoc
+++ b/docs/website/netcdf-java/ncml/faq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NcML FAQ
 ========
 

--- a/docs/website/netcdf-java/ncml/index.adoc
+++ b/docs/website/netcdf-java/ncml/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetCDF Markup Language
 ======================
 

--- a/docs/website/netcdf-java/ncml/reference.adoc
+++ b/docs/website/netcdf-java/ncml/reference.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NcML Reference
 ==============
 

--- a/docs/website/netcdf-java/reference/Auth.adoc
+++ b/docs/website/netcdf-java/reference/Auth.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Auth
 ====
 

--- a/docs/website/netcdf-java/reference/Caching.adoc
+++ b/docs/website/netcdf-java/reference/Caching.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM Caching
 ===========
 

--- a/docs/website/netcdf-java/reference/Cookbook.adoc
+++ b/docs/website/netcdf-java/reference/Cookbook.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Cookbook
 ========
 

--- a/docs/website/netcdf-java/reference/CoordinateAttributes.adoc
+++ b/docs/website/netcdf-java/reference/CoordinateAttributes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 _Coordinate Attribute Convention
 ================================
 

--- a/docs/website/netcdf-java/reference/DatasetUrls.adoc
+++ b/docs/website/netcdf-java/reference/DatasetUrls.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Dataset URLs
 
 The netCDF-Java library can read *datasets* from a variety of sources.

--- a/docs/website/netcdf-java/reference/FeatureDatasets/CFencoding.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/CFencoding.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CF encoding of Point Observation Datasets
 
 === CDM table notation

--- a/docs/website/netcdf-java/reference/FeatureDatasets/CFencodingTable.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/CFencodingTable.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CF encoding Table
 =================
 

--- a/docs/website/netcdf-java/reference/FeatureDatasets/CFpointImplement.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/CFpointImplement.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CDM implementation of CF discrete sampling features
 
 These notes refer to the current release of CDM.

--- a/docs/website/netcdf-java/reference/FeatureDatasets/CoverageFeatures.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/CoverageFeatures.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Coverage Datasets
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/FeatureDatasets/Fmrc.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/Fmrc.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Forecast Model Run Collection (FMRC)
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/FeatureDatasets/Overview.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/Overview.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Feature Datasets
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/FeatureDatasets/PointFeatures.adoc
+++ b/docs/website/netcdf-java/reference/FeatureDatasets/PointFeatures.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Point Feature Datasets
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/HTTPauthentication.adoc
+++ b/docs/website/netcdf-java/reference/HTTPauthentication.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 HTTP Authentication
 ===================
 

--- a/docs/website/netcdf-java/reference/HTTPservice.adoc
+++ b/docs/website/netcdf-java/reference/HTTPservice.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 HTTP reading
 ============
 

--- a/docs/website/netcdf-java/reference/RuntimeLoading.adoc
+++ b/docs/website/netcdf-java/reference/RuntimeLoading.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Runtime Loading
 
 These are the various classes that can be plugged in at runtime:

--- a/docs/website/netcdf-java/reference/Session.adoc
+++ b/docs/website/netcdf-java/reference/Session.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Session
 =======
 

--- a/docs/website/netcdf-java/reference/StandardCoordinateTransforms.adoc
+++ b/docs/website/netcdf-java/reference/StandardCoordinateTransforms.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Standard Horizontal Transforms
 ==============================
 

--- a/docs/website/netcdf-java/reference/StandardVerticalTransforms.adoc
+++ b/docs/website/netcdf-java/reference/StandardVerticalTransforms.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Standard Vertical Transforms
 ============================
 

--- a/docs/website/netcdf-java/reference/StructureData.adoc
+++ b/docs/website/netcdf-java/reference/StructureData.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 ArrayStructures
 ===============
 

--- a/docs/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
+++ b/docs/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = ToolsUI
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/faq.adoc
+++ b/docs/website/netcdf-java/reference/faq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 FAQ
 ===
 

--- a/docs/website/netcdf-java/reference/formats/BufrFiles.adoc
+++ b/docs/website/netcdf-java/reference/formats/BufrFiles.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 BUFR Files
 ==========
 

--- a/docs/website/netcdf-java/reference/formats/BufrTables.adoc
+++ b/docs/website/netcdf-java/reference/formats/BufrTables.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM BUFR Tables
 ===============
 

--- a/docs/website/netcdf-java/reference/formats/FileTypes.adoc
+++ b/docs/website/netcdf-java/reference/formats/FileTypes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM FileTypes
 =============
 

--- a/docs/website/netcdf-java/reference/formats/GribFiles.adoc
+++ b/docs/website/netcdf-java/reference/formats/GribFiles.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Collection
 ===============
 

--- a/docs/website/netcdf-java/reference/formats/GribTables.adoc
+++ b/docs/website/netcdf-java/reference/formats/GribTables.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Tables in CDM
 ==================
 

--- a/docs/website/netcdf-java/reference/formats/NestedStructures.adoc
+++ b/docs/website/netcdf-java/reference/formats/NestedStructures.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Structures in NetCDF-3
 ======================
 

--- a/docs/website/netcdf-java/reference/formats/RadarDataFormat.adoc
+++ b/docs/website/netcdf-java/reference/formats/RadarDataFormat.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Radar Data Format
 =================
 

--- a/docs/website/netcdf-java/reference/formats/RecordsInNetcdf3.adoc
+++ b/docs/website/netcdf-java/reference/formats/RecordsInNetcdf3.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Records in NetCDF-3
 ===================
 

--- a/docs/website/netcdf-java/reference/index.adoc
+++ b/docs/website/netcdf-java/reference/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetCDF-Java Reference
 =====================
 

--- a/docs/website/netcdf-java/reference/manPages.adoc
+++ b/docs/website/netcdf-java/reference/manPages.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 CDM man pages
 =============
 

--- a/docs/website/netcdf-java/reference/netcdf4Clibrary.adoc
+++ b/docs/website/netcdf-java/reference/netcdf4Clibrary.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetCDF-4 C library
 ==================
 

--- a/docs/website/netcdf-java/reference/stream/CdmRemote.adoc
+++ b/docs/website/netcdf-java/reference/stream/CdmRemote.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CDM Remote Web Service
 :tdsDocs: ../../../tds/reference/services
 

--- a/docs/website/netcdf-java/reference/stream/CdmrCoverageParams.adoc
+++ b/docs/website/netcdf-java/reference/stream/CdmrCoverageParams.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Subsetting Parameters for Grid (Coverage) Datasets:
 ===================================================
 

--- a/docs/website/netcdf-java/reference/stream/CdmrFeature.adoc
+++ b/docs/website/netcdf-java/reference/stream/CdmrFeature.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CdmrFeature Web Service
 :tdsDocs: ../../../tds/reference/services
 

--- a/docs/website/netcdf-java/reference/stream/CdmrFeaturePoint.adoc
+++ b/docs/website/netcdf-java/reference/stream/CdmrFeaturePoint.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CDM Remote Feature for Point Data
 :tdsDocs: ../../../tds/reference/services
 :w3cDate: {tdsDocs}/NetcdfSubsetServiceReference.adoc#W3Cdate

--- a/docs/website/netcdf-java/reference/stream/CdmrfGrammer.adoc
+++ b/docs/website/netcdf-java/reference/stream/CdmrfGrammer.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = CdmrFeature Grammer (DRAFT)
 :linkcss:
 :stylesheet: ../../cdm.css

--- a/docs/website/netcdf-java/reference/stream/NcStream.adoc
+++ b/docs/website/netcdf-java/reference/stream/NcStream.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetCDF Streaming Format
 -----------------------
 

--- a/docs/website/netcdf-java/reference/stream/NcStreamGrammer.adoc
+++ b/docs/website/netcdf-java/reference/stream/NcStreamGrammer.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Ncstream Grammar
 
 == Version 2 (DRAFT)

--- a/docs/website/netcdf-java/reference/stream/OpendapDiscussion.adoc
+++ b/docs/website/netcdf-java/reference/stream/OpendapDiscussion.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == Datasets that change email discussion on dods-tech (Dec 2005)
 
 John wrote:

--- a/docs/website/netcdf-java/tutorial/Contributing.adoc
+++ b/docs/website/netcdf-java/tutorial/Contributing.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 :stylesheet: ../../tds/tutorial/tutorial_adoc.css
 :linkcss:
 

--- a/docs/website/netcdf-java/tutorial/CoordSysBuilder.adoc
+++ b/docs/website/netcdf-java/tutorial/CoordSysBuilder.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Building Coordinate Systems
 ===========================
 

--- a/docs/website/netcdf-java/tutorial/CoordTransBuilder.adoc
+++ b/docs/website/netcdf-java/tutorial/CoordTransBuilder.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Writing a Coordinate Transform implementation
 =============================================
 

--- a/docs/website/netcdf-java/tutorial/CoordinateAttributes.adoc
+++ b/docs/website/netcdf-java/tutorial/CoordinateAttributes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 _Coordinate Tutorial
 ====================
 

--- a/docs/website/netcdf-java/tutorial/GridDatatype.adoc
+++ b/docs/website/netcdf-java/tutorial/GridDatatype.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Grid Feature Type
 =================
 

--- a/docs/website/netcdf-java/tutorial/IOSPbackground.adoc
+++ b/docs/website/netcdf-java/tutorial/IOSPbackground.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 IOSP Other Classes
 ==================
 

--- a/docs/website/netcdf-java/tutorial/IOSPdetails.adoc
+++ b/docs/website/netcdf-java/tutorial/IOSPdetails.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 IOSP Details
 ============
 

--- a/docs/website/netcdf-java/tutorial/IOSPexample1.adoc
+++ b/docs/website/netcdf-java/tutorial/IOSPexample1.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 IOSP Example 1
 ==============
 

--- a/docs/website/netcdf-java/tutorial/IOSPoverview.adoc
+++ b/docs/website/netcdf-java/tutorial/IOSPoverview.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 IOSP Overview
 =============
 

--- a/docs/website/netcdf-java/tutorial/IOSPoverview4.adoc
+++ b/docs/website/netcdf-java/tutorial/IOSPoverview4.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 IOSP Overview 4
 ===============
 

--- a/docs/website/netcdf-java/tutorial/NetcdfDataset.adoc
+++ b/docs/website/netcdf-java/tutorial/NetcdfDataset.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetcdfDataset Tutorial
 ======================
 

--- a/docs/website/netcdf-java/tutorial/NetcdfFileWriteable.adoc
+++ b/docs/website/netcdf-java/tutorial/NetcdfFileWriteable.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 NetcdfFileWriteable Tutorial
 ============================
 

--- a/docs/website/netcdf-java/tutorial/NetcdfWriting.adoc
+++ b/docs/website/netcdf-java/tutorial/NetcdfWriting.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Netcdf File Writing
 ===================
 

--- a/docs/website/netcdf-java/tutorial/RadialDatatype.adoc
+++ b/docs/website/netcdf-java/tutorial/RadialDatatype.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 The Radial Datatype
 ===================
 

--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 :stylesheet: ../../tds/tutorial/tutorial_adoc.css
 :linkcss:
 

--- a/docs/website/netcdf-java/tutorial/index.adoc
+++ b/docs/website/netcdf-java/tutorial/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Netcdf Java Tutorial
 ====================
 

--- a/docs/website/tds/README.adoc
+++ b/docs/website/tds/README.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = *THREDDS Data Server* 5.0
 
 == Overview

--- a/docs/website/tds/SUMMARY.adoc
+++ b/docs/website/tds/SUMMARY.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 # Summary
 
 Documentation for the THREDDS Data Server.

--- a/docs/website/tds/TDS.adoc
+++ b/docs/website/tds/TDS.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS
 ===
 

--- a/docs/website/tds/UpgradingTo4.5.adoc
+++ b/docs/website/tds/UpgradingTo4.5.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Upgrading To TDS 4.5
 ====================
 

--- a/docs/website/tds/UpgradingTo4.6.adoc
+++ b/docs/website/tds/UpgradingTo4.6.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Upgrading To TDS 4.6
 ====================
 

--- a/docs/website/tds/catalog/CatalogNotes.adoc
+++ b/docs/website/tds/catalog/CatalogNotes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Catalog Notes
 =============
 

--- a/docs/website/tds/catalog/Changes.adoc
+++ b/docs/website/tds/catalog/Changes.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Catalog Changes
 ===============
 

--- a/docs/website/tds/catalog/InvCatalogServerSpec.adoc
+++ b/docs/website/tds/catalog/InvCatalogServerSpec.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Server-side Catalog Specification +
 
 '''''

--- a/docs/website/tds/catalog/InvCatalogSpec.adoc
+++ b/docs/website/tds/catalog/InvCatalogSpec.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = THREDDS Client Catalog Specification
 
 A THREDDS catalog is a way to describe an inventory of available

--- a/docs/website/tds/catalog/index.adoc
+++ b/docs/website/tds/catalog/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS Catalogs
 ================
 

--- a/docs/website/tds/docinfo-footer.adoc
+++ b/docs/website/tds/docinfo-footer.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Verion: \{tdsversion} +
  Last updated: \{docdatetime} +
  +

--- a/docs/website/tds/faq.adoc
+++ b/docs/website/tds/faq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = image:unidataLogo.png[Unidata]THREDDS Data Server (TDS) FAQ
 
 '''''

--- a/docs/website/tds/index_ud.adoc
+++ b/docs/website/tds/index_ud.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Unidata | THREDDS Data Server (TDS)
 ===================================
 

--- a/docs/website/tds/internal/Caching.adoc
+++ b/docs/website/tds/internal/Caching.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Caching
 ===========
 

--- a/docs/website/tds/internal/GribCollectionInternal.adoc
+++ b/docs/website/tds/internal/GribCollectionInternal.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Feature Collections (Internal docs)
 ========================================
 

--- a/docs/website/tds/internal/GribColllections.adoc
+++ b/docs/website/tds/internal/GribColllections.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Collection Internals
 =========================
 

--- a/docs/website/tds/internal/JMX.adoc
+++ b/docs/website/tds/internal/JMX.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/tds/internal/Logging.adoc
+++ b/docs/website/tds/internal/Logging.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Logging
 ===========
 

--- a/docs/website/tds/internal/Paths.adoc
+++ b/docs/website/tds/internal/Paths.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 URL Paths
 =========
 

--- a/docs/website/tds/internal/REST.adoc
+++ b/docs/website/tds/internal/REST.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/tds/internal/Sessions.adoc
+++ b/docs/website/tds/internal/Sessions.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/tds/internal/SpringConfiguration.adoc
+++ b/docs/website/tds/internal/SpringConfiguration.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Spring Configuration
 ====================
 

--- a/docs/website/tds/internal/Troubleshooting.adoc
+++ b/docs/website/tds/internal/Troubleshooting.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Troubleshooting TDS
 ===================
 

--- a/docs/website/tds/internal/backlogs.adoc
+++ b/docs/website/tds/internal/backlogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS Group - Planning
 ========================
 

--- a/docs/website/tds/internal/catalog2.adoc
+++ b/docs/website/tds/internal/catalog2.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 thredds.catalog2 Development
 ============================
 

--- a/docs/website/tds/internal/featureCollectionInternals.adoc
+++ b/docs/website/tds/internal/featureCollectionInternals.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Feature Collections
 ===================
 

--- a/docs/website/tds/internal/latest.adoc
+++ b/docs/website/tds/internal/latest.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Untitled Document
 =================
 

--- a/docs/website/tds/internal/motherlode.adoc
+++ b/docs/website/tds/internal/motherlode.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS Motherlode Server Information
 =====================================
 

--- a/docs/website/tds/internal/tdsUrls.adoc
+++ b/docs/website/tds/internal/tdsUrls.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS URLs
 ========
 

--- a/docs/website/tds/reference/AccessLog.adoc
+++ b/docs/website/tds/reference/AccessLog.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS - Setup Access Logging
 ==========================
 

--- a/docs/website/tds/reference/CatalogService.adoc
+++ b/docs/website/tds/reference/CatalogService.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Catalog Service
 ===============
 

--- a/docs/website/tds/reference/ChecklistReference.adoc
+++ b/docs/website/tds/reference/ChecklistReference.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Checklist
 =========
 

--- a/docs/website/tds/reference/DLexport.adoc
+++ b/docs/website/tds/reference/DLexport.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Exporting to Digital Libraries
 ==============================
 

--- a/docs/website/tds/reference/DatasetScan.adoc
+++ b/docs/website/tds/reference/DatasetScan.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Configuration - datasetScan
 ===============================
 

--- a/docs/website/tds/reference/DatasetSource.adoc
+++ b/docs/website/tds/reference/DatasetSource.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 DatasetSource
 =============
 

--- a/docs/website/tds/reference/DigitalLibraries.adoc
+++ b/docs/website/tds/reference/DigitalLibraries.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Digital Library Record Generation and Harvesting
 ================================================
 

--- a/docs/website/tds/reference/DirectoryLocations.adoc
+++ b/docs/website/tds/reference/DirectoryLocations.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Location of TDS Directories
 ===========================
 

--- a/docs/website/tds/reference/HTTPsecurityChallenge.adoc
+++ b/docs/website/tds/reference/HTTPsecurityChallenge.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 HTTP Security Challenge
 =======================
 

--- a/docs/website/tds/reference/Performance.adoc
+++ b/docs/website/tds/reference/Performance.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Server Performance
 
 '''''

--- a/docs/website/tds/reference/PluggableRestrictedAccess.adoc
+++ b/docs/website/tds/reference/PluggableRestrictedAccess.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Pluggable Authentication
 ========================
 

--- a/docs/website/tds/reference/RecommendedUpgradeProcessForTDS.adoc
+++ b/docs/website/tds/reference/RecommendedUpgradeProcessForTDS.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Recommended Process for Upgrading a THREDDS Data Server (TDS)
 =============================================================
 

--- a/docs/website/tds/reference/RemoteManagement.adoc
+++ b/docs/website/tds/reference/RemoteManagement.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Remote Management
 =================
 

--- a/docs/website/tds/reference/RestrictedAccess.adoc
+++ b/docs/website/tds/reference/RestrictedAccess.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Restricting Access to Datasets in the TDS
 
 '''''

--- a/docs/website/tds/reference/RunningMultipleTDS.adoc
+++ b/docs/website/tds/reference/RunningMultipleTDS.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Reference: Running Multiple TDS
 ===================================
 

--- a/docs/website/tds/reference/Services.adoc
+++ b/docs/website/tds/reference/Services.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Services
 ============
 

--- a/docs/website/tds/reference/ServletLog.adoc
+++ b/docs/website/tds/reference/ServletLog.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Logging
 ===========
 

--- a/docs/website/tds/reference/ThreddsConfigXMLFile.adoc
+++ b/docs/website/tds/reference/ThreddsConfigXMLFile.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Configuration file
 
 '''''

--- a/docs/website/tds/reference/TomcatBehindProxyServer.adoc
+++ b/docs/website/tds/reference/TomcatBehindProxyServer.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Running The TDS Behind a Proxy Server
 =====================================
 

--- a/docs/website/tds/reference/TomcatSecurity.adoc
+++ b/docs/website/tds/reference/TomcatSecurity.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Tomcat Security
 ===============
 

--- a/docs/website/tds/reference/Viewers.adoc
+++ b/docs/website/tds/reference/Viewers.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Dataset Viewer Links
 
 '''''

--- a/docs/website/tds/reference/WCS.adoc
+++ b/docs/website/tds/reference/WCS.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS WCS Server
 ==================
 

--- a/docs/website/tds/reference/WMS.adoc
+++ b/docs/website/tds/reference/WMS.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Web Map Service (WMS)
 
 '''''

--- a/docs/website/tds/reference/collections/CollectionSpecification.adoc
+++ b/docs/website/tds/reference/collections/CollectionSpecification.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Collection Specification String
 ===============================
 

--- a/docs/website/tds/reference/collections/FCvsAgg.adoc
+++ b/docs/website/tds/reference/collections/FCvsAgg.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Feature Collections vs Aggregations
 ===================================
 

--- a/docs/website/tds/reference/collections/FmrcCollection.adoc
+++ b/docs/website/tds/reference/collections/FmrcCollection.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = FMRC Collections
 
 A __*Forecast Model Run Collection (FMRC)*__ is a  __**collection of

--- a/docs/website/tds/reference/collections/GribCollectionFaq.adoc
+++ b/docs/website/tds/reference/collections/GribCollectionFaq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Feature Collections FAQ
 ============================
 

--- a/docs/website/tds/reference/collections/GribCollections.adoc
+++ b/docs/website/tds/reference/collections/GribCollections.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = GRIB Feature Collections
 
 '''''

--- a/docs/website/tds/reference/collections/GribConfig.adoc
+++ b/docs/website/tds/reference/collections/GribConfig.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 GRIB Collections Configuration
 ==============================
 

--- a/docs/website/tds/reference/collections/Partitions.adoc
+++ b/docs/website/tds/reference/collections/Partitions.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Partitions
 ==========
 

--- a/docs/website/tds/reference/collections/PointFeatures.adoc
+++ b/docs/website/tds/reference/collections/PointFeatures.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Point Feature Collections
 =========================
 

--- a/docs/website/tds/reference/collections/SimpleDateFormat.adoc
+++ b/docs/website/tds/reference/collections/SimpleDateFormat.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 SimpleDateFormat
 ================
 

--- a/docs/website/tds/reference/collections/TDM.adoc
+++ b/docs/website/tds/reference/collections/TDM.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDM
 ===
 

--- a/docs/website/tds/reference/index.adoc
+++ b/docs/website/tds/reference/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Reference
 =============
 

--- a/docs/website/tds/reference/ncISO.adoc
+++ b/docs/website/tds/reference/ncISO.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS and ncISO: Metadata Services
 
 '''''

--- a/docs/website/tds/reference/radarServer/RadarLevel2SubsetService.adoc
+++ b/docs/website/tds/reference/radarServer/RadarLevel2SubsetService.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Subset Service
 ==============
 

--- a/docs/website/tds/reference/radarServer/RadarLevel3SubsetService.adoc
+++ b/docs/website/tds/reference/radarServer/RadarLevel3SubsetService.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Subset Service
 ==============
 

--- a/docs/website/tds/reference/services/NetcdfSubsetServiceConfigure.adoc
+++ b/docs/website/tds/reference/services/NetcdfSubsetServiceConfigure.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Configuring the NetCDF Subset Service
 
 '''''

--- a/docs/website/tds/tutorial/AddingServices.adoc
+++ b/docs/website/tds/tutorial/AddingServices.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = OGC/ISO Services (WCS, WMS, and ncISO)
 
 == Setting up WCS, WMS, and ncISO

--- a/docs/website/tds/tutorial/AdditionalSecurityConfiguration.adoc
+++ b/docs/website/tds/tutorial/AdditionalSecurityConfiguration.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Tutorial: Additional Security Configuration
 ===============================================
 

--- a/docs/website/tds/tutorial/BasicConfigCatalogs.adoc
+++ b/docs/website/tds/tutorial/BasicConfigCatalogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = THREDDS Configuration Catalogs
 
 == TDS Content Directory

--- a/docs/website/tds/tutorial/BasicThreddsConfig_xml.adoc
+++ b/docs/website/tds/tutorial/BasicThreddsConfig_xml.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Basic threddsConfig.xml
 
 == TDS Configuration File threddsConfig.xml

--- a/docs/website/tds/tutorial/BasicTomcatAndTDSSecurity.adoc
+++ b/docs/website/tds/tutorial/BasicTomcatAndTDSSecurity.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Tutorial: Basic Tomcat and TDS Security
 ===========================================
 

--- a/docs/website/tds/tutorial/CatalogPrimer.adoc
+++ b/docs/website/tds/tutorial/CatalogPrimer.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = THREDDS Client Catalog Primer
 
 == What this tutorial covers

--- a/docs/website/tds/tutorial/Checklist.adoc
+++ b/docs/website/tds/tutorial/Checklist.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Installation Checklist for Production Security
 
 == Initial Installation

--- a/docs/website/tds/tutorial/ConfigCatalogs.adoc
+++ b/docs/website/tds/tutorial/ConfigCatalogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Configuration Catalogs
 
 == The `service` Element

--- a/docs/website/tds/tutorial/DAP.adoc
+++ b/docs/website/tds/tutorial/DAP.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 OPeNDAP DAP2 and DAP4 Protocol Services
 =======================================
 

--- a/docs/website/tds/tutorial/FmrcFeatureCollectionsTutorial.adoc
+++ b/docs/website/tds/tutorial/FmrcFeatureCollectionsTutorial.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = FMRC Feature Collection
 
 == FMRC Feature Collection

--- a/docs/website/tds/tutorial/FreeMonitoringAndDebuggingTools.adoc
+++ b/docs/website/tds/tutorial/FreeMonitoringAndDebuggingTools.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Free Monitoring and Debugging Tools
 ===================================
 

--- a/docs/website/tds/tutorial/GRIBFeatureCollectionTutorial.adoc
+++ b/docs/website/tds/tutorial/GRIBFeatureCollectionTutorial.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = GRIB Feature Collection Tutorial
 
 == GRIB Feature Collection

--- a/docs/website/tds/tutorial/GettingStarted.adoc
+++ b/docs/website/tds/tutorial/GettingStarted.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 :coderays:
 
 = Getting Started With the TDS: Local Test Server Setup

--- a/docs/website/tds/tutorial/GribCollectionExamples.adoc
+++ b/docs/website/tds/tutorial/GribCollectionExamples.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Grib Collections
 
 A GRIB Collection is a collection of files that have GRIB records in

--- a/docs/website/tds/tutorial/Metadata.adoc
+++ b/docs/website/tds/tutorial/Metadata.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = THREDDS and Metadata
 
 The term **metadata** refers to ``data about data''. The term is

--- a/docs/website/tds/tutorial/MoreThreddsConfig_xml.adoc
+++ b/docs/website/tds/tutorial/MoreThreddsConfig_xml.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 More on the TDS Configuration File
 ==================================
 

--- a/docs/website/tds/tutorial/NcML.adoc
+++ b/docs/website/tds/tutorial/NcML.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Using NcML in TDS
 
 == NCML and the TDS

--- a/docs/website/tds/tutorial/NcMLAggExamples.adoc
+++ b/docs/website/tds/tutorial/NcMLAggExamples.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = NcML Aggregation Examples
 
 Our goal in this section is to aggregate datafiles using NcML.

--- a/docs/website/tds/tutorial/NcMLExamples.adoc
+++ b/docs/website/tds/tutorial/NcMLExamples.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = NcML Examples
 
 Our goal in this section is to enhance two sample datasets using NcML.

--- a/docs/website/tds/tutorial/Security.adoc
+++ b/docs/website/tds/tutorial/Security.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Production Server Overview
 
 == What This Section Covers

--- a/docs/website/tds/tutorial/Subset.adoc
+++ b/docs/website/tds/tutorial/Subset.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Dataset Subsetting
 ==================
 

--- a/docs/website/tds/tutorial/TDSMonitoringAndDebugging.adoc
+++ b/docs/website/tds/tutorial/TDSMonitoringAndDebugging.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Monitoring and Debugging
 
 == What This Section Covers

--- a/docs/website/tds/tutorial/TomcatAndTDSLogs.adoc
+++ b/docs/website/tds/tutorial/TomcatAndTDSLogs.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = TDS Monitoring and Debugging: Logs!
 
 == What This Section Covers

--- a/docs/website/tds/tutorial/TroubleShooting.adoc
+++ b/docs/website/tds/tutorial/TroubleShooting.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = Troubleshooting Configuration Catalogs
 
 == Check log files for errors

--- a/docs/website/tds/tutorial/cssdocs/_exercise.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_exercise.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/_note.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_note.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/_section.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_section.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 

--- a/docs/website/tds/tutorial/cssdocs/_subsection.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_subsection.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 == SECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/_subsectionq.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_subsectionq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/_subsectionts.adoc
+++ b/docs/website/tds/tutorial/cssdocs/_subsectionts.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/ahead.adoc
+++ b/docs/website/tds/tutorial/cssdocs/ahead.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/code.adoc
+++ b/docs/website/tds/tutorial/cssdocs/code.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 `Lorem ipsum`

--- a/docs/website/tds/tutorial/cssdocs/codes.adoc
+++ b/docs/website/tds/tutorial/cssdocs/codes.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 `   Lorem ipsum`

--- a/docs/website/tds/tutorial/cssdocs/css.adoc
+++ b/docs/website/tds/tutorial/cssdocs/css.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Tutorial: PAGE TITLE
 ========================
 

--- a/docs/website/tds/tutorial/cssdocs/exercise.adoc
+++ b/docs/website/tds/tutorial/cssdocs/exercise.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/h1.adoc
+++ b/docs/website/tds/tutorial/cssdocs/h1.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 = TDS Tutorial: PAGE TITLE

--- a/docs/website/tds/tutorial/cssdocs/info.adoc
+++ b/docs/website/tds/tutorial/cssdocs/info.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/listp.adoc
+++ b/docs/website/tds/tutorial/cssdocs/listp.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/listpre.adoc
+++ b/docs/website/tds/tutorial/cssdocs/listpre.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/listq.adoc
+++ b/docs/website/tds/tutorial/cssdocs/listq.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/listqp.adoc
+++ b/docs/website/tds/tutorial/cssdocs/listqp.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/listx2.adoc
+++ b/docs/website/tds/tutorial/cssdocs/listx2.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/note.adoc
+++ b/docs/website/tds/tutorial/cssdocs/note.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/notep.adoc
+++ b/docs/website/tds/tutorial/cssdocs/notep.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/noteul.adoc
+++ b/docs/website/tds/tutorial/cssdocs/noteul.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/questionp.adoc
+++ b/docs/website/tds/tutorial/cssdocs/questionp.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/reminder.adoc
+++ b/docs/website/tds/tutorial/cssdocs/reminder.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/section.adoc
+++ b/docs/website/tds/tutorial/cssdocs/section.adoc
@@ -1,1 +1,3 @@
+:source-highlighter: coderay
+
 == SECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/subsection.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsection.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE 1

--- a/docs/website/tds/tutorial/cssdocs/subsectionnote.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsectionnote.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/subsectionol.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsectionol.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/subsectionp.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsectionp.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/subsectionts.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsectionts.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/subsectionul.adoc
+++ b/docs/website/tds/tutorial/cssdocs/subsectionul.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/cssdocs/tslist.adoc
+++ b/docs/website/tds/tutorial/cssdocs/tslist.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 == SECTION TITLE
 
 === SUBSECTION TITLE

--- a/docs/website/tds/tutorial/examples/accessingTDSMonitoringAndDebuggingTools.adoc
+++ b/docs/website/tds/tutorial/examples/accessingTDSMonitoringAndDebuggingTools.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 === Accessing TDS Monitoring and Debugging Tools
 
 Other than the compelling security reasons, you will want to enable SSL

--- a/docs/website/tds/tutorial/examples/digestedPasswords.adoc
+++ b/docs/website/tds/tutorial/examples/digestedPasswords.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 === Configure Tomcat to use digested passwords
 
 1.  First we need to enable digest passwords support in Tomcat by

--- a/docs/website/tds/tutorial/examples/enablingSSL.adoc
+++ b/docs/website/tds/tutorial/examples/enablingSSL.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 === Enabling SSL in Tomcat
 
 Modify the Tomcat configuration to enable SSL:

--- a/docs/website/tds/tutorial/examples/tomcatHomePerms.adoc
+++ b/docs/website/tds/tutorial/examples/tomcatHomePerms.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 === Restrict the permissions in `${tomcat_home}`
 
 1.  Change the user/group ownership `${tomcat_home}` to the `tomcat`

--- a/docs/website/tds/tutorial/examples/tomcatManagerSSL.adoc
+++ b/docs/website/tds/tutorial/examples/tomcatManagerSSL.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 Production Server Overview
 ==========================
 

--- a/docs/website/tds/tutorial/examples/tomcatUserAndGroup.adoc
+++ b/docs/website/tds/tutorial/examples/tomcatUserAndGroup.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 === Create a dedicated user/group for running Tomcat
 
 In this example, both the user and group names will be names `tomcat`,

--- a/docs/website/tds/tutorial/index.adoc
+++ b/docs/website/tds/tutorial/index.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 THREDDS Data Server Administration Tutorial
 ===========================================
 

--- a/docs/website/tds/tutorial/tdsConfigChecklist.adoc
+++ b/docs/website/tds/tutorial/tdsConfigChecklist.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 TDS Configuration Checklist for Production
 ==========================================
 

--- a/docs/website/tds/tutorial/tdsMonitor.adoc
+++ b/docs/website/tds/tutorial/tdsMonitor.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 = The `TdsMonitor` Tool
 
 == Setting up the `TdsMonitor` tool

--- a/docs/website/tds/tutorial/workshop2014.adoc
+++ b/docs/website/tds/tutorial/workshop2014.adoc
@@ -1,3 +1,5 @@
+:source-highlighter: coderay
+
 2014 Training Workshop Schedule : TDS Configuration and Administration
 ======================================================================
 


### PR DESCRIPTION
Used the following command to do this:

`find . -type f -name "*.adoc" | xargs grep -iL "source-highlighter" | xargs -n1 /usr/local/bin/gsed -i -e "1 i\source-highlighter: coderay"`

On a mac, I needed to install gnu-sed via homebrew.