### PR TITLE
Added cdm-test:testIndexCreation, which runs before cdm-test:test.

### DIFF
--- a/cdm-test/build.gradle
+++ b/cdm-test/build.gradle
@@ -23,3 +23,19 @@ dependencies {
 
     testCompile libraries["slf4j-api"]
 }
+
+task testIndexCreation(type: Test, dependsOn: [classes, testClasses], group: 'Verification',
+             description: 'Tests creation of Grib and collection indexes, which will be used by subsequent tests.') {
+    include 'ucar/nc2/grib/TestGribIndexCreation.class'
+}
+
+test {
+    dependsOn "testIndexCreation"
+
+    // In addition to preventing TestGribIndexCreation from running during cdm-test:test,
+    // this statement also excludes the results of TestGribIndexCreation from appearing in the cdm-test report:
+    // "/thredds/cdm-test/build/reports/tests/index.html". It's not easy to add them back in. Fortunately, those
+    // results will be included in the allTests aggregate report: "/thredds/build/reports/allTests/index.html".
+    // The should also still get picked up by Jenkins.
+    exclude 'ucar/nc2/grib/TestGribIndexCreation.class'
+}

--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -52,7 +52,7 @@ javadoc {
 }
 
 // TODO: Use the Sync task for this.
-task releaseDocs(dependsOn: javadoc) << {
+task releaseDocs(dependsOn: javadoc, group: 'Release') << {
     def releaseDir = webdir + "javadoc"
 
     ant.delete(dir: releaseDir)

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -16,6 +16,8 @@ configure(javaProjects + rootProject) {
         // Include all Test tasks from this project and any subprojects.
         dependsOn allprojects*.tasks*.withType(Test)
 
+        group = 'Reports'
+
         List<SourceSet> mainSourceSets = javaProjects*.sourceSets*.main
         sourceDirectories = files(mainSourceSets*.allSource*.srcDirs)
         classDirectories = files(mainSourceSets*.output)

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -11,12 +11,12 @@ configure(javaProjects) {
 
     // These will only run when we execute the "publish" task, NOT "assemble".
     // That'll save us from a lot of unnecessary build time in the common case.
-    task sourcesJar(type: Jar, dependsOn: classes) {
+    task sourcesJar(type: Jar, dependsOn: classes, group: 'Publishing') {
         classifier = 'sources'
         from sourceSets.main.allSource
     }
 
-    task javadocJar(type: Jar, dependsOn: javadoc) {
+    task javadocJar(type: Jar, dependsOn: javadoc, group: 'Publishing') {
         classifier = 'javadoc'
         from javadoc.destinationDir
     }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -163,34 +163,37 @@ boolean testRuntimeHasDepNamed(Project project, String depName) {
 
 ///////////////////////////////////////////////// Root tasks /////////////////////////////////////////////////
 
-// FIXME: I'm not sure if either of these consider :it:integrationTest. That would make sense, because it hasn't been
-// evaluated yet. How best to fix?
-// UPDATE (2015-08-13): "testAll" is causing :it:integrationTest to run, but its report isn't being included in the
-// root report.
+gradle.projectsEvaluated {
+    configure (rootProject) {
+        // By default, subprojects are evaluated AFTER their parents, meaning that the full set of subproject Test
+        // tasks won't be available until all subprojects have been evaluated. That's why we've delayed the
+        // configuration of the following two rootProject tasks.
+        Set<Task> subprojectTestTasks = subprojects*.tasks*.withType(Test).flatten()
 
-task testAll(group: 'Build') {
-    description = 'Runs all subproject Test tasks'
-    dependsOn subprojects*.tasks*.withType(Test)
-}
+        task testAll(group: 'Verification') {
+            description = 'Runs all subproject Test tasks'
+            dependsOn subprojectTestTasks
+        }
 
-task rootTestReport(type: TestReport, group: 'Reports') {
-    description = 'Generates an aggregate test report'
-    destinationDir = file("$buildDir/reports/allTests")
+        task rootTestReport(type: TestReport, group: 'Reports') {
+            description = 'Generates an aggregate test report'
+            destinationDir = file("$buildDir/reports/allTests")
 
-    Collection<Task> subprojectTestTasks = subprojects*.tasks*.withType(Test).flatten()
+            // All Test tasks will be finalized by this task. As a result, this task needn't be invoked directly.
+            subprojectTestTasks*.finalizedBy it
 
-    // All Test tasks will be finalized by this task. As a result, this task needn't be invoked directly.
-    subprojectTestTasks*.finalizedBy it
+            // We could also do "reportOn subprojectTestTasks" here, but that would cause this task to be dependent on
+            // all subproject Tests. So, we couldn't do something like ":grib:test" and expect only GRIB tests to run
+            // because:
+            //     ":grib:test" --finalizedBy--> ":rootTestReport" --dependsOn--> "all_subproject_Tests"
+            // In other words, all subproject tests would get run, no matter what.
+            // Passing File arguments to reportOn() instead doesn't create that dependency.
+            reportOn subprojectTestTasks*.binResultsDir
 
-    // We could also do "reportOn subprojectTestTasks" here, but that would cause this task to be dependent on all
-    // subproject Tests. So, we couldn't do something like ":grib:test" and expect only GRIB tests to run because:
-    //     ":grib:test" --finalizedBy--> ":rootTestReport" --dependsOn--> "all_subproject_Tests"
-    // In other words, all subproject tests would get run, no matter what.
-    // Passing File arguments to reportOn() instead doesn't create that dependency.
-    reportOn subprojectTestTasks*.binResultsDir
-
-    // Wait until all Test tasks have run. This creates a task *ordering*, not a dependency.
-    mustRunAfter subprojectTestTasks
+            // Wait until all Test tasks have run. This creates a task *ordering*, not a dependency.
+            mustRunAfter subprojectTestTasks
+        }
+    }
 }
 
 apply plugin: "base"  // Gives us the "clean" task for removing rootTestReport's output.

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -58,7 +58,7 @@ gretty {
 }
 
 // Gretty will start the webapp before this task and shut it down afterward.
-task integrationTest(type: Test) {
+task integrationTest(type: Test, group: 'Verification') {
     // isContentRootAvailable, isJenkins, and contentRootKey are defined on the root project in testing.gradle.
     if (!isContentRootAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
         logger.warn "Skipping all integration tests (task \'$path\'): " +
@@ -118,7 +118,7 @@ afterEvaluate {
         // (e.g. one of its onlyIf()s returns false), but those situations are rare.
         onlyIf {
             Task task = tasks.integrationTest
-            if (!task.enabled) {    // May have been disabled in testing.gradle.
+            if (!task.enabled) {    // May have been disabled above.
                 return false;
             }
 

--- a/tdm/build.gradle
+++ b/tdm/build.gradle
@@ -17,11 +17,3 @@ dependencies {
 }
 
 jar.manifest.attributes 'Main-Class': 'thredds.tdm.Tdm'
-
-task showClasspath << {
-    buildscript.configurations.classpath.each { println it }
-}
-
-task showMeCache << {
-    configurations.compile.each { println it }
-}

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -83,7 +83,7 @@ ext {
    webdir:parent of conan content directory
    ftpdir:ftp directory
  */
-task releaseWebstart(dependsOn: jar) << {
+task releaseWebstart(dependsOn: jar, group: 'Release') << {
     if (project.hasProperty("webdir") && project.hasProperty("keystore")
             && project.hasProperty("keystoreAlias") && project.hasProperty("keystorePassword")) {
         ant.delete(dir: webstartWorkingDir)
@@ -155,7 +155,7 @@ javadoc {
     source = source.plus(fileTree(dir: '../dap4/d4cdmclient/src/main/java', include: '**/*.java'))
 }
 
-task releaseDocs(dependsOn: javadoc) << {
+task releaseDocs(dependsOn: javadoc, group: 'Release') << {
     if (project.hasProperty("webdir")) {
         def releaseDir = webdir + "javadocAll"
 
@@ -173,12 +173,6 @@ task releaseDocs(dependsOn: javadoc) << {
 }
 
 ///////////////////////////////////////////////////////
-
-task showDependencies << {
-    for (file in configurations.runtime.resolve()) {
-        println " " + file
-    }
-}
 
 import java.util.jar.JarEntry
 import java.util.jar.JarFile


### PR DESCRIPTION
* :testAll and :rootTestReport now incorporate ALL subproject Test tasks.
* Assigned various tasks to the appropriate task group.
* Deleted some old, crufty tasks from tdm and ui.