### PR TITLE
Synchronized Nc4prototypes

### DIFF
--- a/docs/website/netcdf-java/reference/netcdf4Clibrary.adoc
+++ b/docs/website/netcdf-java/reference/netcdf4Clibrary.adoc
@@ -112,6 +112,8 @@ configuration file>>.
 http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/javadocAll/ucar/nc2/jni/netcdf/Nc4Iosp.html#setLibraryAndPath(java.lang.String,%20java.lang.String)[Nc4Iosp.setLibraryAndPath()]
 from your Java program
 
+In all cases, it is recommended that you use an absolute path to specify the library location.
+
 === Troubleshooting
 
 If you get a message like this:

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -84,12 +84,14 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   static protected String DEFAULTNETCDF4LIBNAME = "netcdf";
   //static protected String netcdf4libname = DEFAULTNETCDF4LIBNAME;
 
+/*
   static String[] DEFAULTNETCDF4PATH = new String[]{
           "/opt/netcdf4/lib",
           "/home/dmh/opt/netcdf4/lib", //temporary
           "c:/opt/netcdf", // Windows
           "/usr/jna_lib/",
   };
+*/
 
   static private String jnaPath = null;
   static private String libName = DEFAULTNETCDF4LIBNAME;
@@ -107,6 +109,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
    *
    * @return true if we set jna.library.path
    */
+/*
   static private String defaultNetcdf4Library() {
     StringBuilder pathlist = new StringBuilder();
     for (String path : DEFAULTNETCDF4PATH) {
@@ -120,6 +123,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     }
     return pathlist.length() == 0 ? null : pathlist.toString();
   }
+*/
 
   /**
    * set the path and name of the netcdf c library.
@@ -143,9 +147,11 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     if (jna_path == null) {
       jna_path = nullify(System.getenv(JNA_PATH_ENV));   // Next, try environment variable.
     }
+/*
     if (jna_path == null) {
       jna_path = defaultNetcdf4Library();                // Last, try some default paths.
     }
+*/
 
     if (jna_path != null) {
       System.setProperty(JNA_PATH, jna_path);
@@ -165,7 +171,8 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
         // jna_path may still be null (the user didn't specify a "jna.library.path"), but try to load anyway;
         // the necessary libs may be on the system PATH.
         nc4 = (Nc4prototypes) Native.loadLibrary(libName, Nc4prototypes.class);
-
+	// Make the library synchronized
+	nc4 = (Nc4prototypes) Native.synchronizedLibrary(nc4);
         String message = String.format("NetCDF-4 C library loaded (jna_path='%s', libname='%s').", jnaPath, libName);
         startupLog.info(message);
 

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -82,16 +82,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   static public final String JNA_PATH_ENV = "JNA_PATH"; // environment var
 
   static protected String DEFAULTNETCDF4LIBNAME = "netcdf";
-  //static protected String netcdf4libname = DEFAULTNETCDF4LIBNAME;
-
-/*
-  static String[] DEFAULTNETCDF4PATH = new String[]{
-          "/opt/netcdf4/lib",
-          "/home/dmh/opt/netcdf4/lib", //temporary
-          "c:/opt/netcdf", // Windows
-          "/usr/jna_lib/",
-  };
-*/
 
   static private String jnaPath = null;
   static private String libName = DEFAULTNETCDF4LIBNAME;
@@ -103,27 +93,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
           debugUserTypes = false,
           debugLoad = true,
           debugWrite = false;
-
-  /**
-   * Use the default path to try to set jna.library.path
-   *
-   * @return true if we set jna.library.path
-   */
-/*
-  static private String defaultNetcdf4Library() {
-    StringBuilder pathlist = new StringBuilder();
-    for (String path : DEFAULTNETCDF4PATH) {
-      File f = new File(path);
-      if (f.exists() && f.canRead()) {
-        if (pathlist.length() > 0)
-          pathlist.append(File.pathSeparator);
-        pathlist.append(path);
-        break;
-      }
-    }
-    return pathlist.length() == 0 ? null : pathlist.toString();
-  }
-*/
 
   /**
    * set the path and name of the netcdf c library.
@@ -147,11 +116,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     if (jna_path == null) {
       jna_path = nullify(System.getenv(JNA_PATH_ENV));   // Next, try environment variable.
     }
-/*
-    if (jna_path == null) {
-      jna_path = defaultNetcdf4Library();                // Last, try some default paths.
-    }
-*/
 
     if (jna_path != null) {
       System.setProperty(JNA_PATH, jna_path);
@@ -504,12 +468,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
       count++; // dont include the terminating 0
     }
     return new String(b, 0, count, CDM.utf8Charset); // all strings are considered to be UTF-8 unicode.
-    /*
- char[] carray = new char[count];
- for (int i=0; i<count; i++)
-   carray[i] = (char) DataType.unsignedByteToShort(b[i]);
-
- return new String(carray); */
   }
 
   private List<Attribute> makeAttributes(int grpid, int varid, int natts, Variable v) throws IOException {


### PR DESCRIPTION
Modified Nc4Iosp:
1. jna provides a means to force C calls to be synchronized.
   I added this for the Nc4prototypes interface.
   There may be a (small, I hop) performance hit for the calls,
   but improved safety in multi-threaded environments.
2. Remove the default list of places to look for the libraries.
   Now this must be specified either by -Djna.library.path
   or the corresponding env variable or they must be on the classpath.