### PR TITLE
httpservices missing from ncIdv jar (for 5.0.0)

### DIFF
--- a/gradle/fatJars.gradle
+++ b/gradle/fatJars.gradle
@@ -16,6 +16,7 @@ dependencies {
     ncIdv project(':netcdf4')
     ncIdv project(':opendap')
     ncIdv project(':visadCdm')
+    ncIdv project(':httpservices')
 
     tdmFat project(':tdm')
 


### PR DESCRIPTION
Apparently, I accidentally removed httpservices from ncIdv jar.
Re-add it for 5.0.0