### PR TITLE
netCDFtools.jnlp is insulated from version changes

### DIFF
--- a/ui/netCDFtools.jnlp
+++ b/ui/netCDFtools.jnlp
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="1.0+" codebase="http://www.unidata.ucar.edu/software/thredds/v4.6/netcdf-java/webstart" href="netCDFtools.jnlp">
-  <information>
-    <title>NetCDF Tools UI 4.6.6</title>
-    <vendor>Unidata</vendor>
-    <homepage href="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
-    <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
-    <icon href="nc.gif"/>
-    <offline-allowed/>
-  </information>
+<jnlp spec="1.0+" codebase="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart">
+    <information>
+        <title>NetCDF Tools UI</title>
+        <vendor>Unidata</vendor>
+        <homepage href="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
+        <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
+        <icon href="nc.gif"/>
+        <offline-allowed/>
+    </information>
 
-  <security>
-    <all-permissions/>
-  </security>
+    <security>
+        <all-permissions/>
+    </security>
 
-  <update check="always"/>
+    <update check="always"/>
 
-  <resources>
-    <j2se version="1.7+" max-heap-size="1500m"/>
-    <jar href="ui-4.6.6.jar"/>
-    <extension name="netcdfUI Extra" href="netCDFtoolsExtraJars.jnlp"/>
-  </resources>
+    <resources>
+        <j2se version="1.7+" max-heap-size="1500m"/>
+        <extension name="netcdfUI Extra" href="netCDFtoolsExtraJars.jnlp"/>
+    </resources>
 
-  <application-desc main-class="ucar.nc2.ui.ToolsUI"/>
-
+    <application-desc main-class="ucar.nc2.ui.ToolsUI"/>
 </jnlp>

--- a/ui/netCDFtoolsExtraJars.jnlp
+++ b/ui/netCDFtoolsExtraJars.jnlp
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="1.0+" codebase="http://www.unidata.ucar.edu/software/thredds/v4.6/netcdf-java/webstart"
-      href="netCDFtools.jnlp">
+<jnlp spec="1.0+" codebase="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart">
     <information>
-        <title>NetCDF Tools UI 4.6.6</title>
+        <title>NetCDF Tools UI</title>
         <vendor>Unidata</vendor>
         <homepage href="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
         <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
@@ -11,19 +10,20 @@
     </information>
 
     <component-desc/>
+
     <security>
         <all-permissions/>
     </security>
 
     <update check="timeout" policy="always"/>
 
-    <!-- Review the JNLP spec: http://docs.oracle.com/javase/8/docs/technotes/guides/javaws/developersguide/syntax.html -->
-    <!-- In particular, all of these jars should have the download="lazy" attribute. -->
     <resources>
         <j2se version="1.7+" max-heap-size="1500m"/>
-        <!-- Updated by hand for 4.6.6, using :ui:showDependencies to print the deps.
-        In the future, we should be generating this file in Gradle. -->
 
+        <jar href="ui-4.6.6.jar" download="eager"/>
+
+        <!-- Updated by hand for 4.6.6, using :ui:showDependencies to print the deps.
+             In the future, we should be generating this file in Gradle. -->
         <!-- In theory, Webstart will use these in conjunction with ui.jar/META-INF/INDEX.LIST to download
              the minimum number of dependencies when running the application. -->
         <jar href="cdm-4.6.6.jar" download="lazy"/>


### PR DESCRIPTION
* All references to versioned artifacts (e.g. "ui-4.6.6.jar") have been moved to netCDFtoolsExtraJars.jnlp, which netCDFtools.jnlp loads as an extension.
* Both JNLP files use the "current" symlink in their codebase URL, instead of something like "v4.6".

The net effect of these changes is that as long as we're publishing our webstart artifacts to http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart, netCDFtools.jnlp should "just work", even across version increments and even if the file is downloaded and cached. In fact, there shouldn't be a need to change it for the remainder of 4.X; only netCDFtoolsExtraJars.jnlp will need to be modified.

This fixes [DYV-254597](https://andy.unidata.ucar.edu/esupport/staff/index.php?_m=tickets&_a=viewticket&ticketid=27168), although in an alternative way to what was suggested in the thread.