### PR TITLE
Exit redefine mode on close

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFileWriter.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFileWriter.java
@@ -1015,6 +1015,7 @@ public class NetcdfFileWriter implements AutoCloseable {
    */
   public synchronized void close() throws java.io.IOException {
     if (spiw != null) {
+      setRedefineMode(false);
       flush();
       spiw.close();
       spiw = null;

--- a/cdm/src/test/java/ucar/nc2/TestRedefine.java
+++ b/cdm/src/test/java/ucar/nc2/TestRedefine.java
@@ -34,21 +34,17 @@ package ucar.nc2;
 
 import java.io.IOException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 import ucar.ma2.ArrayDouble;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.constants.CDM;
 
-public class TestRedefine extends TestCase {
-
-  public TestRedefine( String name) {
-    super(name);
-  }
-
+public class TestRedefine{
   String filename = TestLocal.temporaryDataDir + "testRedefine.nc";
   String filename2 = TestLocal.temporaryDataDir + "testRedefine2.nc";
 
+  @Test
   public void testRedefine() throws IOException, InvalidRangeException {
     NetcdfFileWriteable file;
     file = NetcdfFileWriteable.createNew(filename, true);
@@ -69,12 +65,7 @@ public class TestRedefine extends TestCase {
     file.addVariable("h", DataType.DOUBLE, dims);
     file.addVariableAttribute("h", "quantity", "Height");
     file.addVariableAttribute("h", "units", "m");
-    try {
-      file.create();
-    } catch (IOException e) {
-      e.printStackTrace(System.err);
-      fail("IOException on creation");
-    }
+    file.create();
 
     double td[] = {1.0, 2.0, 3.0, 4.0};
     double hd[] = {0.0, 0.1, 0.3, 0.9};
@@ -166,6 +157,7 @@ public class TestRedefine extends TestCase {
     file.close();
   }
 
+  @Test
   public void testRewriteHeader3() throws IOException, InvalidRangeException {
     NetcdfFileWriteable file;
     file = NetcdfFileWriteable.createNew(filename2, true);

--- a/cdm/src/test/java/ucar/nc2/TestRedefine.java
+++ b/cdm/src/test/java/ucar/nc2/TestRedefine.java
@@ -34,6 +34,7 @@ package ucar.nc2;
 
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.ma2.ArrayDouble;
 import ucar.ma2.DataType;
@@ -43,6 +44,7 @@ import ucar.nc2.constants.CDM;
 public class TestRedefine{
   String filename = TestLocal.temporaryDataDir + "testRedefine.nc";
   String filename2 = TestLocal.temporaryDataDir + "testRedefine2.nc";
+  String filename3 = TestLocal.temporaryDataDir + "testRedefine3.nc";
 
   @Test
   public void testRedefine() throws IOException, InvalidRangeException {
@@ -177,4 +179,27 @@ public class TestRedefine{
     file.close();
   }
 
+  @Test
+  public void testRedefineClose() throws IOException {
+    // Create a new file
+    try (NetcdfFileWriter file = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3,
+            filename3)) {
+      Attribute attr = new Attribute("att", 5);
+      file.addGroupAttribute(null, attr);
+      file.create();
+    }
+
+    // Re-open file in redefine mode
+    try (NetcdfFileWriter file = NetcdfFileWriter.openExisting(filename3)) {
+      file.setRedefineMode(true);
+      Attribute attr = new Attribute("att2", "foobar");
+      file.addGroupAttribute(null, attr);
+    }
+
+    // Check that attribute is present
+    try (NetcdfFileWriter file = NetcdfFileWriter.openExisting(filename3)) {
+      Assert.assertNotNull(file.findGlobalAttribute("att"));
+      Assert.assertNotNull(file.findGlobalAttribute("att2"));
+    }
+  }
 }


### PR DESCRIPTION
Fixes #287 .
This changes `NetcdfFileWriter` to automatically exit redefine mode if necessary when closing the file.

As a side note, as bad as the behavior in #287 was, I found something even worse:

Before this change, this code
```java
    try (NetcdfFileWriter file = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3,
            filename3)) {
      Attribute attr = new Attribute("att", 5);
      file.addGroupAttribute(null, attr);
    }
```
results in an empty file.