### PR TITLE
Changes refs to thredds-dev to thredds-test.

### DIFF
--- a/cdm-test/src/test/java/thredds/inventory/TestDateExtractorFromName.java
+++ b/cdm-test/src/test/java/thredds/inventory/TestDateExtractorFromName.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @RunWith(Parameterized.class)
 public class TestDateExtractorFromName {
-  static String base = "thredds:resolve:http://"+ TestDir.threddsServer+"/thredds/";
+  static String base = "thredds:resolve:http://"+ TestDir.threddsTestServer+"/thredds/";
 
   @Parameterized.Parameters(name="{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
@@ -207,7 +207,7 @@ public class TestGridSubset {
   @Test
   @Category(NeedsExternalResource.class)
   public void testDODS() throws Exception {
-    String ds = "http://"+TestDir.threddsServer+"/thredds/catalog/grib/NCEP/DGEX/CONUS_12km/files/latest.xml";
+    String ds = "http://"+TestDir.threddsTestServer+"/thredds/catalog/grib/NCEP/DGEX/CONUS_12km/files/latest.xml";
     GridDataset dataset = null;
 
     try {
@@ -340,7 +340,7 @@ public class TestGridSubset {
   @Test
   @Category(NeedsExternalResource.class)
   public void test3D() throws Exception {
-    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsDevServer+"/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best")) {
+    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsTestServer+"/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best")) {
       System.out.printf("%s%n", dataset.getLocation());
       //GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsServer+"/thredds/dodsC/grib/NCEP/NAM/CONUS_12km/best");
 
@@ -506,7 +506,7 @@ public class TestGridSubset {
   @Test
   @Category(NeedsExternalResource.class)
   public void testBBSubset() throws Exception {
-    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsServer+"/thredds/dodsC/grib/NCEP/GFS/CONUS_80km/best")) {
+    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsTestServer+"/thredds/dodsC/grib/NCEP/GFS/CONUS_80km/best")) {
       GeoGrid grid = dataset.findGridByName("Pressure_surface");
       assert null != grid;
       GridCoordSystem gcs = grid.getCoordinateSystem();
@@ -535,7 +535,7 @@ public class TestGridSubset {
   @Test
   @Category(NeedsExternalResource.class)
   public void testBBSubset2() throws Exception {
-    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsServer+"/thredds/dodsC/grib/NCEP/NAM/CONUS_40km/conduit/best")) {
+    try (GridDataset dataset = GridDataset.open("dods://"+TestDir.threddsTestServer+"/thredds/dodsC/grib/NCEP/NAM/CONUS_40km/conduit/best")) {
       GeoGrid grid = dataset.findGridByName("Pressure_hybrid");
       assert null != grid;
       GridCoordSystem gcs = grid.getCoordinateSystem();
@@ -761,7 +761,7 @@ public class TestGridSubset {
   @Test
   @Category(NeedsExternalResource.class)
   public void testFindVerticalCoordinate() throws Exception {
-    String filename = "dods://"+TestDir.threddsServer+"/thredds/dodsC/grib/NCEP/NAM/Alaska_11km/best";
+    String filename = "dods://"+TestDir.threddsTestServer+"/thredds/dodsC/grib/NCEP/NAM/Alaska_11km/best";
     try (GridDataset dataset = GridDataset.open(filename)) {
       GeoGrid grid = dataset.findGridByName("Geopotential_height_isobaric");
       assert null != grid;

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadAndCountMisc.java
@@ -49,7 +49,7 @@ public class TestReadAndCountMisc {
   // We assume that thredds.ucar.edu is unreachable due to some limitation and/or bug in Travis.
   @Test
   public void testLiveServer() throws Exception {
-    TestReadandCount.doOne("thredds:resolve:http://"+TestDir.threddsServer+"/thredds/",
+    TestReadandCount.doOne("thredds:resolve:http://"+TestDir.threddsTestServer+"/thredds/",
             "catalog/grib/NCEP/NAM/CONUS_20km/noaaport/files/latest.xml", 33, 9, 11, 7);  // flips between 40 and 33
   }
 
@@ -61,7 +61,7 @@ public class TestReadAndCountMisc {
 
   @Test
   public void testDevServer() throws Exception {
-    TestReadandCount.doOne("thredds:resolve:http://"+TestDir.threddsDevServer+"/thredds/",
+    TestReadandCount.doOne("thredds:resolve:http://"+TestDir.threddsTestServer+"/thredds/",
             "catalog/grib/NCEP/NAM/CONUS_20km/noaaport/files/latest.xml", 33, 9, 11, 7);
   }
 }

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestGempakAll.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestGempakAll.java
@@ -122,7 +122,7 @@ public class TestGempakAll {
 
   @Category(NeedsExternalResource.class)
   public void utestCdmRemote() throws IOException {
-    TestPointDatasets.checkPointDataset("cdmremote:http://"+TestDir.threddsServer+"/thredds/cdmremote/idd/metar/gempak", FeatureType.STATION, true);
+    TestPointDatasets.checkPointDataset("cdmremote:http://"+TestDir.threddsTestServer+"/thredds/cdmremote/idd/metar/gempak", FeatureType.STATION, true);
     //checkPointDataset("cdmremote:http://localhost:8080/thredds/cdmremote/idd/metar/ncdecodedLocal", FeatureType.STATION, true);
   }
 
@@ -131,7 +131,7 @@ public class TestGempakAll {
     //testDon3("cdmremote:http://motherlode.ucar.edu:9080/thredds/cdmremote/idd/metar/gempak", false);
     while (true) {
       // testDon2("cdmremote:http://localhost:8080/thredds/cdmremote/idd/metar/gempakLocal", false);
-      testDon2("cdmremote:http://"+TestDir.threddsServer+"/thredds/cdmremote/idd/metar/gempak", true);
+      testDon2("cdmremote:http://"+TestDir.threddsTestServer+"/thredds/cdmremote/idd/metar/gempak", true);
       Thread.sleep(60 * 1000);
     }
 

--- a/cdm-test/src/test/java/ucar/nc2/util/net/TestStream.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/TestStream.java
@@ -60,7 +60,7 @@ import ucar.unidata.test.util.TestDir;
 public class TestStream {
   @Test
   public void testStream1() throws URISyntaxException {
-    String catalogName = "http://"+ TestDir.threddsServer+"/thredds/catalog.xml";
+    String catalogName = "http://"+ TestDir.threddsTestServer+"/thredds/catalog.xml";
     URI catalogURI = new URI(catalogName);
 
     try {
@@ -84,7 +84,7 @@ public class TestStream {
 
   @Test
   public void testString() throws URISyntaxException {
-    String catalogName = "http://"+TestDir.threddsServer+"/thredds/catalog.xml";
+    String catalogName = "http://"+TestDir.threddsTestServer+"/thredds/catalog.xml";
     URI catalogURI = new URI(catalogName);
 
     try {

--- a/cdm/src/test/java/ucar/unidata/test/util/CompareNetcdf.java
+++ b/cdm/src/test/java/ucar/unidata/test/util/CompareNetcdf.java
@@ -433,7 +433,7 @@ public class CompareNetcdf {
 
   public static void main(String arg[]) throws IOException {
     NetcdfFile ncfile1 = NetcdfDataset.openFile("dods://thredds.cise-nsf.gov:8080/thredds/dodsC/satellite/SFC-T/SUPER-NATIONAL_1km/20090516/SUPER-NATIONAL_1km_SFC-T_20090516_2200.gini", null);
-    NetcdfFile ncfile2 = NetcdfDataset.openFile("dods://"+TestDir.threddsServer+"/thredds/dodsC/satellite/SFC-T/SUPER-NATIONAL_1km/20090516/SUPER-NATIONAL_1km_SFC-T_20090516_2200.gini", null);
+    NetcdfFile ncfile2 = NetcdfDataset.openFile("dods://"+TestDir.threddsTestServer+"/thredds/dodsC/satellite/SFC-T/SUPER-NATIONAL_1km/20090516/SUPER-NATIONAL_1km_SFC-T_20090516_2200.gini", null);
     compareFiles(ncfile1, ncfile2, false, true, false);
   }
 }

--- a/cdm/src/test/java/ucar/unidata/test/util/TestDir.java
+++ b/cdm/src/test/java/ucar/unidata/test/util/TestDir.java
@@ -32,9 +32,8 @@ import java.util.*;
  *         if the "unidata.testdata.path" and "unidata.upc.share.path" are not
  *         available as system properties.
  * <tr><td>threddsServerPropName<td>thredds
- *     <td>Property name for the hostname of standard thredds server.
- * <tr><td>threddsDevServerPropName<td>thredds-dev
- *     <td>Property name for the hostname of the Java library thredds development server.
+ *     <td>Property name for the hostname of standard thredds server. Only used in
+ *         classes that explicitly reference motherlode.
  * <tr><td>threddsTestServerPropName<td>thredds-test
  *     <td>Property name for the hostname of the Java library thredds test server.
  * <tr><td>remoteTestServerPropName<td>remotetest
@@ -107,9 +106,6 @@ public class TestDir {
 
   static public String threddsServerPropName = "threddsserver";
   static public String threddsServer = "thredds.ucar.edu";
-
-  static public String threddsDevServerPropName = "threddsdevserver";
-  static public String threddsDevServer = "thredds-dev.unidata.ucar.edu";
 
   static public String threddsTestServerPropName = "threddstestserver";
   static public String threddsTestServer = "thredds-test.unidata.ucar.edu";
@@ -188,10 +184,6 @@ public class TestDir {
     String ts = System.getProperty(threddsServerPropName);
     if(ts != null && ts.length() > 0)
       	threddsServer = ts;
-
-    String tds = System.getProperty(threddsDevServerPropName);
-    if(tds != null && tds.length() > 0)
-      	threddsDevServer = tds;
 
     String tts = System.getProperty(threddsTestServerPropName);
     if(tts != null && tts.length() > 0)

--- a/it/src/test/java/thredds/tds/PoundTdsWmsTest.java
+++ b/it/src/test/java/thredds/tds/PoundTdsWmsTest.java
@@ -217,8 +217,8 @@ public class PoundTdsWmsTest
                   "2010-11-02T21:00:00.000Z",
                   "2010-11-03T00:00:00.000Z"
           };
-  private static String ml8081GfsHalfDegreeBestWmsGetCapUrl = "http://"+ TestDir.threddsServer+"/thredds/wms/fmrc/NCEP/GFS/Global_0p5deg/NCEP-GFS-Global_0p5deg_best.ncd?service=WMS&version=1.3.0&request=GetCapabilities";
-  private static String ml8081GfsHalfDegreeBestWmsGetMapBaseUrl = "http://"+TestDir.threddsServer+"/thredds/wms/fmrc/NCEP/GFS/Global_0p5deg/NCEP-GFS-Global_0p5deg_best.ncd?service=WMS&version=1.3.0&request=GetMap&TRANSPARENT=true&STYLES=boxfill%2Frainbow&CRS=EPSG%3A4326&COLORSCALERANGE=0.2%2C62.9&NUMCOLORBANDS=20&LOGSCALE=false&EXCEPTIONS=XML&FORMAT=image%2Fpng&BBOX=-180,-90,180,90&WIDTH=256&HEIGHT=256&LAYERS=Precipitable_water&ELEVATION=0&TIME=";
+  private static String ml8081GfsHalfDegreeBestWmsGetCapUrl = "http://"+ TestDir.threddsTestServer+"/thredds/wms/fmrc/NCEP/GFS/Global_0p5deg/NCEP-GFS-Global_0p5deg_best.ncd?service=WMS&version=1.3.0&request=GetCapabilities";
+  private static String ml8081GfsHalfDegreeBestWmsGetMapBaseUrl = "http://"+TestDir.threddsTestServer+"/thredds/wms/fmrc/NCEP/GFS/Global_0p5deg/NCEP-GFS-Global_0p5deg_best.ncd?service=WMS&version=1.3.0&request=GetMap&TRANSPARENT=true&STYLES=boxfill%2Frainbow&CRS=EPSG%3A4326&COLORSCALERANGE=0.2%2C62.9&NUMCOLORBANDS=20&LOGSCALE=false&EXCEPTIONS=XML&FORMAT=image%2Fpng&BBOX=-180,-90,180,90&WIDTH=256&HEIGHT=256&LAYERS=Precipitable_water&ELEVATION=0&TIME=";
   private static String[] ml8081GfsHalfDegreeBestWmsTimeStrings = new String[]
           {
                   "2010-11-06T00:00:00.000Z",

--- a/opendap/src/test/java/ucar/nc2/dt/grid/TestTime2D.java
+++ b/opendap/src/test/java/ucar/nc2/dt/grid/TestTime2D.java
@@ -53,7 +53,7 @@ public class TestTime2D {
 
   @Test
   public void testTime2D() throws Exception {
-    try (NetcdfFile dataset = NetcdfDataset.openDataset("dods://"+ TestDir.threddsDevServer+"/thredds/dodsC/grib/NCEP/GFS/Pacific_40km/TwoD")) {
+    try (NetcdfFile dataset = NetcdfDataset.openDataset("dods://"+ TestDir.threddsTestServer+"/thredds/dodsC/grib/NCEP/GFS/Pacific_40km/TwoD")) {
       Variable v = dataset.findVariable(null, "Pressure_surface");
       assert null != v;
       assert v.getRank() == 4;

--- a/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
+++ b/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
@@ -60,7 +60,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 	@Category(NeedsExternalResource.class)
 	public void showCommandTest() throws Exception{
 		// Testing against some reliable remote TDS
-		catUriString = "http://"+ TestDir.threddsServer+"/thredds/catalog.xml";
+		catUriString = "http://"+ TestDir.threddsTestServer+"/thredds/catalog.xml";
 		request.setRequestURI(catUriString);
 
 		// REQUEST WITH DEFAULT VALUES
@@ -96,7 +96,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 		// htmlView= null
 		// verbose = null
 		// command null and a providing a datasetId becomes in a subset command  
-		catUriString = "http://"+TestDir.threddsServer+"/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.xml";
+		catUriString = "http://"+TestDir.threddsTestServer+"/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.xml";
 		request.setParameter(parameterNameCatalog, catUriString);
 		request.setParameter(parameterNameCommand, command);
 		request.setParameter(parameterNameDatasetId, "grib/NCEP/NAM/CONUS_80km/Best");
@@ -120,7 +120,7 @@ public class RemoteCatalogControllerTest extends AbstractCatalogServiceTest{
 		// datasetId= null
 		// htmlView= null
 		// verbose = null 
-    catUriString = "http://"+TestDir.threddsServer+"/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.xml";
+    catUriString = "http://"+TestDir.threddsTestServer+"/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.xml";
 		request.setParameter(parameterNameCatalog, catUriString);
 		request.setParameter(parameterNameCommand, cmdValidate);
 		request.setParameter(parameterNameDatasetId, datasetId);

--- a/tds/src/test/java/thredds/tds/ethan/TestAll.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestAll.java
@@ -144,7 +144,7 @@ public class TestAll extends TestCase
   private boolean showDebug;
   private boolean verbose;
 
-  private String host = TestDir.threddsServer;
+  private String host = TestDir.threddsTestServer;
   private String[] catalogList;
 
   private String targetTdsUrl;
@@ -160,7 +160,7 @@ public class TestAll extends TestCase
     if ( null == System.getProperty( "thredds.tds.test.id"))
       System.setProperty( "thredds.tds.test.id", "crawl-newmlode-8080" );
     if ( null == System.getProperty( "thredds.tds.test.server" ) )
-      System.setProperty( "thredds.tds.test.server", TestDir.threddsServer );
+      System.setProperty( "thredds.tds.test.server", TestDir.threddsTestServer );
     if ( null == System.getProperty( "thredds.tds.test.level" ) )
       System.setProperty( "thredds.tds.test.level", "crawl-catalogs" );
     if ( null == System.getProperty( "thredds.tds.test.catalogs" ) )
@@ -781,7 +781,7 @@ public class TestAll extends TestCase
     for ( String curCat : catList )
     {
       gcsMsg.append( "********************\n<h4>" ).append( curCat ).append( "</h4>\n\n<pre>\n" );
-      curCat = "http://"+TestDir.threddsServer+"/thredds/catalog/" + curCat + "/files/catalog.xml";
+      curCat = "http://"+TestDir.threddsTestServer+"/thredds/catalog/" + curCat + "/files/catalog.xml";
       ByteArrayOutputStream os = new ByteArrayOutputStream();
       PrintWriter out = new PrintWriter( new OutputStreamWriter(os, CDM.utf8Charset));
       int numDs = 0;

--- a/tds/src/test/java/thredds/tds/ethan/TestTdsIddPing.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestTdsIddPing.java
@@ -48,7 +48,7 @@ import ucar.unidata.test.util.TestDir;
 public class TestTdsIddPing extends TestCase
 {
 
-  private String host = TestDir.threddsServer;
+  private String host = TestDir.threddsTestServer;
   private String targetTdsUrl;
 
   public TestTdsIddPing( String name )

--- a/tds/src/test/java/thredds/tds/ethan/TestTdsPingMotherlode.java
+++ b/tds/src/test/java/thredds/tds/ethan/TestTdsPingMotherlode.java
@@ -51,7 +51,7 @@ import ucar.unidata.test.util.TestDir;
 public class TestTdsPingMotherlode extends TestCase
 {
 
-  private String host = TestDir.threddsServer;
+  private String host = TestDir.threddsTestServer;
   private String targetTomcatUrl;
   private String targetTdsUrl;
 

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSite.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSite.java
@@ -79,7 +79,7 @@ public class TestServerSite extends TestCase
   private WebConversation wc;
 
   /** The TDS site to test. */
-  private String host = TestDir.threddsServer+":";
+  private String host = TestDir.threddsTestServer+":";
   /** The name of a user with tdsConfig role. */
   private String tdsConfigUser;
   private String tdsConfigWord;

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteIDD.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteIDD.java
@@ -55,7 +55,7 @@ public class TestServerSiteIDD extends TestCase
   private WebConversation wc;
 
   /** The TDS site to test. */
-  private String host = TestDir.threddsServer;
+  private String host = TestDir.threddsTestServer;
 
   private String targetUrl = "http://" + host + "/thredds/";
 

--- a/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteOutOfBox.java
+++ b/tds/src/test/java/thredds/tds/ethan/httpunit/TestServerSiteOutOfBox.java
@@ -55,7 +55,7 @@ public class TestServerSiteOutOfBox extends TestCase
   private WebConversation wc;
 
   /** The TDS site to test. */
-  private String host = TestDir.threddsServer;
+  private String host = TestDir.threddsTestServer;
 
   private String targetUrl;
 

--- a/ui/src/test/java/ucar/nc2/thredds/server/TestConcurrentAccess.java
+++ b/ui/src/test/java/ucar/nc2/thredds/server/TestConcurrentAccess.java
@@ -138,7 +138,7 @@ public class TestConcurrentAccess {
 
   public static void main(String args[]) throws IOException {
     String dodsName = "http://localhost:8080/thredds/dodsC/fmrc/NAM-CONUS-12/Formica-NAM-CONUS-12_best.ncd";
-    String catName = "http://"+ TestDir.threddsServer+"/thredds/catalog/fmrc/NCEP/RUC2/CONUS_20km/surface/catalog.html";
+    String catName = "http://"+ TestDir.threddsTestServer+"/thredds/catalog/fmrc/NCEP/RUC2/CONUS_20km/surface/catalog.html";
 
     JFrame frame = new JFrame("TestTDS");
     frame.addWindowListener(new WindowAdapter() {

--- a/ui/src/test/java/ucar/nc2/thredds/server/TestMlodeThreaded.java
+++ b/ui/src/test/java/ucar/nc2/thredds/server/TestMlodeThreaded.java
@@ -87,7 +87,7 @@ public class TestMlodeThreaded implements Runnable {
 
   public static JPanel main;
   public static void main(String args[]) throws IOException {
-    String server = "http://"+ TestDir.threddsServer+"/thredds";
+    String server = "http://"+ TestDir.threddsTestServer+"/thredds";
 
     // HEY LOOK
     //ucar.nc2.dods.DODSNetcdfFile.setAllowSessions( true);

--- a/ui/src/test/java/ucar/nc2/thredds/server/TestMotherlodeLatest.java
+++ b/ui/src/test/java/ucar/nc2/thredds/server/TestMotherlodeLatest.java
@@ -49,9 +49,9 @@ import java.io.IOException;
 import java.util.*;
 
 public class TestMotherlodeLatest extends TimerTask {
-  static private final String server1 = "http://"+ TestDir.threddsServer+"/";
+  static private final String server1 = "http://"+ TestDir.threddsTestServer+"/";
   //static private final String server1 = "http://thredds.cise-nsf.gov:8080/";
-  static private final String server2 = "http://"+TestDir.threddsDevServer+"/";
+  static private final String server2 = "http://"+TestDir.threddsTestServer+"/";
 
   // fmrc
   static private final String latestPrefix = "thredds/catalog/fmrc/";

--- a/ui/src/test/java/ucar/nc2/thredds/server/TestTDSdataset.java
+++ b/ui/src/test/java/ucar/nc2/thredds/server/TestTDSdataset.java
@@ -66,7 +66,7 @@ public class TestTDSdataset {
     String dataset;
 
     //String dataset = "http://motherlode.ucar.edu:9080/thredds/dodsC/fmrc/NCEP/NDFD/CONUS_5km/files/NDFD_CONUS_5km_20070502_1200.grib2";
-    dataset = "thredds:resolve:http://"+ TestDir.threddsDevServer+"/thredds/catalog/grib/NCEP/GFS/Global_0p5deg/files/latest.xml";
+    dataset = "thredds:resolve:http://"+ TestDir.threddsTestServer+"/thredds/catalog/grib/NCEP/GFS/Global_0p5deg/files/latest.xml";
     //String dataset = "http://www.gomoos.org/cgi-bin/dods/nph-dods/buoy/dods/A01/A01.accelerometer.historical.nc";
     //dataset="dods://dataportal.ucar.edu:9191/dods/cam3_aquaplanet/run1";  // prob GRADS
     //dataset= "http://ingrid.ldeo.columbia.edu/SOURCES/.CAC/dods";


### PR DESCRIPTION
https://github.com/Unidata/thredds/issues/359

TestDir.threddsDevServer -> TestDir.threddsTestServer
Tests should only ever point to thredds-test.unidata.ucar.edu. There's no reason to point at thredds-dev.
Note that some references to TestDir.threddsServer still exist
in classes that explicitly ref motherlode in the name
(e.g. TestTdsPingMotherlode, TestMotherlodeLatest, TestMlodeThreaded).
I suspect that all these classes could be eliminated, but not my call.