### PR TITLE
Add -PpublishSources flag to publish sources jars that are otherwise …

### DIFF
--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
@@ -45,9 +45,10 @@ our link:https://artifacts.unidata.ucar.edu/index.html#view-repositories[Nexus r
 
 However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don't
 upload to Nexus. Never fear: you can build them yourself and publish them to your local Maven repository!
+The optional `-PpublishSources` flag publishes sources jars that are otherwise not published for SNAPSHOTS.
 ----
 git checkout master
-./gradlew publishToMavenLocal
+./gradlew -PpublishSources publishToMavenLocal
 ----
 
 You will find the artifacts in `~/.m2/repository/edu/ucar/`. If you're building your projects using Maven, artifacts

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -36,6 +36,10 @@ configure(javaProjects) {
 
         componentArtifacts << new DefaultPublishArtifact(tasks.javadocJar.archiveName, 'jar', 'jar', 'javadoc', null,
                                                          tasks.javadocJar.archivePath, tasks.javadocJar)
+    } else if (project.hasProperty("publishSources")) {
+        components.java.usages.first().artifacts << new DefaultPublishArtifact(
+            tasks.sourcesJar.archiveName, 'jar', 'jar', 'sources',
+            null, tasks.sourcesJar.archivePath, tasks.sourcesJar)
     }
 
 


### PR DESCRIPTION
…not published for SNAPSHOTS

Sources jars enable cross-project debugging of SNAPSHOTS. For example, local modifications to NetCDF-Java master are published with ```-PpublishSources``` as ```4.6.6-SNAPSHOT```, then when debugging GeoServer built with ```-Dnetcdf.version=4.6.6-SNAPSHOT``` in Eclipse, attached sources of NetCDF-Java are available.

I am happy to port to ```5.0.0``` if you like.