### PR TITLE
Enforce use of shared dimensions in groups

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT41_ncFlat.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT41_ncFlat.java
@@ -114,7 +114,7 @@ public class WriteT41_ncFlat {
       }
 
       int total_seq = countSeq(recordStruct);
-      Dimension seqD = ncfile.addDimension(null, "seq", total_seq, true, true, false);
+      Dimension seqD = ncfile.addDimension(null, "seq", total_seq, true, false);
 
       for (Variable v : recordStruct.getVariables()) {
         if (v.getDataType() != DataType.SEQUENCE) continue;

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT41_ncRect.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT41_ncRect.java
@@ -78,7 +78,7 @@ public class WriteT41_ncRect {
         String useName = N3iosp.makeValidNetcdfObjectName(oldD.getShortName());
         boolean isRecord = useName.equals("record");
         Dimension newD = ncfile.addDimension(null, useName, isRecord ? 0 : oldD.getLength(),
-                oldD.isShared(), isRecord, oldD.isVariableLength());
+                isRecord, oldD.isVariableLength());
         if (isRecord) recordDim = newD;
         if (debug) System.out.println("add dim= " + newD);
       }

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT42_ncRect.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/writer/WriteT42_ncRect.java
@@ -78,7 +78,7 @@ public class WriteT42_ncRect {
         String useName = N3iosp.makeValidNetcdfObjectName(oldD.getShortName());
         boolean isRecord = useName.equals("record");
         Dimension newD = ncfile.addDimension(useName, isRecord ? 0 : oldD.getLength(),
-                oldD.isShared(), isRecord, oldD.isVariableLength());
+                isRecord, oldD.isVariableLength());
         if (isRecord) recordDim = newD;
         if (debug) System.out.println("add dim= " + newD);
       }

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4Structures.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4Structures.java
@@ -181,7 +181,7 @@ public class TestNc4Structures {
       try (NetcdfFileWriter ncFileWriter = NetcdfFileWriter.createNew(
               NetcdfFileWriter.Version.netcdf4, outFile.getAbsolutePath())) {
         // Test passes if we do "isUnlimited == false".
-        Dimension dim = ncFileWriter.addDimension(null, "dim", 5, false, true /*false*/, false);
+        Dimension dim = ncFileWriter.addDimension(null, "dim", 5, true /*false*/, false);
 
         Structure struct = (Structure) ncFileWriter.addVariable(null, "struct", DataType.STRUCTURE, "dim");
         ncFileWriter.addStructureMember(struct, "foo", DataType.INT, null);

--- a/cdm/src/main/java/ucar/nc2/FileWriter2.java
+++ b/cdm/src/main/java/ucar/nc2/FileWriter2.java
@@ -161,7 +161,7 @@ public class FileWriter2 {
       Dimension newD = gdimHash.get(oldD.getShortName());
       if (newD == null) {
         newD = writer.addDimension(null, oldD.getShortName(), oldD.isUnlimited() ? 0 : oldD.getLength(),
-                oldD.isShared(), oldD.isUnlimited(), oldD.isVariableLength());
+                oldD.isUnlimited(), oldD.isVariableLength());
         gdimHash.put(oldD.getShortName(), newD);
         if (debug) System.out.println("add dim= " + newD);
       }
@@ -226,7 +226,7 @@ public class FileWriter2 {
     Map<String, Dimension> dimHash = new HashMap<>();
     for (Dimension oldD : fileIn.getDimensions()) {
       Dimension newD = writer.addDimension(null, oldD.getShortName(), oldD.isUnlimited() ? 0 : oldD.getLength(),
-              oldD.isShared(), oldD.isUnlimited(), oldD.isVariableLength());
+              oldD.isUnlimited(), oldD.isVariableLength());
       dimHash.put(oldD.getShortName(), newD);
       if (debug) System.out.println("add dim= " + newD);
     }
@@ -304,7 +304,7 @@ public class FileWriter2 {
     Map<String, Dimension> dimHash = new HashMap<>();
     for (Dimension oldD : oldGroup.getDimensions()) {
       Dimension newD = writer.addDimension(newGroup, oldD.getShortName(), oldD.isUnlimited() ? 0 : oldD.getLength(),
-              oldD.isShared(), oldD.isUnlimited(), oldD.isVariableLength());
+              oldD.isUnlimited(), oldD.isVariableLength());
       dimHash.put(oldD.getShortName(), newD);
       if (debug) System.out.println("add dim= " + newD);
     }

--- a/cdm/src/main/java/ucar/nc2/Group.java
+++ b/cdm/src/main/java/ucar/nc2/Group.java
@@ -208,7 +208,7 @@ public class Group extends CDMNode implements AttributeContainer {
   }
 
   /**
-   * Get the Dimensions contained directly in this group.
+   * Get the shared Dimensions contained directly in this group.
    *
    * @return List of type Dimension; may be empty, not null.
    */
@@ -481,28 +481,49 @@ public class Group extends CDMNode implements AttributeContainer {
   }
 
   /**
-   * Add a shared Dimension
+   * Adds the specified shared dimension to this group.
    *
-   * @param d add this Dimension
+   * @param dim  the dimension to add.
+   * @throws IllegalStateException  if this dimension is {@link #setImmutable() immutable}.
+   * @throws IllegalArgumentException  if {@code dim} isn't shared or a dimension with {@code dim}'s name already
+   *                                   exists within the group.
    */
-  public void addDimension(Dimension d) {
+  public void addDimension(Dimension dim) {
     if (immutable) throw new IllegalStateException("Cant modify");
 
-    if (findDimensionLocal(d.getShortName()) != null)
-      throw new IllegalArgumentException("Dimension name (" + d.getShortName() + ") must be unique within Group " + getShortName());
+    if (!dim.isShared()) {
+      throw new IllegalArgumentException("Dimensions added to a group must be shared.");
+    }
 
-    dimensions.add(d);
-    d.setGroup(this);
+    if (findDimensionLocal(dim.getShortName()) != null)
+      throw new IllegalArgumentException("Dimension name (" + dim.getShortName() + ") must be unique within Group " + getShortName());
+
+    dimensions.add(dim);
+    dim.setGroup(this);
   }
 
-  public boolean addDimensionIfNotExists(Dimension d) {
+  /**
+   * Adds the specified shared dimension to this group, but only if another dimension with the same name doesn't
+   * already exist.
+   *
+   * @param dim  the dimension to add.
+   * @return {@code true} if {@code dim} was successfully added to the group. Otherwise, {@code false} will be returned,
+   *         meaning that a dimension with {@code dim}'s name already exists within the group.
+   * @throws IllegalStateException  if this dimension is {@link #setImmutable() immutable}.
+   * @throws IllegalArgumentException  if {@code dim} isn't shared.
+   */
+  public boolean addDimensionIfNotExists(Dimension dim) {
     if (immutable) throw new IllegalStateException("Cant modify");
 
-    if (findDimensionLocal(d.getShortName()) != null)
+    if (!dim.isShared()) {
+      throw new IllegalArgumentException("Dimensions added to a group must be shared.");
+    }
+
+    if (findDimensionLocal(dim.getShortName()) != null)
       return false;
 
-    dimensions.add(d);
-    d.setGroup(this);
+    dimensions.add(dim);
+    dim.setGroup(this);
     return true;
   }
 

--- a/cdm/src/main/java/ucar/nc2/NetcdfFileWriter.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFileWriter.java
@@ -320,7 +320,7 @@ public class NetcdfFileWriter implements Closeable {
   //// use these calls in define mode
 
   public Dimension addDimension(String dimName, int length) {
-    return addDimension(null, dimName, length, true, false, false);
+    return addDimension(null, dimName, length, false, false);
   }
 
   /**
@@ -331,38 +331,37 @@ public class NetcdfFileWriter implements Closeable {
    * @return the created dimension
    */
   public Dimension addDimension(Group g, String dimName, int length) {
-    return addDimension(g, dimName, length, true, false, false);
+    return addDimension(g, dimName, length, false, false);
   }
 
   /**
-   * Add single unlimited dimension (classic model)
+   * Add single unlimited, shared dimension (classic model)
    * @param dimName name of dimension
    * @return Dimension object that was added
    */
   public Dimension addUnlimitedDimension(String dimName) {
-    return addDimension(null, dimName, 0, true, true, false);
+    return addDimension(null, dimName, 0, true, false);
   }
 
-  public Dimension addDimension(String dimName, int length, boolean isShared, boolean isUnlimited, boolean isVariableLength) {
-    return addDimension(null, dimName, length, isShared, isUnlimited, isVariableLength);
+  public Dimension addDimension(String dimName, int length, boolean isUnlimited, boolean isVariableLength) {
+    return addDimension(null, dimName, length, isUnlimited, isVariableLength);
   }
 
   /**
-   * Add a Dimension to the file. Must be in define mode.
+   * Add a shared Dimension to the file. Must be in define mode.
    *
    * @param dimName          name of dimension
    * @param length           size of dimension.
-   * @param isShared         if dimension is shared   LOOK what does it mean if false ??
    * @param isUnlimited      if dimension is unlimited
    * @param isVariableLength if dimension is variable length
    * @return the created dimension
    */
-  public Dimension addDimension(Group g, String dimName, int length, boolean isShared, boolean isUnlimited, boolean isVariableLength) {
+  public Dimension addDimension(Group g, String dimName, int length, boolean isUnlimited, boolean isVariableLength) {
     if (!defineMode) throw new UnsupportedOperationException("not in define mode");
     if (!isValidObjectName(dimName))
       throw new IllegalArgumentException("illegal dimension name " + dimName);
 
-    Dimension dim = new Dimension(dimName, length, isShared, isUnlimited, isVariableLength);
+    Dimension dim = new Dimension(dimName, length, true, isUnlimited, isVariableLength);
     ncfile.addDimension(g, dim);
     return dim;
   }

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -692,7 +692,7 @@ public abstract class CFPointWriter implements Closeable {
       String dimName = getSharedDimName(d);
 
       if (!writer.hasDimension(null, dimName)) {
-        Dimension newDim = writer.addDimension(null, dimName, d.getLength(), true, false, d.isVariableLength());
+        Dimension newDim = writer.addDimension(null, dimName, d.getLength(), false, d.isVariableLength());
         dimMap.put(dimName, newDim);
       }
     }

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
@@ -32,20 +32,6 @@
  */
 package ucar.nc2.ncml;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -63,15 +49,15 @@ import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.Index;
 import ucar.ma2.IndexIterator;
-import ucar.nc2.Attribute;
-import ucar.nc2.Dimension;
-import ucar.nc2.EnumTypedef;
-import ucar.nc2.Group;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.Structure;
-import ucar.nc2.Variable;
+import ucar.nc2.*;
 import ucar.nc2.util.URLnaming;
 import ucar.nc2.util.xml.Parse;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Helper class to write NcML.
@@ -410,8 +396,9 @@ public class NcMLWriter {
       try {
         varElem.addContent(makeValuesElement(var, true));
       } catch (IOException e) {
-        String message = String.format("Couldn't read values for %s. Omitting <values> element.", var.getFullName());
-        log.warn(message, e);
+        String message = String.format("Couldn't read values for %s. Omitting <values> element.%n\t%s",
+                                       var.getFullName(), e.getMessage());
+        log.warn(message);
       }
     }
 

--- a/cdm/src/test/java/ucar/nc2/TestRedefine.java
+++ b/cdm/src/test/java/ucar/nc2/TestRedefine.java
@@ -32,14 +32,14 @@
  */
 package ucar.nc2;
 
-import java.io.IOException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import ucar.ma2.ArrayDouble;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.constants.CDM;
+
+import java.io.IOException;
 
 public class TestRedefine{
   String filename = TestLocal.temporaryDataDir + "testRedefine.nc";
@@ -54,7 +54,7 @@ public class TestRedefine{
       file.addGlobalAttribute(CDM.HISTORY, "lava");
       file.addGlobalAttribute("att8", "12345678");
 
-      file.addDimension(null, "time", 4, true, false, false);
+      file.addDimension(null, "time", 4, false, false);
 
     /* Add time */
       file.addVariable("time", DataType.DOUBLE, "time");

--- a/cdm/src/test/java/ucar/nc2/TestWriteFill.java
+++ b/cdm/src/test/java/ucar/nc2/TestWriteFill.java
@@ -33,12 +33,10 @@
 package ucar.nc2;
 
 import junit.framework.TestCase;
-
-import java.io.IOException;
-import java.util.ArrayList;
-
 import ucar.ma2.*;
 import ucar.nc2.iosp.netcdf3.N3iosp;
+
+import java.io.IOException;
 
 /**
  * Test writing with fill values
@@ -57,7 +55,7 @@ public class TestWriteFill  extends TestCase {
     // define dimensions
     Dimension latDim = ncfile.addDimension("lat", 6);
     Dimension lonDim = ncfile.addDimension("lon", 12);
-    Dimension timeDim = ncfile.addDimension(null, "time", 0, true, true, false);
+    Dimension timeDim = ncfile.addDimension(null, "time", 0, true, false);
 
     // define Variables
     ncfile.addVariable("temperature", DataType.DOUBLE, "lat lon");

--- a/cdm/src/test/java/ucar/nc2/TestWriteRecord.java
+++ b/cdm/src/test/java/ucar/nc2/TestWriteRecord.java
@@ -103,7 +103,7 @@ public class TestWriteRecord extends TestCase  {
       // define dimensions, including unlimited
       Dimension latDim = ncfile.addDimension("lat", 3);
       Dimension lonDim = ncfile.addDimension("lon", 4);
-      Dimension timeDim = ncfile.addDimension("time", 0, true, true, false);
+      Dimension timeDim = ncfile.addDimension("time", 0, true, false);
 
       // define Variables
 
@@ -292,7 +292,7 @@ public class TestWriteRecord extends TestCase  {
     // define dimensions, including unlimited
     Dimension latDim = ncfile.addDimension("lat", 64);
     Dimension lonDim = ncfile.addDimension("lon", 128);
-    Dimension timeDim = ncfile.addDimension(null, "time", 0, true, true, false);
+    Dimension timeDim = ncfile.addDimension(null, "time", 0, true, false);
 
     // define Variables
 

--- a/docs/website/tds/UpgradingTo5.adoc
+++ b/docs/website/tds/UpgradingTo5.adoc
@@ -56,6 +56,7 @@ Deprecated classes and methods have been removed, and the module structure and t
 * see link:../netcdf-java/CDM/VariableLengthData.adoc
 
 === AutoCloseable
+
 *AutoCloseable* was introduced in Java 7, along with the _try-with-resources_ language feature. Use of this feature makes code more readable
 and more reliable in ensuring that resources (like file handles) are released when done. We strongly recommend that you modify your code to take advantage of it
 wherever possible, eg:
@@ -80,6 +81,7 @@ wherever possible, eg:
 ** *thredds.client.catalog.tools.DataFactory.Result*
 
 === Iterable
+
 *Iterable* was introduced in Java 7, along with the _foreach_ language feature, and makes code more readable with less boilerplate, eg:
 
 [source,java]
@@ -105,6 +107,7 @@ The interface is changed to remove _throws IOException_, which will now be wrapp
 ** *SectionFeatureCollection* implements _Iterable<SectionFeature>_ (replace _hasNext()_, _next()_, _finish()_, _resetIteration()_)
 
 === ucar.nc2.util.DiskCache2
+
 ** all instances of *DiskCache2* now have one cleanup thread
 ** The _DiskCache2.exit()_ method is now static and need only be called once when the application is exiting.
 ** _DiskCache2.setLogger()_ is removed.
@@ -113,6 +116,7 @@ The interface is changed to remove _throws IOException_, which will now be wrapp
 ** logging of routine cache cleanup is now at _DEBUG_ level
 
 ==== ucar.ma2.Range
+
 ** _Range.copy(String name)_ replaced by _Range.setName(String name)_
 ** _Range.getIterator()_ deprecated, use _Range.iterator()_
 ** Currently a Range is specified by _start:end:stride_
@@ -131,9 +135,11 @@ The interface is changed to remove _throws IOException_, which will now be wrapp
 ----
 
 === ucar.nc2.dataset
+
 ** CoordinateAxis2D.getMidpoints() was deprecated and now removed, use getCoordValuesArray()
 
 === ucar.nc2.ft.PointFeature
+
 * Added method `getTimeUnit()`. An implementation exists in `ucar.nc2.ft.point.PointFeatureImpl`, so if your
 `PointFeature` extends it, you shouldn't need to do any work.
 * Removed method `getObservationTimeAsDate()`. Instead, use `getObservationTimeAsCalendarDate().toDate()`.
@@ -141,6 +147,7 @@ The interface is changed to remove _throws IOException_, which will now be wrapp
 * Removed method `getData()`. Instead, use `getDataAll()`.
 
 === ucar.ma2.MAMath
+
 * Added method `equals(Array, Array)`. It is intended for use in `Object.equals()` implementations.
 This means, among other things, that corresponding floating-point elements must be exactly equal, not merely within
 some epsilon of each other.
@@ -201,6 +208,12 @@ The class *FeatureDatasetCoverage* replaces *GridDataset*.
 Previously, GRID was used as the general type, now it referes to a specific type of Coverage.
 Affects FeatureDatasetFactoryManager.open(FeatureType wantFeatureType, ...)
 
+=== Shared Dimensions
+
+* `Group.addDimension` and `Group.addDimensionIfNotExists` methods now throw an `IllegalArgumentException` if the
+dimension isn't shared.
+* `NetcdfFileWriter.addDimension` methods no longer have an `isShared` parameter. Such dimensions should always be
+shared and allowing them to be private is confusing and error-prone.
 
 === Catalogs
 

--- a/netcdf4/src/main/java/ucar/nc2/rewrite/Rewrite.java
+++ b/netcdf4/src/main/java/ucar/nc2/rewrite/Rewrite.java
@@ -35,7 +35,6 @@ package ucar.nc2.rewrite;
 
 import ucar.ma2.*;
 import ucar.nc2.*;
-import ucar.nc2.jni.netcdf.Nc4Iosp;
 
 import java.io.File;
 import java.io.IOException;
@@ -83,7 +82,7 @@ public class Rewrite {
       newGroup.addAttribute(att);
 
     for (Dimension dim : oldGroup.getDimensions()) {
-      ncOut.addDimension(newGroup, dim.getShortName(), dim.getLength(), true, dim.isUnlimited(), dim.isVariableLength());
+      ncOut.addDimension(newGroup, dim.getShortName(), dim.getLength(), dim.isUnlimited(), dim.isVariableLength());
     }
 
     for (Variable v : oldGroup.getVariables()) {
@@ -95,7 +94,7 @@ public class Rewrite {
           dim.setName("anon"+anon);
           dim.setShared(true);
           anon++;
-          ncOut.addDimension(newGroup, dim.getShortName(), dim.getLength(), true, dim.isUnlimited(), dim.isVariableLength());
+          ncOut.addDimension(newGroup, dim.getShortName(), dim.getLength(), dim.isUnlimited(), dim.isVariableLength());
         }
       }
 


### PR DESCRIPTION
* Group.addDimension() and Group.addDimensionIfNotExists() methods now throw an exception if the dimension isn't shared.
* NetcdfFileWriter.addDimension() methods no longer have an "isShared" parameter. Such dimensions should always be shared and allowing them to be private is confusing and error-prone.
* Update client code that uses those methods.
* Add notes to UpgradingTo5.adoc

Also, an unrelated but too-small-for-its-own-PR commit:
* If there's an exception when writing NcML <values>, produce less spammy warning. Don't include a stack trace.
