### PR TITLE
Every NetcdfDataset.initNetcdfFileCache() paired with shutdown()

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestAggDatasetIsCached.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestAggDatasetIsCached.java
@@ -1,5 +1,7 @@
 package ucar.nc2.ncml;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import ucar.ma2.InvalidRangeException;
@@ -23,11 +25,20 @@ import java.util.List;
  */
 @Category(NeedsCdmUnitTest.class)
 public class TestAggDatasetIsCached {
+  @BeforeClass
+  public static void setupClass() {
+    // All datasets, once opened, will be added to this cache.
+    NetcdfDataset.initNetcdfFileCache(10, 20, -1);
+  }
+
+  @AfterClass
+  public static void cleanupClass() {
+    // Undo global changes we made in setupSpec() so that they do not affect subsequent test classes.
+    NetcdfDataset.shutdown();
+  }
 
   @Test
   public void TestAggCached() throws IOException, InvalidRangeException {
-    NetcdfDataset.initNetcdfFileCache(10, 20, -1);
-
     String filename = TestDir.cdmUnitTestDir + "agg/caching/wqb.ncml";
     //String filename = "file:./"+TestNcML.topDir + "aggExisting.xml";
     boolean ok = true;
@@ -71,8 +82,6 @@ public class TestAggDatasetIsCached {
   @Test
   // check if caching works
   public void TestAggCached2() throws IOException, InvalidRangeException {
-    NetcdfDataset.initNetcdfFileCache(10, 20, -1);
-
     String filename = TestDir.cdmUnitTestDir + "agg/caching/wqb.ncml";  // joinExisting
 
     for (int i=0; i<2; i++) {

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestAggNested.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestAggNested.java
@@ -65,20 +65,22 @@ public class TestAggNested {
 
   @Test
   public void TestCached() throws IOException {
-    NetcdfDataset.initNetcdfFileCache(10, 20, -1);
+    try {
+      NetcdfDataset.initNetcdfFileCache(10, 20, -1);
 
-    String filename = TestDir.cdmUnitTestDir + "ncml/nestedAgg/test.ncml";
-    try (NetcdfDataset ncd = NetcdfDataset.acquireDataset(filename, null)) {
-      Variable time = ncd.findVariable("time");
-      assert time != null;
-      assert time.getSize() == 19723 : time.getSize();
-      //System.out.printf(" time array = %s%n", NCdumpW.toString(time.read()));
+      String filename = TestDir.cdmUnitTestDir + "ncml/nestedAgg/test.ncml";
+      try (NetcdfDataset ncd = NetcdfDataset.acquireDataset(filename, null)) {
+        Variable time = ncd.findVariable("time");
+        assert time != null;
+        assert time.getSize() == 19723 : time.getSize();
+        //System.out.printf(" time array = %s%n", NCdumpW.toString(time.read()));
+      }
+
+      FileCacheIF cache = NetcdfDataset.getNetcdfFileCache();
+      cache.showCache();
+    } finally {
+      NetcdfDataset.shutdown();
     }
-
-    FileCacheIF cache = NetcdfDataset.getNetcdfFileCache();
-    cache.showCache();
-
-    NetcdfDataset.disableNetcdfFileCache();
   }
 
   /*@Test

--- a/cdm/src/test/groovy/ucar/nc2/util/cache/ReacquireClosedDatasetSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/util/cache/ReacquireClosedDatasetSpec.groovy
@@ -1,9 +1,7 @@
 package ucar.nc2.util.cache
-
 import spock.lang.Specification
 import ucar.nc2.dataset.NetcdfDataset
 import ucar.unidata.test.util.TestDir
-
 /**
  * Tests caching behavior when datasets are closed and then reacquired.
  *
@@ -11,14 +9,20 @@ import ucar.unidata.test.util.TestDir
  * @since 2016-01-02
  */
 class ReacquireClosedDatasetSpec extends Specification {
-    def "reacquire"() {
-        setup: 'Initialize cache'
+    def setupSpec() {
+        // All datasets, once opened, will be added to this cache. Config values copied from CdmInit.
         NetcdfDataset.initNetcdfFileCache(100, 150, 12 * 60);
-        String location = TestDir.cdmLocalTestDataDir + "jan.nc"
+    }
 
+    def cleanupSpec() {
+        // Undo global changes we made in setupSpec() so that they do not affect subsequent test classes.
+        NetcdfDataset.shutdown();
+    }
+
+    def "reacquire"() {
         when: 'Acquire and close dataset 4 times'
         (1..4).each { println ''
-            NetcdfDataset.acquireDataset(location, null).close()
+            NetcdfDataset.acquireDataset(TestDir.cdmLocalTestDataDir + "jan.nc", null).close()
         }
 
         and: 'Query cache stats'

--- a/ui/src/main/java/ucar/nc2/ui/ToolsUI.java
+++ b/ui/src/main/java/ucar/nc2/ui/ToolsUI.java
@@ -86,7 +86,6 @@ import ucar.nc2.util.CancelTask;
 import ucar.nc2.util.DebugFlags;
 import ucar.nc2.util.DiskCache2;
 import ucar.nc2.util.IO;
-import ucar.nc2.util.cache.FileCache;
 import ucar.nc2.util.xml.RuntimeConfigParser;
 import ucar.util.prefs.PreferencesExt;
 import ucar.util.prefs.XMLStore;
@@ -6285,10 +6284,14 @@ public class ToolsUI extends JPanel {
     }
 
     done = true; // on some systems, still get a window close event
-    ucar.nc2.util.cache.FileCacheIF cache = NetcdfDataset.getNetcdfFileCache();
-    if (cache != null)
-      cache.clearCache(true);
-    FileCache.shutdown(); // shutdown threads
+
+    // open files caches
+    ucar.unidata.io.RandomAccessFile.shutdown();
+    NetcdfDataset.shutdown();
+
+    // memory caches
+    GribCdmIndex.shutdown();
+
     MetadataManager.closeAll(); // shutdown bdb
   }
 


### PR DESCRIPTION
* Should fix the "IllegalStateException: Timer already cancelled." that ReacquireClosedDatasetSpec was throwing.