### PR TITLE
Fix calls to setContentLength(). (Fixes #197)

### DIFF
--- a/tds/src/main/java/thredds/core/ConfigCatalogHtmlWriter.java
+++ b/tds/src/main/java/thredds/core/ConfigCatalogHtmlWriter.java
@@ -38,6 +38,7 @@ import thredds.client.catalog.*;
 import thredds.client.catalog.writer.DatasetHtmlWriter;
 import thredds.server.config.HtmlConfig;
 import thredds.servlet.HtmlWriter;
+import static thredds.servlet.ServletUtil.setResponseContentLength;
 import thredds.util.ContentType;
 import ucar.nc2.units.DateType;
 import ucar.unidata.util.Format;
@@ -87,15 +88,18 @@ public class ConfigCatalogHtmlWriter {
   public int writeCatalog(HttpServletRequest req, HttpServletResponse res, Catalog cat, boolean isLocalCatalog) throws IOException {
     String catHtmlAsString = convertCatalogToHtml(cat, isLocalCatalog);
 
-    res.setContentLength(catHtmlAsString.length());
+    // Once this header is set, we know the encoding, and thus the actual
+    // number of *bytes*, not characters, to encode
     res.setContentType(ContentType.html.getContentHeader());
+    int len = setResponseContentLength(res, catHtmlAsString);
+
     if (!req.getMethod().equals("HEAD")) {
       PrintWriter writer = res.getWriter();
       writer.write(catHtmlAsString);
       writer.flush();
     }
 
-    return catHtmlAsString.length();
+    return len;
   }
 
   /**

--- a/tds/src/main/java/thredds/server/cdmremote/CdmRemoteController.java
+++ b/tds/src/main/java/thredds/server/cdmremote/CdmRemoteController.java
@@ -161,9 +161,8 @@ public class CdmRemoteController extends AbstractController implements LastModif
 
           ncfile.setLocation(datasetPath); // hide where the file is stored
           String cdl = ncfile.toString();
-          res.setContentLength(cdl.length());
+          size = (long) thredds.servlet.ServletUtil.setResponseContentLength(res, cdl);
           pw.write(cdl);
-          size = cdl.length();
           break;
         }
 

--- a/tds/src/main/java/thredds/server/cdmremote/CdmrFeatureController.java
+++ b/tds/src/main/java/thredds/server/cdmremote/CdmrFeatureController.java
@@ -480,8 +480,8 @@ public class CdmrFeatureController { // implements LastModified {
       return null;
     }
 
-    res.setContentLength(infoString.length());
     res.setContentType(getContentType(query));
+    res.setContentLength(infoString.getBytes(CDM.utf8Charset).length);
 
     OutputStream out = res.getOutputStream();
     out.write(infoString.getBytes(CDM.utf8Charset));

--- a/tds/src/main/java/thredds/server/cdmvalidator/CdmValidatorController.java
+++ b/tds/src/main/java/thredds/server/cdmvalidator/CdmValidatorController.java
@@ -284,7 +284,7 @@ public class CdmValidatorController extends AbstractController {
 
       if (wantXml) {
         infoString = info.writeXML();
-        res.setContentLength(infoString.length());
+        res.setContentLength(infoString.getBytes(CDM.utf8Charset).length);
         res.setContentType(ContentType.xml.getContentHeader());
 
       } else {
@@ -299,7 +299,7 @@ public class CdmValidatorController extends AbstractController {
         res.setContentType(ContentType.html.getContentHeader());
       }
 
-      res.setContentLength(infoString.length());
+      res.setContentLength(infoString.getBytes(CDM.utf8Charset).length);
 
       OutputStream out = res.getOutputStream();
       out.write(infoString.getBytes(CDM.utf8Charset));

--- a/tds/src/main/java/thredds/server/metadata/MetadataController.java
+++ b/tds/src/main/java/thredds/server/metadata/MetadataController.java
@@ -110,7 +110,7 @@ public class MetadataController {
         strResponse = writeHTML(vars);
         res.setContentType(ContentType.html.getContentHeader());
       }
-      res.setContentLength(strResponse.length());
+      thredds.servlet.ServletUtil.setResponseContentLength(res, strResponse);
 
       PrintWriter pw = res.getWriter();
       pw.write(strResponse);

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssDatasetInfoController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssDatasetInfoController.java
@@ -100,13 +100,13 @@ class NcssDatasetInfoController extends AbstractNcssController {
         return; // restricted dataset
 
       String strResponse = ncssShowDatasetInfo.showForm(fd, buildDatasetUrl(datasetPath), wantXML, showPointForm);
-      res.setContentLength(strResponse.length());
 
       if (wantXML)
         res.setContentType(ContentType.xml.getContentHeader());
       else
         res.setContentType(ContentType.html.getContentHeader());
 
+      thredds.servlet.ServletUtil.setResponseContentLength(res, strResponse);
       writeResponse(strResponse, res);
     }
   }

--- a/tds/src/main/java/thredds/servlet/DataRootHandler.java
+++ b/tds/src/main/java/thredds/servlet/DataRootHandler.java
@@ -1139,8 +1139,8 @@ public final class DataRootHandler implements InitializingBean {
     InvCatalogFactory catFactory = getCatalogFactory(false);
     String result = catFactory.writeXML(cat);
 
-    res.setContentLength(result.length());
     res.setContentType(ContentType.xml.getContentHeader());
+    thredds.servlet.ServletUtil.setResponseContentLength(res, result);
     PrintWriter pw = res.getWriter();
     pw.write(result);
   }

--- a/tds/src/main/java/thredds/servlet/HtmlWriter.java
+++ b/tds/src/main/java/thredds/servlet/HtmlWriter.java
@@ -60,6 +60,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import static thredds.servlet.ServletUtil.setResponseContentLength;
+
 /**
  * Provide methods to write HTML representations of a catalog, directory, or CDM dataset to an HTTP response.
  * <p/>
@@ -376,8 +378,8 @@ public class HtmlWriter {
     // Get directory as HTML
     String dirHtmlString = getDirectory(path, dir);
 
-    res.setContentLength(dirHtmlString.length());
     res.setContentType(ContentType.html.getContentHeader());
+    thredds.servlet.ServletUtil.setResponseContentLength(res, dirHtmlString);
     PrintWriter writer = res.getWriter();
     writer.write(dirHtmlString);
     writer.flush();
@@ -527,15 +529,18 @@ public class HtmlWriter {
           throws IOException {
     String catHtmlAsString = convertCatalogToHtml(cat, isLocalCatalog);
 
-    res.setContentLength(catHtmlAsString.length());
+    // Once this header is set, we know the encoding, and thus the actual
+    // number of *bytes*, not characters, to encode
     res.setContentType(ContentType.html.getContentHeader());
+    int len = setResponseContentLength(res, catHtmlAsString);
+
     if (!req.getMethod().equals("HEAD")) {
       PrintWriter writer = res.getWriter();
       writer.write(catHtmlAsString);
       writer.flush();
     }
 
-    return catHtmlAsString.length();
+    return len;
   }
 
   /**
@@ -607,7 +612,7 @@ public class HtmlWriter {
     sb.append("</body>\r\n");
     sb.append("</html>\r\n");
 
-    return (sb.toString());
+    return sb.toString();
   }
 
   private boolean doDatasets(InvCatalogImpl cat, List<InvDataset> datasets, StringBuilder sb, boolean shade, int level, boolean isLocalCatalog) {
@@ -844,8 +849,8 @@ public class HtmlWriter {
           throws IOException {
     String cdmAsString = getCDM(ds);
 
-    res.setContentLength(cdmAsString.length());
     res.setContentType(ContentType.html.getContentHeader());
+    thredds.servlet.ServletUtil.setResponseContentLength(res, cdmAsString);
     PrintWriter writer = res.getWriter();
 
     writer.write(cdmAsString);

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -679,6 +679,20 @@ public class ServletUtil {
   }
 
   /**
+   * Set the proper content length for the string
+   *
+   * @param response the HttpServletResponse to act upon
+   * @param s the string that will be returned
+   * @return the number of bytes
+   * @throws UnsupportedEncodingException on bad character encoding
+   */
+  public static int setResponseContentLength(HttpServletResponse response, String s) throws UnsupportedEncodingException {
+    int length = s.getBytes(response.getCharacterEncoding()).length;
+    response.setContentLength(length);
+    return length;
+  }
+
+  /**
    * Return the request URL relative to the server (i.e., starting with the context path).
    *
    * @param req request


### PR DESCRIPTION
setContentLength() sets the content-length HTTP header, which is defined
as the number of bytes. In all of these changed places, we were passing
in the length of the string, which is the number of characters. This
breaks in the presence UTF-8 characters, which may be encoded as up to 4
bytes; the result is truncated HTML data (observed in #197).

Original report saw stray characters on HTML view; I was not able to see these in chrome, but they were clear (only `</h` of the closing `</html>` tag) when viewing the HTML source. Two items that may warrant discussion:
- I'd like to add a test, but I'm not sure how best to get a useful one that checks the HTML returned when serving up an appropriate catalog. Pointers welcome.
- I hit all of the users of `setContentLength()`, but I'm not sure if that's all of the problem. Anyone know of anything else easily searchable that could be a victim of this?