### PR TITLE
Add explicit logger dependencies to :legacy and :waterml. Fixes #335.

### DIFF
--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile project(":cdm")
     compile project(":opendap")
     compile libraries["aws-java-sdk-s3"]  // For CrawlableDatasetAmazonS3.
+    compile libraries["slf4j-api"]
 
     // These are all for Spock.
     testCompile libraries["spock-core"]

--- a/waterml/build.gradle
+++ b/waterml/build.gradle
@@ -21,4 +21,5 @@ dependencies {
 
     compile libraries["guava"]
     compile libraries["joda-time"]
+    compile libraries["slf4j-api"]
 }


### PR DESCRIPTION
* This will cause the logic in testing.gradle to add a testRuntime dep on "slf4j-jdk14"