### PR TITLE
Fix client-side initiated 404 problem

### DIFF
--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -811,7 +811,7 @@ public class HTTPSession implements Closeable
             throws HTTPException
     {
         assert (scope != null);
-        if(actualurl == null)
+        if(actualurl != null)
             this.sessionURI = actualurl;
         else
             this.sessionURI = HTTPAuthUtil.authscopeToURI(scope).toString();


### PR DESCRIPTION
See: https://github.com/Unidata/thredds/pull/383
HTTPSession is saving the wrong url.