### PR TITLE
Fix writing subset Arrays to NetCDF 4 (Fixes #301)

### DIFF
--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -2832,7 +2832,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     boolean isUnsigned = isUnsigned(typeid);
     int sectionLen = (int) section.computeSize();
 
-    Object data = values.getStorage();
+    Object data = values.get1DJavaArray(values.getElementType());
 
     switch (typeid) {
 


### PR DESCRIPTION
Can't just blindly grab the storage object, as the array may be a subset
of another array. Call methods as needed to generate a true 1D array.

With tests.