### PR TITLE
Remove unused non-API import

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionBuilderFromIndex.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionBuilderFromIndex.java
@@ -36,7 +36,6 @@
 package ucar.nc2.grib.collection;
 
 import com.google.protobuf.ExtensionRegistry;
-import sun.security.ssl.Debug;
 import thredds.inventory.MFile;
 import ucar.coord.*;
 import ucar.nc2.constants.CDM;


### PR DESCRIPTION
This unused import is detected by Eclipse Neon as being a non-API type (```sun.*``` classes are not part of the Java API). Eclipse reports:
```
Access restriction: The type 'Debug' is not API (restriction on required library '/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar')
```

The import is unused and can be removed.

Workaround for Eclipse Neon users is to change Window / Preferences / Java / Compiler / Errors/Warnings / Deprecated and restricted API / Forbidden reference (access rule): from Error to Warning.