### PR TITLE
Compile-time deps have 'compile' scope in generated Maven POMs, not 'runtime'

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'  // Adds gradleApi() compile dep and gradleTestKit() testCompile dep.
 
 // We'd normally apply the dependencies with something like:
 //     apply from: "$rootDir/gradle/dependencies.gradle"
@@ -7,8 +8,6 @@ apply plugin: 'groovy'
 apply from: "../gradle/dependencies.gradle"
 
 dependencies {
-    compile gradleApi()  // We're working with Gradle classes like org.gradle.api.Project.
-
     testCompile (libraries["spock-core"]) {
         // The Gradle API drags in the bundled version of Groovy that Gradle ships with (localGroovy()) –
         // see https://discuss.gradle.org/t/unable-to-force-gradle-to-use-groovy-2-0-0-for-the-project/7021.

--- a/buildSrc/src/main/groovy/edu/ucar/build/PublishingUtil.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/PublishingUtil.groovy
@@ -1,6 +1,8 @@
 package edu.ucar.build
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.publish.maven.MavenArtifact
 import org.gradle.api.publish.maven.MavenPublication
@@ -77,6 +79,49 @@ abstract class PublishingUtil {
                                 // So, we explicitly set it to 'jar'.
                                 pom.packaging = 'jar'
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensures that the project's compile-time dependencies will have a scope of 'compile' in the Maven POMs that are
+     * generated, instead of 'runtime'. This addresses a known bug in the maven-publish plugin:
+     * https://discuss.gradle.org/t/maven-publish-plugin-generated-pom-making-dependency-scope-runtime/
+     *
+     * @param project  the project to adjust POM scopes for.
+     */
+    static void adjustMavenPublicationPomScopes(Project project) {
+        project.with {
+            apply plugin: 'maven-publish'
+
+            // Adapted from code in the above-mentioned Gradle Forums thread but expanded for clarity.
+            publishing {
+                publications.all {
+                    pom.withXml {
+                        Node pomProjectNode = asNode()
+                        assert pomProjectNode.name().localPart == 'project'
+
+                        // The '*' is an alias for Node.breadthFirst(). See http://goo.gl/Bp8s0k
+                        List<Node> pomDependencyNodes = pomProjectNode.dependencies.'*'
+                        assert pomDependencyNodes*.name()*.localPart.toUnique() == ['dependency']
+
+                        // The compile-scoped dependencies of the project. The provided-scoped dependencies are
+                        // already being handled by gradle-extra-configurations-plugin: https://goo.gl/xzRuLu
+                        DependencySet projCompileDeps = project.configurations.compile.dependencies
+
+                        List<Node> depNodesToFix = pomDependencyNodes.findAll { Node pomDependencyNode ->
+                            boolean nodeShouldHaveCompileScope = projCompileDeps.find { Dependency projCompileDep ->
+                                projCompileDep.name == pomDependencyNode.artifactId.text()
+                            }
+
+                            nodeShouldHaveCompileScope && pomDependencyNode.scope.text() != 'compile'
+                        }
+
+                        depNodesToFix.each { Node depNode ->
+                            depNode.scope*.value = 'compile'
                         }
                     }
                 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,9 +36,11 @@ ext {
 
 ////////////////////////////////////////// Plugins //////////////////////////////////////////
 
-libraries["gretty"] = "org.akhikhl.gretty:gretty:1.2.0"
+// Original plugin (last release was 1.2.4): https://github.com/akhikhl/gretty
+// Fork of original (first release was 1.2.5): https://github.com/saladinkzn/gretty
+libraries["gretty"] = "ru.shadam.gretty:gretty:1.3.0"
 
-libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.2"
+libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
 libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1"
 
@@ -244,10 +246,5 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
         // and we don't use the "tidy" functionality (i.e. HTML pretty printing) anyway.
         // Dragged in by httpunit.
         exclude group: 'jtidy', module: 'jtidy'
-
-        // On TDS startup, I'm getting "Class path contains multiple SLF4J bindings" warnings.
-        // This is one of those bindings. Strangely, I have NO idea what dependency is dragging it in.
-        // It doesn't matter though; we always want to see the logging messages.
-        exclude group: 'org.slf4j', module: 'slf4j-nop'
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,6 +4,7 @@ configure(publishedProjects) { Project project ->
     apply plugin: 'maven-publish'
 
     PublishingUtil.addMavenPublicationsForSoftwareComponents(project)
+    PublishingUtil.adjustMavenPublicationPomScopes(project)
 
     publishing {
         repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip


### PR DESCRIPTION
This addresses a known bug in the maven-publish plugin:
https://discuss.gradle.org/t/maven-publish-plugin-generated-pom-making-dependency-scope-runtime/

I easily spent 90% of my time devoted to this commit on figuring out how to test it. I needed the output of the `generatePomFileFor${name}Publication` task, which required a full, nested Gradle build within the test. Luckily, this is possible with GradleRunner, but I needed to make some changes in order to use it:

* Upgraded our Gradle version from 2.9 to 2.14 (latest) so that I could get the java-gradle-plugin.
* Updated Gretty to a forked version of the original, 1.3.0. The old Gretty was incompatible with Gradle 2.14.
  - The new Gretty also fixes a bug where 'slf4j-nop' was being added to TDS's runtime classpath even though 'log4j-slf4j-impl' was present. We no longer need to explicitly exclude that dep now.
* Updated the shadow plugin to 1.2.3, again for compatibility with Gradle 2.14

GradleRunner opens up a lot of opportunities to improve testing of our build code in the future.