### PR TITLE
Publish sources and javadoc jars for all releases

### DIFF
--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
@@ -45,10 +45,9 @@ our link:https://artifacts.unidata.ucar.edu/index.html#view-repositories[Nexus r
 
 However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don't
 upload to Nexus. Never fear: you can build them yourself and publish them to your local Maven repository!
-The optional `-PpublishSources` flag publishes sources jars that are otherwise not published for SNAPSHOTS.
 ----
 git checkout master
-./gradlew -PpublishSources publishToMavenLocal
+./gradlew publishToMavenLocal
 ----
 
 You will find the artifacts in `~/.m2/repository/edu/ucar/`. If you're building your projects using Maven, artifacts

--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
@@ -45,9 +45,10 @@ our link:https://artifacts.unidata.ucar.edu/index.html#view-repositories[Nexus r
 
 However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don't
 upload to Nexus. Never fear: you can build them yourself and publish them to your local Maven repository!
+The optional `-PpublishSources` flag publishes sources jars that are otherwise not published for SNAPSHOTS.
 ----
 git checkout master
-./gradlew publishToMavenLocal
+./gradlew -PpublishSources publishToMavenLocal
 ----
 
 You will find the artifacts in `~/.m2/repository/edu/ucar/`. If you're building your projects using Maven, artifacts

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -22,25 +22,15 @@ configure(javaProjects) {
     }
 
 
-    // Add sources and javadoc jars to the set of components that will be published for each project, but only
-    // if this is a release (i.e. non-SNAPSHOT) version.
-    // It appears that Maven only publishes those artifacts for release versions as well:
-    // http://maven.40175.n5.nabble.com/Deploy-javadoc-sources-for-snapshots-td5472378.html
-    String version = rootProject.version as String
-    if (!version.endsWith('SNAPSHOT')) {
-        JavaLibrary java = components.java
-        Set<PublishArtifact> componentArtifacts = java.usages.first().artifacts
+    // Add sources and javadoc jars to the set of components that will be published for each project.
+    JavaLibrary java = components.java
+    Set<PublishArtifact> componentArtifacts = java.usages.first().artifacts
 
-        componentArtifacts << new DefaultPublishArtifact(tasks.sourcesJar.archiveName, 'jar', 'jar', 'sources', null,
-                                                         tasks.sourcesJar.archivePath, tasks.sourcesJar)
+    componentArtifacts << new DefaultPublishArtifact(tasks.sourcesJar.archiveName, 'jar', 'jar', 'sources', null,
+                                                     tasks.sourcesJar.archivePath, tasks.sourcesJar)
 
-        componentArtifacts << new DefaultPublishArtifact(tasks.javadocJar.archiveName, 'jar', 'jar', 'javadoc', null,
-                                                         tasks.javadocJar.archivePath, tasks.javadocJar)
-    } else if (project.hasProperty("publishSources")) {
-        components.java.usages.first().artifacts << new DefaultPublishArtifact(
-            tasks.sourcesJar.archiveName, 'jar', 'jar', 'sources',
-            null, tasks.sourcesJar.archivePath, tasks.sourcesJar)
-    }
+    componentArtifacts << new DefaultPublishArtifact(tasks.javadocJar.archiveName, 'jar', 'jar', 'javadoc', null,
+                                                     tasks.javadocJar.archivePath, tasks.javadocJar)
 
 
     // Will apply to "compileJava", "compileTestJava", "compileSourceSetJava", etc.

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -36,6 +36,10 @@ configure(javaProjects) {
 
         componentArtifacts << new DefaultPublishArtifact(tasks.javadocJar.archiveName, 'jar', 'jar', 'javadoc', null,
                                                          tasks.javadocJar.archivePath, tasks.javadocJar)
+    } else if (project.hasProperty("publishSources")) {
+        components.java.usages.first().artifacts << new DefaultPublishArtifact(
+            tasks.sourcesJar.archiveName, 'jar', 'jar', 'sources',
+            null, tasks.sourcesJar.archivePath, tasks.sourcesJar)
     }
 
 


### PR DESCRIPTION
There was a disk space issue on our Nexus server that prevented us from publishing these jars for all SNAPSHOTS, but that's been resolved.

EDIT: This follows from PR #529, opened by @bencaradocdavies.