### PR TITLE
-DNetcdf4Clibrary.useForReading command line flag.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -114,6 +114,8 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
     }
     try {
       registerIOProvider("ucar.nc2.iosp.hdf5.H5iosp");
+      if(System.getProperty("Netcdf4Clibrary.useForReading") != null)
+	registerIOProvider("ucar.nc2.jni.netcdf.Nc4Iosp"); // Make sure it precedes hdf5 IOSP
     } catch (Throwable e) {
       if (loadWarnings) log.info("Cant load class H5iosp: {}", e);
     }

--- a/cdm/src/main/java/ucar/nc2/util/xml/RuntimeConfigParser.java
+++ b/cdm/src/main/java/ucar/nc2/util/xml/RuntimeConfigParser.java
@@ -291,6 +291,8 @@ public class RuntimeConfigParser {
         }
 
         boolean useForReading = Boolean.parseBoolean(elem.getChildText("useForReading"));
+	if(!useForReading && System.getProperty("Netcdf4Clibrary.useForReading") != null)
+	    useForReading = true;
         if (useForReading) {
           try {
             // Registers Nc4Iosp in front of all the other IOSPs already registered in NetcdfFile.<clinit>().

--- a/cdm/src/main/java/ucar/nc2/util/xml/RuntimeConfigParser.java
+++ b/cdm/src/main/java/ucar/nc2/util/xml/RuntimeConfigParser.java
@@ -291,8 +291,6 @@ public class RuntimeConfigParser {
         }
 
         boolean useForReading = Boolean.parseBoolean(elem.getChildText("useForReading"));
-	if(!useForReading && System.getProperty("Netcdf4Clibrary.useForReading") != null)
-	    useForReading = true;
         if (useForReading) {
           try {
             // Registers Nc4Iosp in front of all the other IOSPs already registered in NetcdfFile.<clinit>().

--- a/tds/src/main/java/thredds/server/config/CdmInit.java
+++ b/tds/src/main/java/thredds/server/config/CdmInit.java
@@ -134,9 +134,6 @@ public class CdmInit implements InitializingBean,  DisposableBean{
     }
 
     Boolean useForReading = ThreddsConfig.getBoolean("Netcdf4Clibrary.useForReading", false);
-    if(!useForReading && System.getProperty("Netcdf4Clibrary.useForReading") != null)
-	useForReading = Boolean.TRUE;
-
     if (useForReading) {
       if (Nc4Iosp.isClibraryPresent()) {
         try {

--- a/tds/src/main/java/thredds/server/config/CdmInit.java
+++ b/tds/src/main/java/thredds/server/config/CdmInit.java
@@ -134,6 +134,9 @@ public class CdmInit implements InitializingBean,  DisposableBean{
     }
 
     Boolean useForReading = ThreddsConfig.getBoolean("Netcdf4Clibrary.useForReading", false);
+    if(!useForReading && System.getProperty("Netcdf4Clibrary.useForReading") != null)
+	useForReading = Boolean.TRUE;
+
     if (useForReading) {
       if (Nc4Iosp.isClibraryPresent()) {
         try {


### PR DESCRIPTION
Added support for a -DNetcdf4Clibrary.useForReading
command line property. This allows for testing without
having to modify other config files.