### PR TITLE
Added default path on MacOSX for netCDF-4

### DIFF
--- a/docs/website/netcdf-java/reference/netcdf4Clibrary.html
+++ b/docs/website/netcdf-java/reference/netcdf4Clibrary.html
@@ -82,9 +82,10 @@
 
 <h4><a name="loading_preferred_mac" id="loading_preferred_mac">Mac</a></h4>
 
-<p>The system library path maps to the <code>DYLD_LIBRARY_PATH</code> environment variable.</p>
+<p>The system library path maps to the <code>DYLD_LIBRARY_PATH</code> environment variable. If you use Homebrew or
+    MacPorts to install netCDF-4, netCDF-Java will check their default installation directories automatically (
+    <code>/usr/local/lib/</code> and <code>/opt/local/lib/</code>, respectively).</p>
 
-<p>TODO: Where is NetCDF typically installed on Mac?</p>
 
 <h3><a name="loading_alternate" id="loading_alternate">Alternate methods</a></h3>
 

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -131,6 +131,8 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
           "/home/dmh/opt/netcdf4/lib", //temporary
           "c:/opt/netcdf", // Windows
           "/usr/jna_lib/",
+          "/usr/local/lib/", // MacOSX homebrew default
+          "/opt/local/lib/", // MacOSX MacPorts default
   };
 
   static private String jnaPath = null;


### PR DESCRIPTION
The default paths that are added are for the two most common
package managers on OSX - MacPorts and Homebrew.