### PR TITLE
Unneeded longitude normalization in GribGds.LatLon  (fixes #340) and TDM authentication problem (fixes #361)

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
@@ -532,11 +532,12 @@ public abstract class Grib1Gds {
       return sb.toString();
     }
 
+    @Override
     public GdsHorizCoordSys makeHorizCoordSys() {
       LatLonProjection proj = new LatLonProjection(getEarth());
-      ProjectionPoint startP = proj.latLonToProj(new LatLonPointImpl(la1, lo1));
-      double startx = startP.getX();
-      double starty = startP.getY();
+      //ProjectionPoint startP = proj.latLonToProj(new LatLonPointImpl(la1, lo1));
+      double startx = lo1; // startP.getX();
+      double starty = la1; // startP.getY();
       return new GdsHorizCoordSys(getNameShort(), template, 0, scanMode, proj, startx, getDx(), starty, getDy(), getNx(), getNy(), null);
     }
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
@@ -174,6 +174,7 @@ public abstract class Grib2Gds {
   public int getScanMode() {
     return scanMode;
   }
+
   // hack to fix eumetsat GDS
   public void setCenter(int center) {
     this.center = center;
@@ -238,7 +239,7 @@ public abstract class Grib2Gds {
 
   public boolean isThin() {
     boolean isThin = (getOctet(11) != 0);
-    assert !isThin || (nx <0 || ny < 0);
+    assert !isThin || (nx < 0 || ny < 0);
     return isThin;
   }
 
@@ -338,36 +339,36 @@ public abstract class Grib2Gds {
     }
   }
 
-/*
-Template 3.0 (Grid definition template 3.0 - latitude/longitude (or equidistant cylindrical, or Plate Carre))
-     1-4 (4): GDS length
-     5-5 (1): Section
-     6-6 (1): Source of Grid Definition (see code table 3.0)
-    7-10 (4): Number of data points
-   11-11 (1): Number of octects for optional list of numbers
-   12-12 (1): Interpretation of list of numbers
-   13-14 (2): Grid Definition Template Number
-      15 (1): Shape of the Earth - (see Code table 3.2)#GRIB2_6_0_1_codeflag.doc#G2_CF32
-      16 (1): Scale factor of radius of spherical Earth
-   17-20 (4): Scaled value of radius of spherical Earth
-      21 (1): Scale factor of major axis of oblate spheroid Earth
-   22-25 (4): Scaled value of major axis of oblate spheroid Earth
-      26 (1): Scale factor of minor axis of oblate spheroid Earth
-   27-30 (4): Scaled value of minor axis of oblate spheroid Earth
-   31-34 (4): Ni - number of points along a parallel
-   35-38 (4): Nj - number of points along a meridian
-   39-42 (4): Basic angle of the initial production domain - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   43-46 (4): Subdivisions of basic angle used to define extreme longitudes and latitudes, and direction increments - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   47-50 (4): La1 - latitude of first grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   51-54 (4): Lo1 - longitude of first grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-      55 (1): Resolution and component flags - (see Flag table 3.3)#GRIB2_6_0_1_codeflag.doc#G2_CF33
-   56-59 (4): La2 - latitude of last grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   60-63 (4): Lo2 - longitude of last grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   64-67 (4): Di - i direction increment - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-   68-71 (4): Dj - j direction increment - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-      72 (1): Scanning mode - (flags - see Flag table 3.4)#GRIB2_6_0_1_codeflag.doc#G2_CF34
-   73-nn (0): List of number of points along each meridian or parallel. - (These octets are only present for quasi-regular grids as described in Notes 2 and 3)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
-*/
+  /*
+  Template 3.0 (Grid definition template 3.0 - latitude/longitude (or equidistant cylindrical, or Plate Carre))
+       1-4 (4): GDS length
+       5-5 (1): Section
+       6-6 (1): Source of Grid Definition (see code table 3.0)
+      7-10 (4): Number of data points
+     11-11 (1): Number of octects for optional list of numbers
+     12-12 (1): Interpretation of list of numbers
+     13-14 (2): Grid Definition Template Number
+        15 (1): Shape of the Earth - (see Code table 3.2)#GRIB2_6_0_1_codeflag.doc#G2_CF32
+        16 (1): Scale factor of radius of spherical Earth
+     17-20 (4): Scaled value of radius of spherical Earth
+        21 (1): Scale factor of major axis of oblate spheroid Earth
+     22-25 (4): Scaled value of major axis of oblate spheroid Earth
+        26 (1): Scale factor of minor axis of oblate spheroid Earth
+     27-30 (4): Scaled value of minor axis of oblate spheroid Earth
+     31-34 (4): Ni - number of points along a parallel
+     35-38 (4): Nj - number of points along a meridian
+     39-42 (4): Basic angle of the initial production domain - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     43-46 (4): Subdivisions of basic angle used to define extreme longitudes and latitudes, and direction increments - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     47-50 (4): La1 - latitude of first grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     51-54 (4): Lo1 - longitude of first grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+        55 (1): Resolution and component flags - (see Flag table 3.3)#GRIB2_6_0_1_codeflag.doc#G2_CF33
+     56-59 (4): La2 - latitude of last grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     60-63 (4): Lo2 - longitude of last grid point - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     64-67 (4): Di - i direction increment - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+     68-71 (4): Dj - j direction increment - (see Note 1)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+        72 (1): Scanning mode - (flags - see Flag table 3.4)#GRIB2_6_0_1_codeflag.doc#G2_CF34
+     73-nn (0): List of number of points along each meridian or parallel. - (These octets are only present for quasi-regular grids as described in Notes 2 and 3)#GRIB2_6_0_1_temp.doc#G2_Gdt30n
+  */
   public static class LatLon extends Grib2Gds {
     public float la1, lo1, la2, lo2, deltaLon, deltaLat;
     public int basicAngle, basicAngleSubdivisions;
@@ -401,9 +402,11 @@ Template 3.0 (Grid definition template 3.0 - latitude/longitude (or equidistant 
       float lastLat = getOctet4(56) * scale;
       float dLat = getOctet4(68) * scale;       // may be pos or neg
       if (GribUtils.scanModeYisPositive(scanMode)) {
-        if (firstLat > lastLat) f.format("  **latlon scan mode=%d dLat=%f lat=(%f,%f)%n", scanMode, dLat, firstLat, lastLat);
+        if (firstLat > lastLat)
+          f.format("  **latlon scan mode=%d dLat=%f lat=(%f,%f)%n", scanMode, dLat, firstLat, lastLat);
       } else {
-        if (firstLat < lastLat) f.format("  **latlon scan mode=%d dLat=%f lat=(%f,%f)%n", scanMode, dLat, firstLat, lastLat);
+        if (firstLat < lastLat)
+          f.format("  **latlon scan mode=%d dLat=%f lat=(%f,%f)%n", scanMode, dLat, firstLat, lastLat);
       }
     }
 
@@ -440,7 +443,8 @@ Template 3.0 (Grid definition template 3.0 - latitude/longitude (or equidistant 
       if (!super.equals(o)) return false;
 
       LatLon other = (LatLon) o;
-      if (!Misc.closeEnoughAbs(la1, other.la1, maxReletiveErrorPos * deltaLat)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.closeEnoughAbs(la1, other.la1, maxReletiveErrorPos * deltaLat))
+        return false;   // allow some slop, reletive to grid size
       if (!Misc.closeEnoughAbs(lo1, other.lo1, maxReletiveErrorPos * deltaLon)) return false;
       if (!Misc.closeEnoughAbs(la2, other.la2, maxReletiveErrorPos * deltaLat)) return false;
       if (!Misc.closeEnoughAbs(lo2, other.lo2, maxReletiveErrorPos * deltaLon)) return false;
@@ -484,9 +488,9 @@ Template 3.0 (Grid definition template 3.0 - latitude/longitude (or equidistant 
 
     public GdsHorizCoordSys makeHorizCoordSys() {
       LatLonProjection proj = new LatLonProjection(getEarth());
-      ProjectionPoint startP = proj.latLonToProj(new LatLonPointImpl(la1, lo1));
-      double startx = startP.getX();
-      double starty = startP.getY();
+      //ProjectionPoint startP = proj.latLonToProj(new LatLonPointImpl(la1, lo1));
+      double startx = lo1; // startP.getX();
+      double starty = la1; // startP.getY();
       return new GdsHorizCoordSys(getNameShort(), template, getOctet4(7), scanMode, proj, startx, deltaLon, starty, deltaLat,
               getNxRaw(), getNyRaw(), getNptsInLine());
     }
@@ -653,9 +657,11 @@ Template 3.10 (Grid definition template 3.10 - Mercator)
       float lastLat = getOctet4(52) * scale;
       float dY = getOctet4(69) * scale;       // may be pos or neg
       if (GribUtils.scanModeYisPositive(scanMode)) {
-        if (firstLat > lastLat) f.format("  **Mercator scan mode=%d dY=%f lat=(%f,%f)%n", scanMode, dY, firstLat, lastLat);
+        if (firstLat > lastLat)
+          f.format("  **Mercator scan mode=%d dY=%f lat=(%f,%f)%n", scanMode, dY, firstLat, lastLat);
       } else {
-        if (firstLat < lastLat) f.format("  **Mercator scan mode=%d dY=%f lat=(%f,%f)%n", scanMode, dY, firstLat, lastLat);
+        if (firstLat < lastLat)
+          f.format("  **Mercator scan mode=%d dY=%f lat=(%f,%f)%n", scanMode, dY, firstLat, lastLat);
       }
     }
 
@@ -667,7 +673,8 @@ Template 3.10 (Grid definition template 3.10 - Mercator)
 
       Mercator that = (Mercator) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+        return false;   // allow some slop, reletive to grid size
       if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
       if (!Misc.closeEnoughAbs(lad, that.lad, maxReletiveErrorPos * dY)) return false;
       if (!Misc.closeEnough(dY, that.dY)) return false;
@@ -800,7 +807,8 @@ Template 3.20 (Grid definition template 3.20 - polar stereographic projection)
 
       PolarStereographic that = (PolarStereographic) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+        return false;   // allow some slop, reletive to grid size
       if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
       if (!Misc.closeEnough(lad, that.lad)) return false;
       if (!Misc.closeEnough(lov, that.lov)) return false;
@@ -847,7 +855,7 @@ Template 3.20 (Grid definition template 3.20 - polar stereographic projection)
       if (GribNumbers.isUndefined(lad)) { // LOOK
         scale = 0.9330127018922193;
       } else {
-        scale = (1.0 + Math.sin(Math.toRadians( Math.abs( Math.abs(lad))))) / 2;
+        scale = (1.0 + Math.sin(Math.toRadians(Math.abs(Math.abs(lad))))) / 2;
       }
 
       ProjectionImpl proj;
@@ -960,7 +968,8 @@ Template 3.30 (Grid definition template 3.30 - Lambert conformal)
 
       LambertConformal that = (LambertConformal) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+        return false;   // allow some slop, reletive to grid size
       if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
       if (!Misc.closeEnough(lad, that.lad)) return false;
       if (!Misc.closeEnough(lov, that.lov)) return false;
@@ -1185,7 +1194,7 @@ some records differ only by:
 
     protected void finish() {
       super.finish();
-      deltaLon = (lo2 - lo1) / (getNx()-1); // more accurate - deltaLon may have roundoff
+      deltaLon = (lo2 - lo1) / (getNx() - 1); // more accurate - deltaLon may have roundoff
       deltaLat = 0.1f; // meaningless for gaussian
     }
 
@@ -1380,36 +1389,36 @@ Template 3.90 (Grid definition template 3.90 - space view perspective or orthogr
     /**
      * Make a Eumetsat MSG "Normalized Geostationary Projection" projection.
      * Fake coordinates for now, then see if this can be generalized.
-     * <p/>
+     * <p>
      * =======
-     * <p/>
+     * <p>
      * from  simon.elliott@eumetsat.int
-     * <p/>
+     * <p>
      * For products on a single pixel resolution grid, the scan angle is 83.84333 E-6 rad.
      * So dx = 2 * arcsin(10e6/Nr) / 83.84333 E-6 = 3622.30, which encoded to the nearest integer is 3622.
      * This is correctly encoded in our products.
-     * <p/>
+     * <p>
      * For products on a 3x3 pixel resolution grid, the scan angle is 3 * 83.84333 E-6 rad = 251.52999 E-6 rad.
      * So dx = 2 * arcsin(10e6/Nr) / 251.52999 E-6 = 1207.43, which encoded to the nearest integer is 1207.
      * This is correctly encoded in our products.
-     * <p/>
+     * <p>
      * Due to the elliptical shape of the earth, the calculation is a bit different in the y direction (Nr is in multiples of
      * the equatorial radius, but the tangent point is much closer to the polar radius from the earth's centre.
      * Approximating that the tangent point is actually at the polar radius from the earth's centre:
      * The sine of the angle subtended by the Earths centre and the tangent point on the equator as seen from the spacecraft
      * = Rp / (( Nr * Re) / 10^6) = (Rp * 10^6) / (Re * Nr)
-     * <p/>
+     * <p>
      * The angle subtended by the Earth equator as seen by the spacecraft is, by symmetry twice the inverse sine above,
      * = 2 * arcsine ((Rp * 10^6) / (Re * Nr))
-     * <p/>
+     * <p>
      * For products on a single pixel resolution grid, the scan angle is 83.84333 E-6 rad.
      * So dy = 2 * arcsine ((Rp * 10^6) / (Re * Nr)) / 83.84333 E-6 = 3610.06, which encoded to the nearest integer is 3610.
      * This is currently encoded in our products as 3568.
-     * <p/>
+     * <p>
      * For products on a 3x3 pixel resolution grid, the scan angle is 3 * 83.84333 E-6 rad = 251.52999 E-6 rad.
      * So dy = 2 * arcsine ((Rp * 10^6) / (Re * Nr)) / 251.52999 E-6 = 1203.35, which encoded to the nearest integer is 1203.
      * This is currently encoded in our products as 1189.
-     * <p/>
+     * <p>
      * As you can see the dx and dy values we are using will lead to an error of around 1% in the y direction.
      * I will ensure that the values are corrected to those explained here (3610 and 1203) as soon as possible.
      */
@@ -1435,7 +1444,7 @@ Template 3.90 (Grid definition template 3.90 - space view perspective or orthogr
 
       getEarth(); // fix units if needed
 
-       // use km, so scale by the earth radius
+      // use km, so scale by the earth radius
       double scale_factor = (Nr - 1) * majorAxis / 1000; // this sets the units of the projection x,y coords in km
       double scale_x = scale_factor; // LOOK fake neg need scan value
       double scale_y = -scale_factor; // LOOK fake neg need scan value
@@ -1464,7 +1473,7 @@ Template 3.90 (Grid definition template 3.90 - space view perspective or orthogr
         incry = (scale_factor / lfac);
       } else {
         incry = -(scale_factor / lfac);
-        starty = scale_factor * (Yp - getNy()) / lfac - incry * (getNy()-1);
+        starty = scale_factor * (Yp - getNy()) / lfac - incry * (getNy() - 1);
       }
 
       MSGnavigation proj = new MSGnavigation(LaP, LoP, majorAxis, minorAxis, Nr * majorAxis, scale_x, scale_y);
@@ -1517,8 +1526,8 @@ Template 3.90 (Grid definition template 3.90 - space view perspective or orthogr
     CurvilinearOrthogonal(byte[] data) {
       super(data, 204);
 
-      flags =  getOctet(55);
-      scanMode =  getOctet(72);
+      flags = getOctet(55);
+      scanMode = getOctet(72);
     }
 
     @Override

--- a/tdm/src/main/java/thredds/tdm/Tdm.java
+++ b/tdm/src/main/java/thredds/tdm/Tdm.java
@@ -36,7 +36,6 @@
 package thredds.tdm;
 
 import org.apache.http.auth.*;
-import org.apache.http.client.CredentialsProvider;
 import org.slf4j.Logger;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 import org.springframework.core.io.FileSystemResource;
@@ -84,6 +83,7 @@ public class Tdm {
 
   private String user, pass;
   private boolean sendTriggers;
+  private String[] serverNames;
   private List<Server> servers;
 
   private java.util.concurrent.ExecutorService executor;
@@ -144,16 +144,21 @@ public class Tdm {
     this.catalog = catalog;
   }
 
-  public void setServerNames(String[] serverNames) throws HTTPException {
+  public void setServerNames(String[] serverNames) {
+    this.serverNames = serverNames;
+  }
+
+  public void initServers() throws HTTPException {
     if (serverNames == null) {
       servers = new ArrayList<>(); // empty list
       return;
     }
 
-    servers = new ArrayList<>(serverNames.length);
-    for (String name : serverNames) {
+    this.servers = new ArrayList<>(this.serverNames.length);
+    for (String name : this.serverNames) {
       try (HTTPSession session = HTTPFactory.newSession(name)) {
-        session.setCredentials(new UsernamePasswordCredentials(user, pass));
+        if (user != null && pass != null)
+          session.setCredentials(new UsernamePasswordCredentials(user, pass));
         session.setUserAgent("TDM");
         servers.add(new Server(name, session));
       }
@@ -166,7 +171,9 @@ public class Tdm {
     aliasHandler = new AliasHandler(aliasExpanders);
   }
 
-  boolean init() {
+  boolean init() throws HTTPException {
+    initServers();
+
     System.setProperty("tds.log.dir", contentTdmDir.toString());
 
     if (!Files.exists(threddsConfig)) {


### PR DESCRIPTION
Both Grib1Gds.LatLon and Grib2Gds.LatLon
makeHorizCoordSys() changed. (rest is reformating)

GitHub Issue 340

need to see if any unit tests are affected.