### PR TITLE
Improve performance of timeseries reading.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -189,7 +189,7 @@ libraries["commons-compress"] = "org.apache.commons:commons-compress:1.8.1"
 
 libraries["oro"] = "oro:oro:2.0.8"
 
-libraries["ncwms"] = dependencies.create("uk.ac.rdg.resc:ncwms:1.2.tds.4.6.4") {
+libraries["ncwms"] = dependencies.create("uk.ac.rdg.resc:ncwms:1.2.tds.4.6.5-SNAPSHOT") {
     // This is an external dependency on an old artifact of ours.
     // The "cdm" artifact that we build in this project will take its place.
     // This needs to be a local exclusion; globally excluding "edu.ucar:cdm" would be very bad.

--- a/tds/src/main/java/thredds/server/wms/ThreddsScalarLayer.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsScalarLayer.java
@@ -176,41 +176,19 @@ class ThreddsScalarLayer extends AbstractScalarLayer implements ThreddsLayer {
       throw new IOException(e);
     }
     return horizontalPoints;
-
   }
     
   @Override
   public List<Float> readTimeseries(List<DateTime> times, double elevation, HorizontalPosition xy)
       throws InvalidDimensionValueException, IOException
   {
-      Domain<HorizontalPosition> singlePoint = new HorizontalDomain(xy);;
-      HorizontalGrid hg = CdmUtils.createHorizontalGrid(grid.getCoordinateSystem());
-      PixelMap pixelMap = new PixelMap(hg, singlePoint);
-      List<Float> timePoints = new ArrayList<Float>(times.size());
-      int zIndex = this.findAndCheckElevationIndex(elevation);
+      HorizontalGrid horizGrid = CdmUtils.createHorizontalGrid(grid.getCoordinateSystem());
+      List<Integer> tIndices = new ArrayList<Integer>(times.size());
       for (DateTime time : times)
-      {
-          int tIndex = this.findAndCheckTimeIndex(time);
-          try{
-              timePoints.add(CdmUtils.readHorizontalPoints(null, grid,  tIndex, zIndex, pixelMap, this.dataReadingStrategy, 1).get(0));
-          }catch(Exception e){
-              //Catching and wrapping any exception reading data into a new IOException
-              throw new IOException(e);
-          }
-      }
-      return timePoints;
+          tIndices.add(this.findAndCheckTimeIndex(time));
+      int zIndex = this.findAndCheckElevationIndex(elevation);
+      return CdmUtils.readTimeseries(null, grid, horizGrid, tIndices, zIndex, xy);
   }
-
-    /*public List<Float> readHorizonalPoints(DateTime time, double elevation, Domain<HorizontalPosition> domain)
-            throws InvalidDimensionValueException, IOException
-    {
-        int tIndex = this.findAndCheckTimeIndex(time);
-        int zIndex = this.findAndCheckElevationIndex(elevation);
-        Domain<HorizontalPosition> targetDomain = domain;
-        HorizontalGrid hg = CdmUtils.createHorizontalGrid(grid.getCoordinateSystem());
-        PixelMap pixelMap = new PixelMap(hg, targetDomain);
-        return CdmUtils.readHorizontalPoints(null, grid,  tIndex, zIndex, pixelMap, this.dataReadingStrategy, (int)targetDomain.size());
-    }*/
 
   public String getStandardName() {
     if (this.grid == null) return null;


### PR DESCRIPTION
This is a rebase of #439 .

The current implementation of timeseries reading in `ThreddsScalarLayer`
queries the dataset once for each involved time instant with
`CdmUtils.readHorizontalPoints`. The original layer implementation in
ncwms uses the function `CdmUtils.readTimeseries`, which retrieves
all the data from the earliest to the latest time instant at once.
With the modifications in socib/ncWMS@timeseries_fast_read_thredds
the loading can be delegated to that function with a significant
improvement in speed and caching opportunities. In addition,
this is the same approach used to implement `readHorizontalPoints`.
Please note that this will only work with the above mentioned changes to ncwms.

See Unidata/ncWMS#18 and Unidata/thredds#439.