### PR TITLE
Fixed misinterpretation of Lat axis as Time axis in point stack

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/CoordSysEvaluator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/CoordSysEvaluator.java
@@ -60,7 +60,7 @@ public class CoordSysEvaluator {
   static public void findCoords(TableConfig nt, NetcdfDataset ds, Predicate p) {
     nt.lat =  findCoordShortNameByType(ds, AxisType.Lat, p);
     nt.lon =  findCoordShortNameByType(ds, AxisType.Lon, p);
-    nt.time =  findCoordShortNameByType(ds, AxisType.Lat, p);
+    nt.time =  findCoordShortNameByType(ds, AxisType.Time, p);
     nt.elev =  findCoordShortNameByType(ds, AxisType.Height, p);
     if (nt.elev == null)
       nt.elev =  findCoordShortNameByType(ds, AxisType.Pressure, p);


### PR DESCRIPTION
* One way this manifested was that when time values for a PointFeature were requested, latitude values for that feature were returned instead.
* This may have only affected datasets that were interpreted via the "Structure" Table.Type.
* Bug discovered and reported by Yuan Ho.