### PR TITLE
NcStream changes

### DIFF
--- a/cdm/src/main/java/ucar/ma2/StructureDataDeep.java
+++ b/cdm/src/main/java/ucar/ma2/StructureDataDeep.java
@@ -194,13 +194,17 @@ public class StructureDataDeep extends StructureDataA {
           case LONG:
             bb.putLong(sdata.getScalarLong(m));
             break;
+          case STRUCTURE:
+            StructureData sd  = sdata.getScalarStructure(m);
+            ArrayStructureBB out_abb = new ArrayStructureBB(sd.getStructureMembers(),
+                    new int[]{1}, bb, 0);
+            copyToArrayBB(sd, out_abb);
+            break;
           default:
             throw new IllegalStateException("scalar " + dtype.toString());
             /* case BOOLEAN:
            break;
          case SEQUENCE:
-           break;
-         case STRUCTURE:
            break;
          case OPAQUE:
            break; */

--- a/cdm/src/main/java/ucar/nc2/stream/NcStreamCompression.java
+++ b/cdm/src/main/java/ucar/nc2/stream/NcStreamCompression.java
@@ -1,6 +1,5 @@
 package ucar.nc2.stream;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -32,7 +31,7 @@ public class NcStreamCompression {
         return new NcStreamCompression(NcStreamProto.Compress.DEFLATE, level);
     }
 
-    public DataOutputStream setupStream(OutputStream out, int size)
+    public OutputStream setupStream(OutputStream out, int size)
             throws IOException
     {
         switch (type) {
@@ -50,9 +49,8 @@ public class NcStreamCompression {
             // In the case of no compression, go ahead and write the block
             // size so that the stream is ready for data
             case NONE:
-                DataOutputStream dos = new DataOutputStream(out);
-                NcStream.writeVInt(dos, size);
-                return dos;
+                NcStream.writeVInt(out, size);
+                return out;
         }
     }
 }

--- a/cdm/src/main/java/ucar/nc2/stream/NcStreamWriter.java
+++ b/cdm/src/main/java/ucar/nc2/stream/NcStreamWriter.java
@@ -38,8 +38,6 @@ import ucar.nc2.constants.CDM;
 
 import java.io.*;
 import java.nio.ByteOrder;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
 
 /**
  * Write a NetcdfFile to a OutputStream using ncstream protocol
@@ -140,10 +138,9 @@ public class NcStreamWriter {
     }
 
     // Writing the size of the block is handled for us.
-    DataOutputStream dos = compress.setupStream(out, (int)uncompressedLength);
-    v.readToStream(section, dos);
-    dos.flush();
-    size += dos.size();
+    out = compress.setupStream(out, (int)uncompressedLength);
+    size += v.readToStream(section, out);
+    out.flush();
     return size;
   }
 


### PR DESCRIPTION
- Remove unneeded use of `DataOutputStream` with compression
- Implement serializing nested scalar structures.

The latter code path was exercised by the attached file I found laying around our netcdf4 test files. Serving it locally with cdmremote resulted in a 500, and this fixes that.

It parses fine on the Python side.

Attn @JohnLCaron 