### PR TITLE
post merge issue and edal-java bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     // Matches Maven's "project.groupId". Used in MANIFEST.MF for "Implementation-Vendor-Id".
     group = "edu.ucar"
     // Matches Maven's "project.version". Used in MANIFEST.MF for "Implementation-Version".
-    version = '4.6.6-SNAPSHOT'
+    version = '5.0.0-SNAPSHOT'
     // Eventually, we'll stop appending "SNAPSHOT" to our versions and just use this.
     status = 'development'
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -202,7 +202,7 @@ libraries["oro"] = "oro:oro:2.0.6"
 
 libraries["thymeleaf-spring4"] = "org.thymeleaf:thymeleaf-spring4:2.1.4.RELEASE"
 
-versions["edal"] = "1.1.1"
+versions["edal"] = "1.1.2"
 
 libraries["edal-common"] = "uk.ac.rdg.resc:edal-common:${versions["edal"]}"
 


### PR DESCRIPTION
basic edal-java bump (but not to latest version)

@cwardgar - I noticed after the merge of changes from master, the build.gradle picked up during the merge was from 4.6, not 5.0, so I bumped the version in the pom back to 5.0 snapshot. Not sure if other changes to build.gradle were overwritten by pulling in the 4.6 version or not.