### PR TITLE
Link to artifacts on FTP server, not Nexus

### DIFF
--- a/docs/internal/release.txt
+++ b/docs/internal/release.txt
@@ -133,6 +133,8 @@ Making a release for CDM/TDS using Gradle
     - Make the commit message something like "Release {release.minor}".
 
 22. Create a tag for the release: "v{release.minor}".
+    - In IntelliJ, do VCS->Git->Tag...
+    - Apparently tags don't ever get moved from GitHub pull requests. Might need a different way to tag releases.
 
 23. Prepare for next round of development.
     - Update the project version. Increment it and add the "-SNAPSHOT" suffix.
@@ -144,10 +146,19 @@ Making a release for CDM/TDS using Gradle
     - Be sure to include the tag you created.
       * In IntelliJ, check the "Push Tags" box in the "Push Commits" dialog.
 
-25. Make blog post for the release. Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds1
+25. Make a release announcement on GitHub.
+    - Example: https://github.com/Unidata/thredds/releases/tag/v4.6.4
+    - To help create the changelog, examine the pull requests on GitHub. For example, this URL shows all PRs that
+      have been merged into "master" since 2016-02-12:
+      https://github.com/Unidata/thredds/pulls?q=base%3Amaster+merged%3A%3E%3D2016-02-12
 
-26. Make a release announcement to the mailing lists. It should build off the blog post.
-    Example: http://www.unidata.ucar.edu/mailing_lists/archives/netcdf-java/2016/msg00001.html
+26. Make blog post for the release. Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds1
+    - Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds1
+    - Best to leave it relatively short and just link to the GitHub release.
+
+27. Make a release announcement to the mailing lists: netcdf-java@unidata.ucar.edu and thredds@unidata.ucar.edu
+    - Example: http://www.unidata.ucar.edu/mailing_lists/archives/netcdf-java/2016/msg00001.html
+    - Best to leave it relatively short and just link to the GitHub release.
 
 NOTE 1: In the Maven build, the maven-release-plugin roughly handled steps 2-6 and 21-24 for us. In the future, we
 should investigate similar Gradle plugins that offer the same functionality.

--- a/docs/internal/release.txt
+++ b/docs/internal/release.txt
@@ -152,7 +152,7 @@ Making a release for CDM/TDS using Gradle
       have been merged into "master" since 2016-02-12:
       https://github.com/Unidata/thredds/pulls?q=base%3Amaster+merged%3A%3E%3D2016-02-12
 
-26. Make blog post for the release. Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds1
+26. Make blog post for the release.
     - Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds1
     - Best to leave it relatively short and just link to the GitHub release.
 

--- a/docs/website/netcdf-java/documentation.htm
+++ b/docs/website/netcdf-java/documentation.htm
@@ -43,9 +43,9 @@ To build the latest stable version from source or contribute code  to the THREDD
 <span id="current"/>
 <h3 id="v46">Current stable release version 4.6 (requires Java 7) </h3>
 <ul>
-  <li>The <a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/4.6.4/netcdfAll-4.6.4.jar">complete netCDF library jar</a> implements the full CDM model, with all
+  <li>The <a href="ftp://ftp.unidata.ucar.edu/pub/netcdf-java/v4.6/netcdfAll-4.6.jar">complete netCDF library jar</a> implements the full CDM model, with all
     dependent jars included. </li>
-  <li>The <a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/toolsUI/4.6.4/toolsUI-4.6.4.jar">toolsUI.jar</a> also includes UI classes, and allows you to run the netCDF
+  <li>The <a href="ftp://ftp.unidata.ucar.edu/pub/netcdf-java/v4.6/toolsUI-4.6.jar">toolsUI.jar</a> also includes UI classes, and allows you to run the netCDF
     ToolsUI application directly from it such as &quot;<em>java -Xmx1g -jar toolsUI.jar</em>&quot;</li>
   <li><a href="javadoc/index.html">Public javadoc.</a> This is the public interface. Future changes to the API will attempt to remain backwards compatible
     with this API. </li>

--- a/docs/website/tds/TDS.html
+++ b/docs/website/tds/TDS.html
@@ -69,11 +69,11 @@
 
 <p><strong>TDS 4.6 is the stable release. It requires Tomcat 7+ and Java 7+.</strong></p>
 <ul>
-  <li>Download the latest release: [<a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/4.6.4/tds-4.6.4.war">thredds.war</a> (rename download to thredds.war or, if using tomcat, thredds##4.6.4.war) (<a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/4.6.4/tds-4.6.4.war.md5">MD5</a>)]
-    (<a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/4.6.4/tds-4.6.4.war.sha1">SHA1</a>)]
+  <li>Download the latest release: [<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war">thredds.war</a> (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war.md5">MD5</a>)]
+    (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war.sha1">SHA1</a>)]
     [<a href="https://github.com/Unidata/thredds">source on GitHub</a>]
     [<a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>] </li>
-  <li>The THREDDS Data Manager (TDM)  <a href="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/4.6.4/tdmFat-4.6.4.jar">tdm.jar</a></li>
+  <li>The THREDDS Data Manager (TDM)  <a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/tdm-4.6.jar">tdm.jar</a></li>
   <li>Documentation:
     <ul>
       <li><a href="reference/index.html">Reference</a></li>


### PR DESCRIPTION
If you follow the release.txt document, it tells you to upload artifacts to the ftp server and then update some symlinks. If you do that, the NetCDF-Java and TDS front pages don't need to be updated.

For 5.0, I'd like to manage the links as properties in AsciiDoctor, which will cause them to be updated automatically. At that point, we should go back to pointing to Nexus.

In this commit, I also added more detailed instructions to release.txt about making release announcements. Up to 27 steps, oof! Must automate soon.