### PR TITLE
NetCDF-4 structure writing: tests and bug fixes

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
@@ -165,7 +165,7 @@ public class TestNc4IospWriting {
 
     /////////////////////////////////////////////////
 
-    // Demonstrates GitHub issue #191. Unignore when we have a fix in place.
+    // Demonstrates GitHub issue #191.
     @Test
     public void writeEnumType() throws IOException {
         // NetcdfFile's 0-arg constructor is protected, so must use NetcdfFileSubclass
@@ -200,34 +200,25 @@ public class TestNc4IospWriting {
 
 
         File outFile = File.createTempFile("writeEnumType", ".nc");
-        //File outFile = new File("f:/git/thredds/writeEnumType.nc"); outFile.delete();
         try {
             FileWriter2 writer = new FileWriter2(
                     ncFile, outFile.getAbsolutePath(), NetcdfFileWriter.Version.netcdf4, new Nc4ChunkingStrategyNone());
-            String mem = null;
-            String disk = null;
+            String mem;
+            String disk;
             try (NetcdfFile ncFileOut = writer.write()) {
                 ncFileOut.setLocation("writeEnumType");
-                // For debugging. Delete this entire try block when done.
+
                 Writer out = new StringWriter();
                 NCdumpW.print(ncFile, out, WantValues.all, false, false, null, null);
                 out.close();
                 mem = out.toString();
+
                 out = new StringWriter();
                 NCdumpW.print(ncFileOut, out, WantValues.all, false, false, null, null);
                 out.close();
                 disk = out.toString();
-                System.out.println("-------------------In memory-------------------");
-                System.out.print(mem);
-                System.out.println("-------------------On disk-------------------");
-                System.out.print(disk);
             }
             String diffs = UnitTestCommon.compare("TestNc4IospWriting.writeEnumType", mem, disk);
-            if(diffs != null) {
-                System.out.println("-------------------Diffs-------------------");
-                System.err.println(diffs);
-                System.out.println("---------------------------------------------");
-            }
             Assert.assertTrue("Differences", diffs == null);
         } finally {
             ncFile.close();

--- a/cdm/src/main/java/ucar/ma2/StructureData.java
+++ b/cdm/src/main/java/ucar/ma2/StructureData.java
@@ -38,7 +38,7 @@ import java.util.Formatter;
 import java.util.List;
 
 /**
- * A container for a Structure's data. 
+ * A container for a Structure's data.
  * Is normally contained within an ArrayStructure, which is an Array of StructureData.
  * This is the abstract supertype for all implementations.
  *
@@ -54,7 +54,7 @@ import java.util.List;
     <pre> Array getArray(Member m) </pre>
     <pre> Array getArray(String memberName) </pre>
 
- * The following will return an object of type Byte, Char, Double, Float, Int, Long, Short, String, or Structure, depending 
+ * The following will return an object of type Byte, Char, Double, Float, Int, Long, Short, String, or Structure, depending
  * upon the member type:
    <pre> Object getScalarObject( Member m) </pre>
 
@@ -681,10 +681,10 @@ abstract public class StructureData {
     indent.incr();
     for (StructureMembers.Member m : getMembers())
       m.showInternal(f, indent);
-    indent.incr();
+    indent.decr();
   }
 
-   public String toString() { 
+   public String toString() {
     return members.toString();
   }
 

--- a/cdm/src/main/java/ucar/nc2/FileWriter2.java
+++ b/cdm/src/main/java/ucar/nc2/FileWriter2.java
@@ -32,16 +32,16 @@
  */
 package ucar.nc2;
 
+import ucar.ma2.*;
+import ucar.nc2.util.CancelTask;
+import ucar.nc2.util.CancelTaskImpl;
+import ucar.nc2.write.Nc4Chunking;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import ucar.ma2.*;
-import ucar.nc2.write.Nc4Chunking;
-import ucar.nc2.util.CancelTask;
-import ucar.nc2.util.CancelTaskImpl;
 
 /**
  * Utility class for copying a NetcdfFile object, or parts of one, to a netcdf-3 or netcdf-4 disk file.
@@ -325,7 +325,7 @@ public class FileWriter2 {
       DataType newType = oldVar.getDataType();
       Variable v;
       if (newType == DataType.STRUCTURE) {
-        v = writer.addStructure(newGroup, (Structure) oldVar, oldVar.getShortName(), dims);
+        v = writer.addCopyOfStructure(newGroup, (Structure) oldVar, oldVar.getShortName(), dims);
       } else if(newType.isEnum()) {
         EnumTypedef en = oldVar.getEnumTypedef();
         v = writer.addVariable(newGroup, oldVar.getShortName(), newType, dims);

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -33,60 +33,17 @@
 
 package ucar.nc2.ft.point.writer;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.Array;
-import ucar.ma2.ArrayChar;
-import ucar.ma2.ArrayObject;
-import ucar.ma2.ArrayStructureW;
-import ucar.ma2.DataType;
-import ucar.ma2.InvalidRangeException;
-import ucar.ma2.StructureData;
-import ucar.ma2.StructureMembers;
-import ucar.nc2.Attribute;
-import ucar.nc2.Dimension;
-import ucar.nc2.NetcdfFileWriter;
-import ucar.nc2.Structure;
-import ucar.nc2.Variable;
-import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.ACDD;
-import ucar.nc2.constants.AxisType;
-import ucar.nc2.constants.CDM;
-import ucar.nc2.constants.CF;
-import ucar.nc2.constants.FeatureType;
-import ucar.nc2.constants._Coordinate;
+import ucar.ma2.*;
+import ucar.nc2.*;
+import ucar.nc2.constants.*;
 import ucar.nc2.dataset.CoordinateAxis;
-import ucar.nc2.ft.DsgFeatureCollection;
-import ucar.nc2.ft.FeatureDatasetFactoryManager;
-import ucar.nc2.ft.FeatureDatasetPoint;
-import ucar.nc2.ft.PointFeature;
-import ucar.nc2.ft.PointFeatureCollection;
-import ucar.nc2.ft.ProfileFeature;
-import ucar.nc2.ft.ProfileFeatureCollection;
-import ucar.nc2.ft.TrajectoryProfileFeature;
-import ucar.nc2.ft.TrajectoryProfileFeatureCollection;
-import ucar.nc2.ft.StationProfileFeature;
-import ucar.nc2.ft.StationProfileFeatureCollection;
-import ucar.nc2.ft.StationTimeSeriesFeatureCollection;
-import ucar.nc2.ft.TrajectoryFeature;
-import ucar.nc2.ft.TrajectoryFeatureCollection;
+import ucar.nc2.ft.*;
 import ucar.nc2.ft.point.StationPointFeature;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateFormatter;
@@ -96,6 +53,11 @@ import ucar.nc2.write.Nc4Chunking;
 import ucar.nc2.write.Nc4ChunkingStrategy;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonRect;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Write Point Feature Collections into netcdf3/4 files in CF 1.6 point obs conventions.
@@ -514,7 +476,6 @@ public abstract class CFPointWriter implements Closeable {
       record = (Structure) writer.addVariable(null, recordName, DataType.STRUCTURE, recordDimName);
       addCoordinatesExtended(record, obsCoords);
       addDataVariablesExtended(obsData, coordNames);
-      record.calcElementSize();
       writer.create();
 
     } else {
@@ -539,7 +500,6 @@ public abstract class CFPointWriter implements Closeable {
       record = (Structure) writer.addVariable(null, recordName, DataType.STRUCTURE, recordDimName);
       addCoordinatesExtended(record, obsCoords);
       addDataVariablesExtended(obsData, coordNames);
-      record.calcElementSize();
       writer.create();
 
     } else {
@@ -626,7 +586,6 @@ public abstract class CFPointWriter implements Closeable {
       for (Attribute att : vs.getAttributes())
         member.addAttribute(att);
     }
-    parent.calcElementSize();
   }
 
    // added as variables with the unlimited (record) dimension

--- a/cdm/src/test/java/ucar/ma2/TestStructureArrayW.java
+++ b/cdm/src/test/java/ucar/ma2/TestStructureArrayW.java
@@ -83,13 +83,10 @@ public class TestStructureArrayW extends TestCase {
     StructureMembers members = new StructureMembers("s");
 
     StructureMembers.Member f1 = members.addMember("f1", "desc", "units", DataType.FLOAT, new int[]{1});
-    members.addMember(f1);
 
     StructureMembers.Member f2 = members.addMember("f2", "desc", "units", DataType.SHORT, new int[]{3});
-    members.addMember(f2);
 
     StructureMembers.Member nested1 = members.addMember("nested1", "desc", "units", DataType.STRUCTURE, new int[]{9});
-    members.addMember(nested1);
 
     int size = 4;
     StructureData[] sdata = new StructureData[size];
@@ -148,19 +145,14 @@ public class TestStructureArrayW extends TestCase {
     assert (h2data[1] == 12019);
   }
 
-
   public Array makeNested1(StructureMembers.Member nested1, int size1, int size2) throws IOException, InvalidRangeException {
     StructureMembers members = new StructureMembers(nested1.getName());
     nested1.setStructureMembers(members);
 
     StructureMembers.Member g1 = members.addMember("g1", "desc", "units", DataType.INT, new int[]{1});
-    members.addMember(g1);
     StructureMembers.Member g2 = members.addMember("g2", "desc", "units", DataType.DOUBLE, new int[]{2});
-    members.addMember(g2);
     StructureMembers.Member g3 =  members.addMember("g3", "desc", "units", DataType.DOUBLE, new int[]{3, 4});
-    members.addMember(g3);
     StructureMembers.Member nested2 =  members.addMember("nested2", "desc", "units", DataType.STRUCTURE, new int[]{7});
-    members.addMember(nested2);
 
     StructureData[] sdata = new StructureData[size1];
     for (int i=0; i<size1; i++) {
@@ -191,9 +183,7 @@ public class TestStructureArrayW extends TestCase {
     nested.setStructureMembers(members);
 
     StructureMembers.Member h1 = members.addMember("h1", "desc", "units", DataType.INT, new int[]{1});
-    members.addMember(h1);
     StructureMembers.Member h2 = members.addMember("h2", "desc", "units", DataType.DOUBLE, new int[]{2});
-    members.addMember(h2);
 
     StructureData[] sdata = new StructureData[size];
     for (int i=0; i<size; i++) {

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -37,10 +37,10 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
-import ucar.nc2.constants.DataFormatType;
 import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
+import ucar.nc2.constants.DataFormatType;
 import ucar.nc2.iosp.AbstractIOServiceProvider;
 import ucar.nc2.iosp.IOServiceProviderWriter;
 import ucar.nc2.iosp.IospHelper;
@@ -1286,6 +1286,28 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
         this.dims = edims;
         this.ndims++;
       }
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Field field = (Field) o;
+      return grpid == field.grpid &&
+             typeid == field.typeid &&
+             fldidx == field.fldidx &&
+             offset == field.offset &&
+             fldtypeid == field.fldtypeid &&
+             ndims == field.ndims &&
+             Objects.equals(name, field.name) &&
+             Arrays.equals(dims, field.dims);
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(grpid, typeid, fldidx, name, offset, fldtypeid, ndims, dims);
     }
 
     public String toString2() {
@@ -2580,7 +2602,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     // keep track of the User Defined types
     UserType ut = new UserType(g4.grpid, typeid, name, size, 0, (long) fldidx, NC_COMPOUND);
     userTypes.put(typeid, ut);
-    ut.setFields(flds);
+    ut.setFields(flds);  // LOOK: These were already set in the UserType ctor.
   }
 
   private void createCompoundMemberAtts(int grpid, int varid, Structure s) throws IOException {


### PR DESCRIPTION
* Added tests to TestNc4Structures to demonstrate GitHub issues #296, #298, and #299.
* NetcdfFileWriter.addStructureMember() recalculates structure element size.
* NetcdfFileWriter.addStructure() renamed to addCopyOfStructure(), for clarity. Improved Javadoc.
* NetcdfFileWriter.addCopyOfStructure now propagates original structure's attributes.
* Removed debugging code from TestNc4IospWriting.writeEnumType().