### PR TITLE
Fallback to FSL/NCEP local table superclasses for GRIB2 level and sta…

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/FslLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/FslLocalTables.java
@@ -139,24 +139,22 @@ public class FslLocalTables extends NcepLocalTables {
 
   @Override
   public String getLevelNameShort(int id) {
-    if (id < 192) return super.getLevelNameShort(id);
     switch (id) {
       case 200:
         return "Entire_atmosphere";
       default:
-        return null;
+        return super.getLevelNameShort(id);
     }
   }
 
   @Override
 
   public String getLevelName(int id) {
-    if (id < 192) return super.getLevelName(id);
     switch (id) {
       case 200:
         return "Entire atmosphere layer";
       default:
-        return null;
+        return super.getLevelName(id);
     }
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/NcepLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/NcepLocalTables.java
@@ -344,7 +344,6 @@ public class NcepLocalTables extends LocalTables {
 
   @Override
   public String getLevelNameShort(int id) {
-    if (id < 192) return super.getLevelNameShort(id);
     switch (id) {
       case 200:
         return "entire_atmosphere_single_layer";
@@ -433,7 +432,6 @@ public class NcepLocalTables extends LocalTables {
 
   @Override
   public String getStatisticNameShort(int id) {
-    if (id < 192) return super.getStatisticNameShort(id);
     switch (id) {
       case 192:
         return "ClimatologicalMeanValue";


### PR DESCRIPTION
…tistic names

[NOAA Rapid Refresh (RAPv3)](http://rapidrefresh.noaa.gov/) native grid GRIB2 files contain names that are defined in FSL/NCEP local table superclasses yet are inexplicably overridden to return null. While this works for the first null, subsequent nulls cause duplicate NetCDF variable names and failure to read the GRIB2 file. This fix enables fallback to definitions in superclasses.

I am happy to port this to 5.0.0 as well.