### PR TITLE
Build failed when executing gradle 2.13 (latest release)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -38,7 +38,7 @@ ext {
 
 libraries["gretty"] = "org.akhikhl.gretty:gretty:1.2.0"
 
-libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.2"
+libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
 libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1"
 

--- a/tds/src/main/java/thredds/servlet/restrict/TomcatAuthorizer.java
+++ b/tds/src/main/java/thredds/servlet/restrict/TomcatAuthorizer.java
@@ -116,7 +116,7 @@ public class TomcatAuthorizer implements Authorizer {
       }
     }
 
-    res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authorized to access this dataset.");
+    res.sendError(HttpServletResponse.SC_FORBIDDEN, "Not authorized to access this dataset.");
   }
 
 }

--- a/tds/src/main/webapp/WEB-INF/jsp/errorpages/403.jsp
+++ b/tds/src/main/webapp/WEB-INF/jsp/errorpages/403.jsp
@@ -1,0 +1,20 @@
+<%@ include file="/WEB-INF/jsp/includes.jsp" %>
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>TDS - Error report</title>
+    <link rel="stylesheet" href="<c:url value="/tds.css"/>" type="text/css"/>
+  </head>
+  <body>
+    <h1>HTTP Status 403 - Forbidden</h1>
+    <HR size="1" noshade="noshade">
+    <p><b>Status</b> 403 - Forbidden</p>
+    <p>
+      You do not have the necessary permissions for the resource.
+    </p>
+    <HR size="1" noshade="noshade">
+    <h3>THREDDS Data Server Version 5.0
+      -- <a href='http://www.unidata.ucar.edu/software/thredds/v5.0/tds/TDS.html'>Documentation</a></h3>
+  </body>
+</html>

--- a/tds/src/main/webapp/WEB-INF/web.xml
+++ b/tds/src/main/webapp/WEB-INF/web.xml
@@ -64,6 +64,11 @@
   </welcome-file-list>
 
   <error-page>
+    <error-code>403</error-code>
+    <location>/WEB-INF/jsp/errorpages/403.jsp</location>
+  </error-page>
+
+  <error-page>
     <error-code>404</error-code>
     <location>/WEB-INF/jsp/errorpages/404.jsp</location>
   </error-page>


### PR DESCRIPTION
Incremented version of the gradle shadow plugin to 1.2.3, which contains a fix for compability with gradle 2.11 and higher