### PR TITLE
Test cleanup

### DIFF
--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -811,7 +811,7 @@ public class HTTPSession implements Closeable
             throws HTTPException
     {
         assert (scope != null);
-        if(actualurl == null)
+        if(actualurl != null)
             this.sessionURI = actualurl;
         else
             this.sessionURI = HTTPAuthUtil.authscopeToURI(scope).toString();

--- a/it/src/test/java/thredds/TestWithLocalServer.java
+++ b/it/src/test/java/thredds/TestWithLocalServer.java
@@ -78,9 +78,11 @@ public class TestWithLocalServer {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
 
-      if (expectCodes == null)
+      if (expectCodes == null) {
         Assert.assertEquals(200, statusCode);
-      else {
+      } else if (expectCodes.length == 1) {
+        Assert.assertEquals(expectCodes[0], statusCode);
+      } else {
         boolean ok = false;
         for (int expectCode : expectCodes)
           if (expectCode == statusCode) ok = true;

--- a/it/src/test/java/thredds/TestWithLocalServer.java
+++ b/it/src/test/java/thredds/TestWithLocalServer.java
@@ -53,6 +53,7 @@ import java.io.InputStream;
  * @since 10/15/13
  */
 public class TestWithLocalServer {
+  static private org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestWithLocalServer.class);
   public static String server = "http://localhost:8081/thredds/";
 
   public static String withPath(String path) {
@@ -68,11 +69,9 @@ public class TestWithLocalServer {
   }
 
   public static byte[] getContent(Credentials cred, String endpoint, int[] expectCodes, ContentType expectContentType) {
-    System.out.printf("req = '%s'%n", endpoint);
+    logger.debug("req = '{}'", endpoint);
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       if (cred != null) {
-        int pos = endpoint.indexOf("?");
-        String url = pos < 0 ? endpoint : endpoint.substring(0, pos);
         session.setCredentials(cred);
       }
 
@@ -89,7 +88,7 @@ public class TestWithLocalServer {
       }
 
       if (statusCode != 200) {
-        System.out.printf("statusCode = %d '%s'%n", statusCode, method.getResponseAsString());
+        logger.warn("statusCode = {} '{}'", statusCode, method.getResponseAsString());
         return null;
       }
 
@@ -101,7 +100,7 @@ public class TestWithLocalServer {
       return method.getResponseAsBytes();
 
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error("Problem with HTTP request", e);
       assert false;
     }
 
@@ -109,12 +108,12 @@ public class TestWithLocalServer {
   }
 
   public static void saveContentToFile(String endpoint, int expectCode, ContentType expectContentType, File saveTo) {
-    System.out.printf("req = '%s'%n", endpoint);
+    logger.debug("req = '{}'", endpoint);
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
       if (statusCode != 200) {
-        System.out.printf("statusCode = %d '%s'%n", statusCode, method.getResponseAsString());
+        logger.warn("statusCode = {} '{}'", statusCode, method.getResponseAsString());
         Assert.assertEquals(expectCode, statusCode);
         return;
       }
@@ -130,7 +129,7 @@ public class TestWithLocalServer {
       IO.appendToFile(content, saveTo.getAbsolutePath());
 
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error("Problem with HTTP request", e);
       assert false;
     }
   }

--- a/it/src/test/java/thredds/TestWithLocalServer.java
+++ b/it/src/test/java/thredds/TestWithLocalServer.java
@@ -101,7 +101,7 @@ public class TestWithLocalServer {
 
       return method.getResponseAsBytes();
 
-    } catch (Exception e) {
+    } catch (HTTPException e) {
       logger.error("Problem with HTTP request", e);
       assert false;
     }

--- a/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
+++ b/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
@@ -1,6 +1,7 @@
 /* Copyright */
 package thredds.server.catalog;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,7 +41,7 @@ public class TestTdsFCcatalogs {
             {"testStationFeatureCollection.v5/files/catalog", "?dataset=testStationFeatureCollection.v5/files/Surface_METAR_20060328_0000.nc"}, // point fc
     });
   }
-  private static final boolean show = false;
+  static private org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTdsFCcatalogs.class);
 
   @Parameterized.Parameter(value = 0)
   public String path;
@@ -52,16 +53,16 @@ public class TestTdsFCcatalogs {
   public void testOpenXml() {
     String endpoint = TestWithLocalServer.withPath("catalog/"+path+".xml"+query);
     byte[] response = TestWithLocalServer.getContent(endpoint, 200, ContentType.xml);
-    if (show)
-      System.out.printf("%s%n", new String(response, CDM.utf8Charset));
+    Assert.assertNotNull(response);
+    logger.debug(new String(response, CDM.utf8Charset));
   }
 
   @Test
   public void testOpenHtml() {
     String endpoint = TestWithLocalServer.withPath("catalog/"+path+".html"+query);
-    byte[]  response = TestWithLocalServer.getContent(endpoint, 200, ContentType.html);
-    if (show)
-      System.out.printf("%s%n", new String(response, CDM.utf8Charset));
+    byte[] response = TestWithLocalServer.getContent(endpoint, 200, ContentType.html);
+    Assert.assertNotNull(response);
+    logger.debug(new String(response, CDM.utf8Charset));
   }
 
 }

--- a/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
+++ b/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 @Category(NeedsCdmUnitTest.class)
 public class TestTdsFCcatalogs {
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name = "{0}{1}")
   public static Collection<Object[]> getTestParameters() {
     return Arrays.asList(new Object[][]{
             {"catalogGrib", ""},
@@ -42,13 +42,11 @@ public class TestTdsFCcatalogs {
   }
   private static final boolean show = false;
 
-  String path, query;
+  @Parameterized.Parameter(value = 0)
+  public String path;
 
-  public TestTdsFCcatalogs(String path, String query) {
-    this.path = path;
-    this.query = query;
-  }
-
+  @Parameterized.Parameter(value = 1)
+  public String query;
 
   @Test
   public void testOpenXml() {


### PR DESCRIPTION
Some clean-ups to some tests. Adds names for some parameterized tests, moves some prints to actual logging messages, and gives a much more useful message when we fail a comparison on a single HTTP code (instead of `AssertionError` we actually get a message saying what the codes were.

I was hoping to run this on jenkins to see if I can use this to see why all those tests are failing, but I can't get the integration tests to run on anything but master or 5.0.0 on jenkins.