### PR TITLE
Array.get1DJavaArray(Class) returns correct value for constant arrays

### DIFF
--- a/cdm/src/main/java/ucar/ma2/IndexConstant.java
+++ b/cdm/src/main/java/ucar/ma2/IndexConstant.java
@@ -108,6 +108,15 @@ public class IndexConstant extends Index {
     return this;
   }
 
+  // This method is only used in Array.get1DJavaArray(Class), where it's used to decide whether a copy is necessary.
+  // In the case of a constant array, we DO need a copy because the size of our backing storage (length=1) is likely
+  // not the size of the Array.
+  // Fixes bug in https://github.com/Unidata/thredds/issues/581
+  @Override
+  boolean isFastIterator() {
+    return false;
+  }
+
   ///////////////////////
 
   IndexIterator getIndexIterator(Array maa) {

--- a/cdm/src/test/java/ucar/ma2/ArrayTest.java
+++ b/cdm/src/test/java/ucar/ma2/ArrayTest.java
@@ -1,9 +1,8 @@
 package ucar.ma2;
 
+import org.junit.Assert;
 import org.junit.Test;
 import ucar.nc2.util.Misc;
-
-import java.io.IOException;
 
 /**
  * Created with IntelliJ IDEA.
@@ -43,8 +42,14 @@ public class ArrayTest {
     double sum = MAMath.sumDouble(data);
     double sumReduce = MAMath.sumDouble(data.reduce(0));
     assert Misc.closeEnough(sum, sumReduce);
+  }
 
-    System.out.printf(" sum =          %f%n", MAMath.sumDouble(data));
-    System.out.printf(" sum2 =          %f%n", MAMath.sumDouble(data.reduce(0)));
+  // Demonstrates bug in https://github.com/Unidata/thredds/issues/581.
+  @Test
+  public void testConstantArray_get1DJavaArray() {
+    Array array = Array.factoryConstant(int.class, new int[] {3}, new int[] {47});
+
+    // Prior to fix, the actual value returned by get1DJavaArray was {47}.
+    Assert.assertArrayEquals(new int[] {47, 47, 47}, (int[]) array.get1DJavaArray(int.class));
   }
 }


### PR DESCRIPTION
* Fixes bug in https://github.com/Unidata/thredds/issues/581