### PR TITLE
More GINI cleanup

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/gini/TestGini.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/gini/TestGini.java
@@ -57,31 +57,40 @@ public class TestGini{
     @Parameterized.Parameters(name="{0}")
     public static Collection giniFiles() {
         Object[][] data = new Object[][] {
-                {"n0r_20041013_1852-compress", "Reflectivity"},
-                {"n0r_20041013_1852-uncompress", "Reflectivity"},
-                {"n1p_20041206_2140", "Precipitation"},
-                {"ntp_20041206_2154", "Precipitation"},
-                {"AK-NATIONAL_8km_IR_20050912_2345.gini", "IR"},
-                {"PR-REGIONAL_4km_12.0_20050922_0600.gini", "IR"},
-                {"HI-NATIONAL_10km_SOUND-6.51_20050918_1824.gini", "sounder_imagery"},
-                {"HI-NATIONAL_14km_IR_20050918_2000.gini", "IR"},
-                {"HI-REGIONAL_4km_IR_20050919_1315.gini", "IR"},
-                {"SUPER-NATIONAL_1km_PW_20050923_1400.gini", "PW"},
-                {"SUPER-NATIONAL_1km_SFC-T_20050912_1900.gini", "SFC_T"},
-                {"SUPER-NATIONAL_8km_IR_20050911_2345.gini", "IR"},
-                {"EAST-CONUS_4km_12.0_20050912_0600.gini", "IR"},
-                {"EAST-CONUS_8km_13.3_20050912_2240.gini", "IR"},
-                {"WEST-CONUS_4km_3.9_20050912_2130.gini", "IR"}
+                {"n0r_20041013_1852-compress", "Reflectivity", 4736, 3000, -120.0, -80.190548, 23.0, 50.391550},
+                {"n0r_20041013_1852-uncompress", "Reflectivity", 4736, 3000, -120.0, -80.190548, 23.0, 50.391550},
+                {"n1p_20041206_2140", "Precipitation", 2368, 1500, -120.0, -80.189163, 23.0, 50.3905},
+                {"ntp_20041206_2154", "Precipitation", 1184, 750, -120.0, -80.189344, 23.0, 50.390403},
+                {"AK-NATIONAL_8km_IR_20050912_2345.gini", "IR", 1012, 874, 174.1623, -114.732224, 19.132, 84.121303},
+                {"PR-REGIONAL_4km_12.0_20050922_0600.gini", "IR", 480, 480, -77.0, -58.6254, 9.0, 26.4222},
+                {"HI-NATIONAL_10km_SOUND-6.51_20050918_1824.gini", "sounder_imagery", 1472, 1073, 109.9999, -109.1284, -25.0004, 60.6914},
+                {"HI-NATIONAL_14km_IR_20050918_2000.gini", "IR", 1012, 737, 109.9999, -109.1285, -25.0004, 60.6443},
+                {"HI-REGIONAL_4km_IR_20050919_1315.gini", "IR", 560, 520, -167.315, -145.878, 9.343, 28.0922},
+                {"SUPER-NATIONAL_1km_PW_20050923_1400.gini", "PW", 1536, 1008, -141.0274, -32.417681, 7.8381, 79.760853},
+                {"SUPER-NATIONAL_1km_SFC-T_20050912_1900.gini", "SFC_T", 1536, 1008, -141.0274, -32.417681, 7.8381, 79.760853},
+                {"SUPER-NATIONAL_8km_IR_20050911_2345.gini", "IR", 1536, 1008, -141.0274, -32.54069, 7.8381, 79.679395},
+                {"EAST-CONUS_4km_12.0_20050912_0600.gini", "IR", 1280, 1280, -113.1333, -68.314380, 16.3691, 63.081454},
+                {"EAST-CONUS_8km_13.3_20050912_2240.gini", "IR", 640, 640, -113.1333, -68.348871, 16.3691, 63.045506},
+                {"WEST-CONUS_4km_3.9_20050912_2130.gini", "IR", 1100, 1280, -133.4588, -94.225514, 12.19, 58.902354}
         };
         return Arrays.asList(data);
     }
 
     String fname, varName;
+    int xSize, ySize;
+    double min_lon, max_lon, min_lat, max_lat;
 
-    public TestGini(String fname, String varName)
+    public TestGini(String fname, String varName, int nx, int ny,
+                    double min_lon, double max_lon, double min_lat, double max_lat)
     {
         this.fname = fname;
         this.varName = varName;
+        this.xSize = nx;
+        this.ySize = ny;
+        this.min_lon = min_lon;
+        this.max_lon = max_lon;
+        this.min_lat = min_lat;
+        this.max_lat = max_lat;
     }
 
     @Test
@@ -89,10 +98,30 @@ public class TestGini{
         try (NetcdfFile ncfile = NetcdfFile.open(TestDir.cdmUnitTestDir + "formats/gini/" + fname)) {
             Variable v = ncfile.findVariable(varName);
 
-            // Make sure we can get the expected variable and that it is 2D
+            // Make sure we can get the expected variable and that it is at-least 2D
             Assert.assertNotNull(v);
             Assert.assertNotNull(v.getDimension(0));
             Assert.assertNotNull(v.getDimension(1));
+
+            // Check size
+            Assert.assertEquals(ySize,
+                    v.getDimension(v.findDimensionIndex("y")).getLength());
+            Assert.assertEquals(xSize,
+                    v.getDimension(v.findDimensionIndex("x")).getLength());
+
+            // Check projection info
+            Assert.assertEquals(min_lon,
+                    ncfile.findAttribute("@geospatial_lon_min").getNumericValue().doubleValue(),
+                    1e-6);
+            Assert.assertEquals(max_lon,
+                    ncfile.findAttribute("@geospatial_lon_max").getNumericValue().doubleValue(),
+                    1e-6);
+            Assert.assertEquals(min_lat,
+                    ncfile.findAttribute("@geospatial_lat_min").getNumericValue().doubleValue(),
+                    1e-6);
+            Assert.assertEquals(max_lat,
+                    ncfile.findAttribute("@geospatial_lat_max").getNumericValue().doubleValue(),
+                    1e-6);
 
             // Read the array and check that its size matches the variable's
             Array a = v.read();

--- a/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -309,7 +309,6 @@ class Giniheader {
     ** Get grid dimensions
     */
 
-    byte[] b3 = new byte[3];
     nx = bos.getShort();
     att = new Attribute("NX", nx);
     this.ncfile.addAttribute(null, att);
@@ -329,43 +328,23 @@ class Giniheader {
         */
 
         /* Latitude of first grid point */
-        bos.get(b3, 0, 3);
-        int nn = getInt(b3, 3);
-        lat1 = (double) nn / 10000.0;
-        Double nd = lat1;
-        att = new Attribute("Latitude0", nd);
+        lat1 = readScaledInt(bos);
+        att = new Attribute("Latitude0", lat1);
         this.ncfile.addAttribute(null, att);
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        int b33 = (b3[0] & (1 << 7));
-        //  if( b33 == 128)      //west longitude
-        //      nd = new Double(((double) nn) / 10000.0 * (-1));
-        //  else
-        nd = ((double) nn) / 10000.0;
-        lon1 = nd;
-        att = new Attribute("Longitude0", nd);
+        lon1 = readScaledInt(bos);
+        att = new Attribute("Longitude0", lon1);
         this.ncfile.addAttribute(null, att);
 
         /* Longitude of last grid point */
         bos.get(); /* skip one byte */
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        nd = ((double) nn) / 10000.0;
-        lat2 = nd;
-        att = new Attribute("LatitudeN", nd);
+        lat2 = readScaledInt(bos);
+        att = new Attribute("LatitudeN", lat2);
         this.ncfile.addAttribute(null, att);
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        b33 = (b3[0] & (1 << 7));
-        // if( b33 == 128)      //west longitude
-        //      nd = new Double(((double) nn) / 10000.0 * (-1));
-        //  else
-        nd = ((double) nn) / 10000.0;
-        lon2 = nd;
-        att = new Attribute("LongitudeN", nd);
+        lon2 = readScaledInt(bos);
+        att = new Attribute("LongitudeN", lon2);
         this.ncfile.addAttribute(null, att);
 
         /*
@@ -391,23 +370,11 @@ class Giniheader {
         bos.getInt(); /* skip 4 bytes */
         bos.get();    /* skip 1 byte */
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        nd = ((double) nn) / 10000.0;
-
         /* Latitude of proj cylinder intersects */
-        att = new Attribute("LatitudeX", nd);
-        latin = nd;
+        latin = readScaledInt(bos);
+        att = new Attribute("LatitudeX", latin);
         this.ncfile.addAttribute(null, att);
 
-        latt = 0.0; // this is not corrected  // jc 8/7/08 not used
-
-        // dyKm =  Math.cos( DEG_TO_RAD*latt);
-        // dxKm = DEG_TO_RAD * EARTH_RAD_KMETERS * Math.abs((lon_1-lon_2) / (nx-1));
-        //  double dy  =  EARTH_RAD_KMETERS * Math.cos(DEG_TO_RAD*latt) / (ny - 1);
-        //  dyKm = dy *( Math.log( Math.tan(DEG_TO_RAD*( (lat2-latt)/2.0 + 45.0 ) ) )
-        //                  -Math.log( Math.tan(DEG_TO_RAD*( (lat1-latt)/2.0 + 45.0 ) ) ) );
-        //  dxKm = DEG_TO_RAD * EARTH_RAD_KMETERS * Math.abs(lon1-lon2) / (ny-1);
         projection = new Mercator(lonv, latin);
         break;
 
@@ -416,50 +383,31 @@ class Giniheader {
         /*
         ** Get lat/lon of first grid point
         */
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        nd = ((double) nn) / 10000.0;
-        lat1 = nd;
-        //att = new Attribute( "Lat1", nd);
-        //this.ncfile.addAttribute(null, att);
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        nd = ((double) nn) / 10000.0;
-        lon1 = nd;
+        lat1 = readScaledInt(bos);
+        lon1 = readScaledInt(bos);
         /*
         ** Get Lov - the orientation of the grid; i.e. the east longitude of
         ** the meridian which is parallel to the y-aixs
         */
         bos.get(); /* skip one byte */
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        nd = ((double) nn) / 10000.0;
-        lonv = nd;
+        lonv = readScaledInt(bos);
         lonProjectionOrigin = lonv;
-        att = new Attribute("Lov", nd);
+        att = new Attribute("Lov", lonv);
         this.ncfile.addAttribute(null, att);
 
         /*
         ** Get distance increment of grid
         */
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        dxKm = ((double) nn) / 10000.0;
-
-        nd = ((double) nn) / 10000.;
-        att = new Attribute("DxKm", nd);
+        dxKm = readScaledInt(bos);
+        att = new Attribute("DxKm", dxKm);
         this.ncfile.addAttribute(null, att);
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        dyKm = ((double) nn) / 10000.0;
-
-        nd = ((double) nn) / 10000.;
-        att = new Attribute("DyKm", nd);
+        dyKm = readScaledInt(bos);
+        att = new Attribute("DyKm", dyKm);
         this.ncfile.addAttribute(null, att);
+
         /* calculate the lat2 and lon2 */
-
         if (proj == 5) {
           latt = 60.0;            /* Fixed for polar stereographic */
           imageScale = (1. + Math.sin(DEG_TO_RAD * latt)) / 2.;
@@ -467,11 +415,9 @@ class Giniheader {
 
         lat2 = lat1 + dyKm * (ny - 1) / 111.26;
 
-
         /* Convert to east longitude */
         if (lonv < 0.) lonv += 360.;
         if (lon1 < 0.) lon1 += 360.;
-
 
         lon2 = lon1 + dxKm * (nx - 1) / 111.26 * Math.cos(DEG_TO_RAD * lat1);
 
@@ -492,12 +438,8 @@ class Giniheader {
 
         bos.get(); /* skip one byte for Scanning mode */
 
-        bos.get(b3, 0, 3);
-        nn = getInt(b3, 3);
-        latin = (((double) nn) / 10000.);
-
-        nd = ((double) nn) / 10000.;
-        att = new Attribute("Latin", nd);
+        latin = readScaledInt(bos);
+        att = new Attribute("Latin", latin);
         this.ncfile.addAttribute(null, att);
 
         if (proj == 3)
@@ -1224,39 +1166,21 @@ class Giniheader {
 
   }
 
+  // Read a scaled, 3-byte integer from file and convert to double
+  private double readScaledInt(ByteBuffer buf) {
+    // Get the first two bytes
+    short s1 = buf.getShort();
 
-  /*
-  ** Name:       GetInt
-  **
-  ** Purpose:    Convert GINI 2 or 3-byte quantities to int
-  **
-  */
-  int getInt(byte[] b, int num) {
-    int base = 1;
-    int i;
-    int word = 0;
+    // And the last one as unsigned
+    short s2 = DataType.unsignedByteToShort(buf.get());
 
-    int bv[] = new int[num];
+    // Get the sign bit, converting from 0 or 2 to +/- 1.
+    int posneg = 1 - ((s1 & 0x8000) >> 14);
 
-    for (i = 0; i < num; i++) {
-      bv[i] = DataType.unsignedByteToShort(b[i]);
-    }
-
-    if (bv[0] > 127) {
-      bv[0] -= 128;
-      base = -1;
-    }
-      /*
-      ** Calculate the integer value of the byte sequence
-      */
-
-    for (i = num - 1; i >= 0; i--) {
-      word += base * bv[i];
-      base *= 256;
-    }
-
-    return word;
-
+    // Combine the first two bytes (without sign bit) with the last byte.
+    // Multiply by proper factor for +/-
+    int nn = (((s1 & 0x7FFF) << 8) | s2) * posneg;
+    return (double) nn / 10000.0;
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -57,12 +57,7 @@ import java.nio.*;
  */
 
 class Giniheader {
-  static final byte[] MAGIC = new byte[]{0x43, 0x44, 0x46, 0x01};
-  static final int MAGIC_DIM = 10;
-  static final int MAGIC_VAR = 11;
-  static final int MAGIC_ATT = 12;
-  private boolean debug = false, debugPos = false, debugString = false, debugHeaderSize = false;
-  private ucar.unidata.io.RandomAccessFile raf;
+  private boolean debug = false;
   private ucar.nc2.NetcdfFile ncfile;
   // private PrintStream out = System.out;
   static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Giniheader.class);
@@ -70,7 +65,7 @@ class Giniheader {
   int recsize = 0; // size of each record (padded)
   int dataStart = 0; // where the data starts
   int recStart = 0; // where the record data starts
-  int GINI_PIB_LEN = 21;   // gini product indentification block
+  int GINI_PIB_LEN = 21;   // gini product identification block
   int GINI_PDB_LEN = 512;  // gini product description block
   int GINI_HED_LEN = 533;  // gini product header
   double DEG_TO_RAD = 0.017453292;
@@ -91,7 +86,6 @@ class Giniheader {
 
 
   boolean validatePIB(ucar.unidata.io.RandomAccessFile raf) throws IOException {
-    this.raf = raf;
     this.actualSize = raf.length();
     int pos = 0;
     raf.seek(pos);
@@ -116,7 +110,6 @@ class Giniheader {
 
 
   byte[] readPIB(ucar.unidata.io.RandomAccessFile raf) throws IOException {
-    this.raf = raf;
     this.actualSize = raf.length();
     int doff = 0;
     int pos = 0;
@@ -156,7 +149,7 @@ class Giniheader {
     int inflatedLen = 0;
     int pos1 = 0;
 
-    if (isZlibHed(b2) == 1) {
+    if (Giniiosp.isZlibHed(b2)) {
       Z_type = 1;
       inflater.setInput(b, pos, GINI_HED_LEN);
       try {
@@ -197,8 +190,7 @@ class Giniheader {
     return head;
   }
 
-  void read(ucar.unidata.io.RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile, PrintStream out) throws IOException {
-    this.raf = raf;
+  void read(ucar.unidata.io.RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile) throws IOException {
     this.ncfile = ncfile;
     int proj;                        /* projection type indicator     */
                                             /* 1 - Mercator                  */
@@ -218,10 +210,9 @@ class Giniheader {
     int gminute;
     int gsecond;
     double lonv;                        /* meridian parallel to y-axis */
-    double diff_lon;
     double lon1 = 0.0, lon2 = 0.0;
     double lat1 = 0.0, lat2 = 0.0;
-    double latt = 0.0, lont = 0.0;
+    double latt;
     double imageScale = 0.0;
     //long       hoff = 0;
 
@@ -236,7 +227,6 @@ class Giniheader {
     this.ncfile.addAttribute(null, att);
 
     bos.position(0);
-    byte[] b2 = new byte[2];
 
     //sat_id = (int )( raf.readByte());
     Byte nv = bos.get();
@@ -320,17 +310,12 @@ class Giniheader {
     */
 
     byte[] b3 = new byte[3];
-    bos.get(b2, 0, 2);
-    nx = getInt(b2, 2);
-    Integer ni = nx;
-    att = new Attribute("NX", ni);
+    nx = bos.getShort();
+    att = new Attribute("NX", nx);
     this.ncfile.addAttribute(null, att);
 
-
-    bos.get(b2, 0, 2);
-    ny = getInt(b2, 2);
-    ni = ny;
-    att = new Attribute("NY", ni);
+    ny = bos.getShort();
+    att = new Attribute("NY", ny);
     this.ncfile.addAttribute(null, att);
 
     ProjectionImpl projection = null;
@@ -490,10 +475,6 @@ class Giniheader {
 
         lon2 = lon1 + dxKm * (nx - 1) / 111.26 * Math.cos(DEG_TO_RAD * lat1);
 
-        diff_lon = lonv - lon1;
-
-        if (diff_lon > 180.) diff_lon -= 360.;
-        if (diff_lon < -180.) diff_lon += 360.;
         /*
         ** Convert to normal longitude to McIDAS convention
         */
@@ -506,8 +487,7 @@ class Giniheader {
         nv = bos.get();
         pole = nv.intValue();
         pole = (pole > 127) ? -1 : 1;
-        ni = pole;
-        att = new Attribute("ProjCenter", ni);
+        att = new Attribute("ProjCenter", pole);
         this.ncfile.addAttribute(null, att);
 
         bos.get(); /* skip one byte for Scanning mode */
@@ -529,10 +509,7 @@ class Giniheader {
 
       default:
         System.out.println("unimplemented projection");
-
-
     }
-
 
     this.ncfile.addAttribute(null, new Attribute("title", gini_GetEntityID(ent_id)));
     this.ncfile.addAttribute(null, new Attribute("summary", getPhysElemSummary(phys_elem, ent_id)));
@@ -544,10 +521,10 @@ class Giniheader {
     this.ncfile.addAttribute(null, new Attribute("creator_name", "UNIDATA"));
     this.ncfile.addAttribute(null, new Attribute("creator_url", "http://www.unidata.ucar.edu/"));
     this.ncfile.addAttribute(null, new Attribute("naming_authority", "UCAR/UOP"));
-    this.ncfile.addAttribute(null, new Attribute("geospatial_lat_min", new Float(lat1)));
-    this.ncfile.addAttribute(null, new Attribute("geospatial_lat_max", new Float(lat2)));
-    this.ncfile.addAttribute(null, new Attribute("geospatial_lon_min", new Float(lon1)));
-    this.ncfile.addAttribute(null, new Attribute("geospatial_lon_max", new Float(lon2)));
+    this.ncfile.addAttribute(null, new Attribute("geospatial_lat_min", lat1));
+    this.ncfile.addAttribute(null, new Attribute("geospatial_lat_max", lat2));
+    this.ncfile.addAttribute(null, new Attribute("geospatial_lon_min", lon1));
+    this.ncfile.addAttribute(null, new Attribute("geospatial_lon_max", lon2));
     //this.ncfile.addAttribute(null, new Attribute("geospatial_vertical_min", new Float(0.0)));
     //this.ncfile.addAttribute(null, new Attribute("geospatial_vertical_max", new Float(0.0)));
 
@@ -566,7 +543,7 @@ class Giniheader {
     att = new Attribute("compressionFlag", nv);
     this.ncfile.addAttribute(null, att);
 
-    if (convertunsignedByte2Short(nv) == 128) {
+    if (DataType.unsignedByteToShort(nv) == 128) {
       Z_type = 2;
       //out.println( "ReadNexrInfo:: This is a Z file ");
     }
@@ -574,7 +551,7 @@ class Giniheader {
    /* new 47 - 60 */
     bos.position(46);
     nv = bos.get();      /* Cal indicator */
-    int navcal = convertunsignedByte2Short(nv);
+    int navcal = DataType.unsignedByteToShort(nv);
     int[] calcods = null;
     if (navcal == 128)
       calcods = getCalibrationInfo(bos, phys_elem, ent_id);
@@ -588,7 +565,6 @@ class Giniheader {
     // var.addAttribute( new Attribute(CDM.MISSING_VALUE, new Byte((byte) 0))); // ??
 
     // get dimensions
-    int velems;
     List<Dimension> dims = new ArrayList<>();
 
     Dimension dimX = new Dimension("x", nx, true, false, false);
@@ -597,7 +573,6 @@ class Giniheader {
     ncfile.addDimension(null, dimY);
     ncfile.addDimension(null, dimX);
 
-    velems = dimX.getLength() * dimY.getLength();
     dims.add(dimT);
     dims.add(dimY);
     dims.add(dimX);
@@ -606,7 +581,7 @@ class Giniheader {
 
     // size and beginning data position in file
     long begin = dataStart;
-    if (debug) log.warn(" name= " + vname + " velems=" + velems + " begin= " + begin + "\n");
+    if (debug) log.warn(" name= " + vname + " velems=" + var.getSize() + " begin= " + begin + "\n");
     if (navcal == 128) {
       var.setDataType(DataType.FLOAT);
       var.setSPobject(new Vinfo(begin, nx, ny, calcods));
@@ -718,20 +693,19 @@ class Giniheader {
 
     bos.position(46);
     byte nv = bos.get();      /* Cal indicator */
-    int navcal = convertunsignedByte2Short(nv);
+    int navcal = DataType.unsignedByteToShort(nv);
     int[] calcods = null;
     if (navcal == 128) {    /* Unidata Cal block found; unpack values */
       int scale = 10000;
       int jscale = 100000000;
       byte[] unsb = new byte[8];
-      byte[] b4 = new byte[4];
       bos.get(unsb);
       String unitStr = new String(unsb, CDM.utf8Charset).toUpperCase();
       String iname;
       String iunit;
       bos.position(55);
       nv = bos.get();
-      int calcod = convertunsignedByte2Short(nv);
+      int calcod = DataType.unsignedByteToShort(nv);
 
       if (unitStr.contains("INCH")) {
         iname = "RAIN";
@@ -763,14 +737,10 @@ class Giniheader {
         for (int i = 0; i < calcod; i++) {
 
           bos.position(56 + i * 16);
-          bos.get(b4);
-          int minb = getInt(b4, 4) / 10000;        /* min brightness values         */
-          bos.get(b4);
-          int maxb = getInt(b4, 4) / 10000;       /* max brightness values         */
-          bos.get(b4);
-          int mind = getInt(b4, 4);               /* min data values               */
-          bos.get(b4);
-          int maxd = getInt(b4, 4);               /* max data values               */
+          int minb = bos.getInt() / 10000;        /* min brightness values         */
+          int maxb = bos.getInt() / 10000;       /* max brightness values         */
+          int mind = bos.getInt();               /* min data values               */
+          int maxd = bos.getInt();               /* max data values               */
 
           int idscal = 1;
           while (mind % idscal == 0 && maxd % idscal == 0) {
@@ -809,7 +779,6 @@ class Giniheader {
     }
 
     return calcods;
-
   }
 
 
@@ -1270,7 +1239,7 @@ class Giniheader {
     int bv[] = new int[num];
 
     for (i = 0; i < num; i++) {
-      bv[i] = convertunsignedByte2Short(b[i]);
+      bv[i] = DataType.unsignedByteToShort(b[i]);
     }
 
     if (bv[0] > 127) {
@@ -1288,50 +1257,6 @@ class Giniheader {
 
     return word;
 
-  }
-
-  public short convertunsignedByte2Short(byte b) {
-    return (short) ((b < 0) ? (short) b + 256 : (short) b);
-  }
-
-
-  // this converts a byte array to a wrapped primitive (Byte, Short, Integer, Double, Float, Long)
-  protected Object convert(byte[] barray, DataType dataType, int byteOrder) {
-
-    if (dataType == DataType.BYTE) {
-      return barray[0];
-    }
-
-    if (dataType == DataType.CHAR) {
-      return (char) barray[0];
-    }
-
-    ByteBuffer bbuff = ByteBuffer.wrap(barray);
-    if (byteOrder >= 0)
-      bbuff.order(byteOrder == ucar.unidata.io.RandomAccessFile.LITTLE_ENDIAN ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
-
-    if (dataType == DataType.SHORT) {
-      ShortBuffer tbuff = bbuff.asShortBuffer();
-      return tbuff.get();
-
-    } else if (dataType == DataType.INT) {
-      IntBuffer tbuff = bbuff.asIntBuffer();
-      return tbuff.get();
-
-    } else if (dataType == DataType.LONG) {
-      LongBuffer tbuff = bbuff.asLongBuffer();
-      return tbuff.get();
-
-    } else if (dataType == DataType.FLOAT) {
-      FloatBuffer tbuff = bbuff.asFloatBuffer();
-      return tbuff.get();
-
-    } else if (dataType == DataType.DOUBLE) {
-      DoubleBuffer tbuff = bbuff.asDoubleBuffer();
-      return tbuff.get();
-    }
-
-    throw new IllegalStateException();
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1355,23 +1280,6 @@ class Giniheader {
       this.ny = y;
       this.levels = levels;
     }
-
-  }
-
-
-  int isZlibHed(byte[] buf) {
-    short b0 = convertunsignedByte2Short(buf[0]);
-    short b1 = convertunsignedByte2Short(buf[1]);
-
-    if ((b0 & 0xf) == Z_DEFLATED) {
-      if ((b0 >> 4) + 8 <= DEF_WBITS) {
-        if ((((b0 << 8) + b1) % 31) == 0) {
-          return 1;
-        }
-      }
-    }
-
-    return 0;
 
   }
 

--- a/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1998-2014 University Corporation for Atmospheric Research/Unidata
+ * Copyright 1998-2015 University Corporation for Atmospheric Research/Unidata
  *
  *   Portions of this software were developed by the Unidata Program at the
  *   University Corporation for Atmospheric Research.
@@ -57,25 +57,17 @@ import java.nio.*;
  */
 
 class Giniheader {
+  static private final int GINI_PIB_LEN = 21;   // gini product identification block
+  static private final int GINI_PDB_LEN = 512;  // gini product description block
+  static private final int GINI_HED_LEN = GINI_PDB_LEN + GINI_PIB_LEN;  // gini product header
+  static private final double DEG_TO_RAD = 0.017453292;
   private boolean debug = false;
   private ucar.nc2.NetcdfFile ncfile;
-  // private PrintStream out = System.out;
   static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Giniheader.class);
-  int numrecs = 0; // number of records written
-  int recsize = 0; // size of each record (padded)
   int dataStart = 0; // where the data starts
-  int recStart = 0; // where the record data starts
-  int GINI_PIB_LEN = 21;   // gini product identification block
-  int GINI_PDB_LEN = 512;  // gini product description block
-  int GINI_HED_LEN = 533;  // gini product header
-  double DEG_TO_RAD = 0.017453292;
-  double EARTH_RAD_KMETERS = 6371.200;
-  byte Z_DEFLATED = 8;
-  byte DEF_WBITS = 15;
-  private long actualSize, calcSize;
   protected int Z_type = 0;
 
-  public boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) {
+  static public boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) {
     try {
       return validatePIB(raf);
     } catch (IOException e) {
@@ -84,16 +76,8 @@ class Giniheader {
     }
   }
 
-
-  boolean validatePIB(ucar.unidata.io.RandomAccessFile raf) throws IOException {
-    this.actualSize = raf.length();
-    int pos = 0;
-    raf.seek(pos);
-
-    // gini header process
-    String pib = raf.readString(GINI_PIB_LEN + GINI_HED_LEN);
-
-    pos = pib.indexOf("KNES");
+  static private int findWMOHeader(String pib) {
+    int pos = pib.indexOf("KNES");
     if (pos == -1) pos = pib.indexOf("CHIZ");
 
     if (pos != -1) {                    /* 'KNES' or 'CHIZ' found         */
@@ -103,15 +87,21 @@ class Giniheader {
       }
     } else {
       pos = 0;
-      return false;
     }
-    return true;
+    return pos;
   }
 
+  static boolean validatePIB(ucar.unidata.io.RandomAccessFile raf) throws IOException {
+    int pos = 0;
+    raf.seek(pos);
+
+    // gini header process
+    String pib = raf.readString(GINI_PIB_LEN + GINI_HED_LEN);
+
+    return findWMOHeader(pib) != 0;
+  }
 
   byte[] readPIB(ucar.unidata.io.RandomAccessFile raf) throws IOException {
-    this.actualSize = raf.length();
-    int doff = 0;
     int pos = 0;
     raf.seek(pos);
 
@@ -123,58 +113,31 @@ class Giniheader {
     raf.readFully(b);
     String pib = new String(b, CDM.utf8Charset);
 
-    //if( !pib.startsWith("TICZ")) return (int)pos; // gini header start with TICZ 99....
-
-    pos = pib.indexOf("KNES");
-    if (pos == -1) pos = pib.indexOf("CHIZ");
-
-    if (pos != -1) {                    /* 'KNES' or 'CHIZ' found         */
-      pos = pib.indexOf("\r\r\n");    /* <<<<< UPC mod 20030710 >>>>>   */
-      if (pos != -1) {                 /* CR CR NL found             */
-        pos = pos + 3;
-      }
-    } else {
-      pos = 0;
-    }
-
+    pos = findWMOHeader(pib);
     dataStart = pos + GINI_PDB_LEN;
 
     // Test the next two bytes to see if the image portion looks like
     // it is zlib-compressed
-    byte[] b2 = new byte[2];
-    b2[0] = b[pos];
-    b2[1] = b[pos + 1];
-    Inflater inflater = new Inflater(false);
-    int resultLength = 0;
-    int inflatedLen = 0;
+    byte[] b2 = new byte[] {b[pos], b[pos + 1]};
     int pos1 = 0;
 
     if (Giniiosp.isZlibHed(b2)) {
       Z_type = 1;
+      Inflater inflater = new Inflater(false);
       inflater.setInput(b, pos, GINI_HED_LEN);
       try {
-        resultLength = inflater.inflate(buf, 0, GINI_HED_LEN);
+        int resultLength = inflater.inflate(buf, 0, GINI_HED_LEN);
+        if (resultLength != GINI_HED_LEN) log.warn("GINI: Zlib inflated image header size error");
       } catch (DataFormatException ex) {
-        log.warn("ERROR on inflation " + ex.getMessage());
+        log.error("ERROR on inflation " + ex.getMessage());
         ex.printStackTrace();
         throw new IOException(ex.getMessage());
       }
 
-      if (resultLength != GINI_HED_LEN) System.out.println("Zlib inflated image header size error");
-      inflatedLen = GINI_HED_LEN - inflater.getRemaining();
+      int inflatedLen = GINI_HED_LEN - inflater.getRemaining();
 
       String inf = new String(buf, CDM.utf8Charset);
-      pos1 = inf.indexOf("KNES");
-      if (pos1 == -1) pos1 = inf.indexOf("CHIZ");
-
-      if (pos1 != -1) {                    /* 'KNES' or 'CHIZ' found         */
-        pos1 = inf.indexOf("\r\r\n");    /* <<<<< UPC mod 20030710 >>>>>   */
-        if (pos1 != -1) {                 /* CR CR NL found             */
-          pos1 = pos1 + 3;
-        }
-      } else {
-        pos1 = 0;
-      }
+      pos1 = findWMOHeader(inf);
 
       System.arraycopy(buf, pos1, head, 0, GINI_PDB_LEN);
       dataStart = pos + inflatedLen;
@@ -214,14 +177,9 @@ class Giniheader {
     double lat1 = 0.0, lat2 = 0.0;
     double latt;
     double imageScale = 0.0;
-    //long       hoff = 0;
 
-
-    // long pos = GINI_PIB_LEN;
     byte[] head = readPIB(raf);
     ByteBuffer bos = ByteBuffer.wrap(head);
-    //if (out != null) this.out = out;
-    actualSize = raf.length();
 
     Attribute att = new Attribute(CDM.CONVENTIONS, "GRIB");
     this.ncfile.addAttribute(null, att);
@@ -251,7 +209,7 @@ class Giniheader {
     bos.position(bos.position() + 4);
 
     gyear = (int) (bos.get());
-    gyear += (gyear < 50) ? 2000 : 1900;
+    gyear += (gyear < 50) ? 2000 : 1900; //TODO: Find example where this hack is necessary
     gmonth = (int) (bos.get());
     gday = (int) (bos.get());
     ghour = (int) (bos.get());
@@ -357,7 +315,7 @@ class Giniheader {
         if (lon1 < 0) lon_1 += 360.0;
         if (lon2 < 0) lon_2 += 360.0;
 
-        lonv = lon_1 - (lon_1 - lon_2) / 2.0;
+        lonv = (lon_1 + lon_2) / 2.0;
 
         if (lonv > 180.0) lonv -= 360.0;
         if (lonv < -180.0) lonv += 360.0;
@@ -552,7 +510,7 @@ class Giniheader {
     // latin, lov, la1, lo1
 
     // we have to project in order to find the origin
-    ProjectionPointImpl start = (ProjectionPointImpl) projection.latLonToProj(new LatLonPointImpl(lat1, lon1));
+    ProjectionPoint start = projection.latLonToProj(new LatLonPointImpl(lat1, lon1));
     if (debug) log.warn("start at proj coord " + start);
 
     double startx = start.getX();
@@ -575,7 +533,7 @@ class Giniheader {
 
       for (int i = 0; i < data.length; i++) {
         double ln = lon1 + i * dx;
-        ProjectionPointImpl pt = (ProjectionPointImpl) projection.latLonToProj(new LatLonPointImpl(lat1, ln));
+        ProjectionPoint pt = projection.latLonToProj(new LatLonPointImpl(lat1, ln));
         data[i] = pt.getX();  // startx + i*dx;
       }
     } else {
@@ -599,7 +557,7 @@ class Giniheader {
       double dy = (lat2 - lat1) / (ny - 1);
       for (int i = 0; i < data.length; i++) {
         double la = lat2 - i * dy;
-        ProjectionPointImpl pt = (ProjectionPointImpl) projection.latLonToProj(new LatLonPointImpl(la, lon1));
+        ProjectionPoint pt = projection.latLonToProj(new LatLonPointImpl(la, lon1));
         data[i] = pt.getY();  //endyy - i*dy;
       }
     } else {

--- a/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniiosp.java
+++ b/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniiosp.java
@@ -73,7 +73,7 @@ public class Giniiosp extends AbstractIOServiceProvider {
     super.open(raf, ncfile, cancelTask);
 
     headerParser = new Giniheader();
-    headerParser.read(raf, ncfile, null);
+    headerParser.read(raf, ncfile);
 
     ncfile.finish();
   }
@@ -111,7 +111,7 @@ public class Giniiosp extends AbstractIOServiceProvider {
     }
 
     for (int i = 0; i < data.length; i++) {
-      int ival = convertUnsignedByte2Short(data[i]);
+      int ival = DataType.unsignedByteToShort(data[i]);
       int k = -1;
       for (int j = 0; j < level; j++) {
         if (levels[3 + (j * 5)] <= ival && ival <= levels[4 + (j * 5)]) {
@@ -271,7 +271,7 @@ public class Giniiosp extends AbstractIOServiceProvider {
           // Check if remaining data are zlib--if not copy out and bail
           byte[] b2 = new byte[2];
           System.arraycopy(data, inputOffset, b2, 0, b2.length);
-          if (isZlibHed(b2) == 0) {
+          if (!isZlibHed(b2)) {
             System.arraycopy(data, inputOffset, uncomp, offset, bytesLeft);
             break;
           }
@@ -336,51 +336,19 @@ public class Giniiosp extends AbstractIOServiceProvider {
 
   }
 
-  /*
-  ** Name:       IsZlibed
-  **
-  ** Purpose:    Check a two-byte sequence to see if it indicates the start of
-  **             a zlib-compressed buffer
-  **
-  ** Parameters:
-  **             buf     - buffer containing at least two bytes
-  **
-  ** Returns:
-  **             SUCCESS 1
-  **             FAILURE 0
-  **
-  *
-  int issZlibed(byte[] buf) {
-
-    if ((buf[0] & 0xf) == Z_DEFLATED) {
-      if ((buf[0] >> 4) + 8 <= DEF_WBITS) {
-        if ((((buf[0] << 8) + (buf[1])) % 31) == 0) {
-          return 1;
-        }
-      }
-    }
-
-    return 0;
-  }  */
-
-  // get this to inline for performance
-  private short convertUnsignedByte2Short(byte b) {
-    return (short) ((b < 0) ? (short) b + 256 : (short) b);
-  }
-
-  private int isZlibHed(byte[] buf) {
-    short b0 = convertUnsignedByte2Short(buf[0]);
-    short b1 = convertUnsignedByte2Short(buf[1]);
+  static boolean isZlibHed(byte[] buf) {
+    short b0 = DataType.unsignedByteToShort(buf[0]);
+    short b1 = DataType.unsignedByteToShort(buf[1]);
 
     if ((b0 & 0xf) == Z_DEFLATED) {
       if ((b0 >> 4) + 8 <= DEF_WBITS) {
         if ((((b0 << 8) + b1) % 31) == 0) {
-          return 1;
+          return true;
         }
       }
     }
 
-    return 0;
+    return false;
   }
 
   public String getFileTypeId() {


### PR DESCRIPTION
- Make tests check more of processing
- Refactor to remove duplicated code
- Use general purpose functions instead of custom code for ubyte->short
- Refactor function for converting 24-bit scaled ints to double.
- Remove unused code

Another 210 lines gone. 0 loss of functionality.