### PR TITLE
Add SonarQube analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: java
-sudo: false
+
+# Previously, we were seeing a failure in :it:appBeforeIntegrationTest:
+#     Process 'command '/usr/lib/jvm/java-8-oracle/bin/java'' finished with non-zero exit value 137
+#     No output has been received in the last 10 minutes, this potentially indicates a stalled build or
+#     something wrong with the build itself. The build has been terminated.
+# This thread indicates that running the job on Travis's container-based infrastructure may be causing resource issues:
+#     https://github.com/travis-ci/travis-ci/issues/5582
+# Setting sudo to "true" forces the job to run on Travis's standard infrastructure, which seems to fix the problem.
+sudo: true
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ buildscript {
     // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"  // For Gradle plugins.
+        }
     }
     
     dependencies {
@@ -20,6 +23,7 @@ buildscript {
         classpath libraries["shadow"]
         classpath libraries["coveralls-gradle-plugin"]
         classpath libraries["gradle-extra-configurations-plugin"]
+        classpath libraries["sonarqube-gradle-plugin"]
     }
 }
 
@@ -61,6 +65,7 @@ apply from: "$rootDir/gradle/root/testing.gradle"
 apply from: "$rootDir/gradle/root/coverage.gradle"
 apply from: "$rootDir/gradle/root/fatJars.gradle"
 apply from: "$rootDir/gradle/root/publishing.gradle" // Creates pubs for artifacts created in fatJars.gradle
+apply from: "$rootDir/gradle/root/sonarqube.gradle"
 
 apply from: "$rootDir/gradle/any/coverage.gradle"    // Modifies Test task from root/testing.gradle and
                                                      // JacocoReport task from root/coverage.gradle

--- a/gradle/any/coverage.gradle
+++ b/gradle/any/coverage.gradle
@@ -5,22 +5,50 @@ jacoco {
     toolVersion = "0.7.7.201606060606"  // The latest version as of 2016-09-16.
 }
 
-Collection<Task> testTasks = tasks.withType(Test)
-Collection<Task> jacocoReportTasks = tasks.withType(JacocoReport)
+Closure isExtendedByJacoco = { Task task -> task.extensions.findByType(JacocoTaskExtension) }
+Collection<Task> tasksExtendedByJacoco = tasks.matching(isExtendedByJacoco)
 
-// Will apply to ":<subproject>:test" and ":it:integrationTest".
-testTasks.all {
+tasksExtendedByJacoco.all {  // Will apply to ":<subproject>:test" and ":it:appBeforeIntegrationTest".
     // Add the execution data that Jacoco generates as a task output.
+    // The data is a record of all the classes visited during test execution. It is self-contained; we don't need to
+    // provide any source or class directories for it to "work". Those are only necessary for the report.
     outputs.file jacoco.destinationFile
+    
+    // Whether or not data should be appended if the execution data already exists.
+    jacoco.append = false
 }
 
-// Will apply to ":<subproject>:jacocoTestReport", ":it:integrationTestReport" and ":rootJacocoReport".
-jacocoReportTasks.all {
+/*
+ * By default, when the 'jacoco' plugin is applied to a project, a 'jacocoTestReport' task will be added that reports
+ * on the 'main' SourceSet of that project only. For example, ':cdm:jacocoTestReport' reports on the coverage of code
+ * in cdm/src/main only.
+ *
+ * That's fine for :cdm, but we have subprojects that contain no code in their 'main' source set, namely :it,
+ * :cdm-test, and :dap4:d4tests. They only have code in their 'test' SourceSets. As a result, the default
+ * 'jacocoTestReport' task added to those tasks will generate an empty report, because there's nothing to report on.
+ *
+ * We could remedy this by adding main SourceSets from other projects to report on. This would be particularly
+ * appropriate for :cdm-test, which touches code in damn near every subproject. However, I don't really like that idea
+ * because we're already producing an aggregate report in :rootJacocoReport. And frankly, that's the only report
+ * that we REALLY care about; it gets published to Jenkins and Coveralls.
+ *
+ * Therefore, I'd like to maintain the default behavior: a subproject only reports on how well its own tests cover its
+ * own 'main' code. That partitioning of reports promotes TRUE unit tests in our project, which--by definition--
+ * have scopes constrained to a single subproject (and often a single class). The addition of more true unit tests
+ * would be a huge benefit to THREDDS: they execute quickly and are the easiest way to improve our lacking code
+ * coverage. Right now, most of our tests are of the integration variety, straddling several subprojects.
+ *
+ * Furthermore, I don't think that subprojects with no 'main' SourceSet like ':cdm-test' and ':it' are long for this
+ * world. They are a relic of the old Maven build. The NeedsCdmUnitTest category obviates the need for a separate
+ * ':cdm-test' module and the separation of tests that need a running TDS could be better done by adding an
+ * 'integTest' SourceSet to :tds. So in the future, we won't be generating empty Jacoco reports.
+ */
+tasks.withType(JacocoReport).all {  // Will apply to ":<subproject>:jacocoTestReport" and ":rootJacocoReport".
     group = 'Reports'
-    dependsOn testTasks
+    dependsOn tasksExtendedByJacoco
     
     reports {
-        xml.enabled = true
+        xml.enabled = false
         html.enabled = true
         csv.enabled = false
     }

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -36,6 +36,8 @@ libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-
 
 libraries["gradle-extra-configurations-plugin"] = "com.netflix.nebula:gradle-extra-configurations-plugin:3.1.0"
 
+libraries["sonarqube-gradle-plugin"] = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.1"
+
 ////////////////////////////////////////// Spring //////////////////////////////////////////
 
 versions["spring"] = "4.3.2.RELEASE"

--- a/gradle/any/properties.gradle
+++ b/gradle/any/properties.gradle
@@ -1,0 +1,27 @@
+ext {
+    // Used to publish Maven artifacts to Unidata's Nexus repository, https://artifacts.unidata.ucar.edu
+    NEXUS_USERNAME_KEY = 'nexus.username'
+    NEXUS_PASSWORD_KEY = 'nexus.password'
+    
+    // Used to publish code coverage report to https://coveralls.io/github/Unidata/thredds
+    COVERALLS_REPO_TOKEN_KEY = 'coveralls.repo.token'
+    
+    // Used to publish static analysis report to https://sonarqube.com/dashboard/index/thredds
+    SONARQUBE_USER_TOKEN_KEY = 'sonarqube.user.token'
+}
+
+String getPropertyOrFailBuild(String key) {
+    if (!hasProperty(key)) {
+        throw new GradleException("You must define the '$key' property.")
+    } else {
+        property(key) as String
+    }
+}
+
+// It isn't possible to share methods, but we can share extra properties containing a closure, which boils down to
+// the same thing. We're going to do that by converting our methods to closures.
+// See http://stackoverflow.com/questions/18715137/extract-common-methods-from-gradle-build-script
+ext {
+    // Export methods by turning them into closures
+    getPropertyOrFailBuild = this.&getPropertyOrFailBuild
+}

--- a/gradle/any/publishing.gradle
+++ b/gradle/any/publishing.gradle
@@ -13,13 +13,13 @@ publishing {
             maven {
                 name = 'snapshots'
                 url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots/'
-                // Set credentials in taskGraph.whenReady {}
+                // Set credentials in root/coverage.gradle.
             }
         } else {
             maven {
                 name = 'releases'
                 url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/'
-                // Set credentials in taskGraph.whenReady {}
+                // Set credentials in root/coverage.gradle.
             }
         }
     }

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -4,6 +4,7 @@ if (name != "thredds") {
 
 apply plugin: "jacoco"
 apply plugin: "base" // Gives us the "clean" task for removing rootJacocoReport's output.
+apply from: "$rootDir/gradle/any/properties.gradle"  // For Coveralls repo token property.
 
 gradle.projectsEvaluated {  // Several statements below rely upon all subprojects having been evaluated.
     // Add the source directories for each Java subproject to one big FileCollection.
@@ -101,9 +102,9 @@ gradle.projectsEvaluated {  // Several statements below rely upon all subproject
         
         // We want to add the COVERALLS_REPO_TOKEN entry, but coveralls.env is an UnmodifiableMap.
         // So, create a copy of env, add our entry, then replace the old map with it.
-        // FIXME: In production, COVERALLS_REPO_TOKEN should be an environment variable.
         Map<String, String> envCopy = new HashMap<>(env)
-        envCopy["COVERALLS_REPO_TOKEN"] = System.properties['coveralls.repo.token'] // TODO: Fail if not present.
+        // Defer invocation of getPropertyOrFailBuild() until the execution phase, using lazy GStrings.
+        envCopy["COVERALLS_REPO_TOKEN"] = "${-> getPropertyOrFailBuild COVERALLS_REPO_TOKEN_KEY}"
         env = envCopy
         
         // Configure the "coveralls" extension. These properties only appear on the extension, not the task.
@@ -119,7 +120,7 @@ gradle.projectsEvaluated {  // Several statements below rely upon all subproject
         }
         
         doLast {
-            // TODO: Print the URL of where the Coveralls report can be found.
+            println "The latest Coveralls report can be found at https://coveralls.io/github/Unidata/thredds"
         }
     }
 }

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -2,22 +2,30 @@ if (name != "thredds") {
     throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 
-gradle.projectsEvaluated {
-    // This statement relies upon all subprojects having been evaluated.
+apply plugin: "jacoco"
+apply plugin: "base" // Gives us the "clean" task for removing rootJacocoReport's output.
+
+gradle.projectsEvaluated {  // Several statements below rely upon all subprojects having been evaluated.
+    // Add the source directories for each Java subproject to one big FileCollection.
+    // Ditto for the class directories.
     Collection<Project> javaProjects = subprojects*.findAll { it.plugins.withType(JavaPlugin) }
+    FileCollection allSubprojectSourceDirs = files(javaProjects*.sourceSets*.main*.allSource*.srcDirs)
+    FileCollection allSubprojectClassDirs = files(javaProjects*.sourceSets*.main*.output)
     
     task rootJacocoReport(type: JacocoReport, group: 'Reports') {
         description = 'Generates an aggregate coverage report from all subprojects'
         dependsOn tasks.testAll  // Added in root/testing.gradle.
     
+        reports.xml.enabled = true  // Needed by the coveralls task.
+    
         // Add the source directories for the :buildSrc project. Note that by this time in the 'thredds' config,
         // :buildSrc has already run as a SEPARATE build (see http://stackoverflow.com/questions/26597147),
         // so we cannot programmatically access its Project object to retrieve these paths.
         // Also add the source directories of all Java subprojects.
-        sourceDirectories = files('buildSrc/src/main/groovy', javaProjects*.sourceSets*.main*.allSource*.srcDirs)
+        sourceDirectories = files('buildSrc/src/main/groovy', allSubprojectSourceDirs)
         
         // Ditto for class directories.
-        classDirectories = files('buildSrc/build/classes/main', javaProjects*.sourceSets*.main*.output)
+        classDirectories = files('buildSrc/build/classes/main', allSubprojectClassDirs)
         
         // :buildSrc:test always runs and produces execution data, no matter what.
         assert file('buildSrc/build/jacoco/test.exec').exists(): "Can't find :buildSrc Jacoco execution data."
@@ -35,8 +43,8 @@ gradle.projectsEvaluated {
         // changes manually below.
         outputs.upToDateWhen { false } // Evaluated at configuration time (onlyIf{} is evaluated at execution time)
         
-        // This closure will be run during the execution phase. Therefore, we can trust that subprojects will have
-        // been configured.
+        // This closure will be run during the execution phase, after the subproject test tasks.
+        // Therefore, we can trust that execution data for those tasks will have been generated.
         doFirst {
             Closure isExtendedByJacoco = { Task task -> task.extensions.findByType(JacocoTaskExtension) }
             Collection<Task> tasksExtendedByJacoco = subprojects*.tasks*.matching(isExtendedByJacoco).flatten()
@@ -58,8 +66,6 @@ gradle.projectsEvaluated {
             }
         }
     }
-    
-    apply plugin: "base" // Gives us the "clean" task for removing rootJacocoReport's output.
     
     apply plugin: "com.github.kt3k.coveralls"
     
@@ -97,13 +103,13 @@ gradle.projectsEvaluated {
         // So, create a copy of env, add our entry, then replace the old map with it.
         // FIXME: In production, COVERALLS_REPO_TOKEN should be an environment variable.
         Map<String, String> envCopy = new HashMap<>(env)
-        envCopy["COVERALLS_REPO_TOKEN"] = "viswgi0kF5EOgHJXEb58OrOZzToIbi0oJ"
+        envCopy["COVERALLS_REPO_TOKEN"] = System.properties['coveralls.repo.token'] // TODO: Fail if not present.
         env = envCopy
         
         // Configure the "coveralls" extension. These properties only appear on the extension, not the task.
         coveralls {
             jacocoReportPath = tasks.rootJacocoReport.reports.xml.destination
-            sourceDirs = tasks.rootJacocoReport.sourceDirectories.files.collect { task.path }
+            sourceDirs = tasks.rootJacocoReport.sourceDirectories.flatten()
     
             sendToCoveralls = true
             saveAsFile = true  // Save JSON payload to file, so we can use it for UP-TO-DATE checking.

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -8,7 +8,7 @@ apply plugin: "base" // Gives us the "clean" task for removing rootJacocoReport'
 gradle.projectsEvaluated {  // Several statements below rely upon all subprojects having been evaluated.
     // Add the source directories for each Java subproject to one big FileCollection.
     // Ditto for the class directories.
-    Collection<Project> javaProjects = subprojects*.findAll { it.plugins.withType(JavaPlugin) }
+    Collection<Project> javaProjects = subprojects.findAll { it.plugins.withType(JavaPlugin) }
     FileCollection allSubprojectSourceDirs = files(javaProjects*.sourceSets*.main*.allSource*.srcDirs)
     FileCollection allSubprojectClassDirs = files(javaProjects*.sourceSets*.main*.output)
     
@@ -116,6 +116,10 @@ gradle.projectsEvaluated {  // Several statements below rely upon all subproject
     
             inputs.file jacocoReportPath
             outputs.file saveFilePath
+        }
+        
+        doLast {
+            // TODO: Print the URL of where the Coveralls report can be found.
         }
     }
 }

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -3,6 +3,7 @@ if (name != "thredds") {
 }
 
 apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/any/properties.gradle"  // For Nexus credential properties.
 
 import edu.ucar.build.PublishingUtil
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
@@ -38,6 +39,9 @@ publishing {
     }
 }
 
+// Use taskGraph.whenReady() to delay the evaluation of the Nexus credentials for as long as possible.
+// It appears that it can't be deferred until the evaluation phase using Groovy GStrings: it's always done in the
+// execution phase.
 gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
     // This won't find any publishToMavenLocal tasks. Those are of type PublishToMavenLocal
     Collection<Task> mavenPublishTasks = taskGraph.allTasks.findAll { it instanceof PublishToMavenRepository }
@@ -47,19 +51,11 @@ gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
     }
     
     Closure nexusCredentials = {
-        username = getPropertyOrFailBuild 'nexus.username'
-        password = getPropertyOrFailBuild 'nexus.password'
+        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
     }
     
     mavenPublishTasks.each {
         it.repository.credentials nexusCredentials
-    }
-}
-
-String getPropertyOrFailBuild(String key) {
-    if (!rootProject.hasProperty(key)) {
-        throw new GradleException("You must define the '$key' property in order to publish to Nexus.")
-    } else {
-        rootProject.property(key) as String
     }
 }

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -6,15 +6,18 @@ if (name != "thredds") {
 // Adds "sonarqube" task to only the root project. However, the task analyzes the root and all subprojects.
 apply plugin: "org.sonarqube"
 
+apply from: "$rootDir/gradle/any/properties.gradle"  // For SonarQube user token.
+
 gradle.projectsEvaluated {
     // Root project
     sonarqube {
         properties {
             // Global properties. See http://docs.sonarqube.org/display/SONAR/Analysis+Parameters
+            properties["sonar.verbose"] = "false"
             properties["sonar.projectKey"] = "thredds"
-            // properties["sonar.host.url"] = "https://sonarqube.com"
-            // property "sonar.login","62dddbe68f6cd0803ea7c76178bcee93be35bf22"
-            properties["sonar.verbose"] = "true"
+            properties["sonar.host.url"] = "https://sonarqube.com"
+            // Defer invocation of getPropertyOrFailBuild() until the execution phase, using lazy GStrings.
+            properties["sonar.login"] = "${-> getPropertyOrFailBuild SONARQUBE_USER_TOKEN_KEY}"
             
             /*
              * We want to analyze the code in :buildSrc. Unfortunately, that's doesn't happen by default with the

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -2,29 +2,172 @@ if (name != "thredds") {
     throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 
+// Adds "sonarqube" extension to all projects.
+// Adds "sonarqube" task to only the root project. However, the task analyzes the root and all subprojects.
 apply plugin: "org.sonarqube"
 
-allprojects {
+gradle.projectsEvaluated {
+    // Root project
     sonarqube {
         properties {
-            property "sonar.host.url", "https://sonarqube.com"
-            // Unidata
-            property "sonar.login","62dddbe68f6cd0803ea7c76178bcee93be35bf22"
-            // cwardgar
-            // property "sonar.login", "49fefac6d9c88b2a7eda6ea7ebb41dbfbd4d5a30"
-    
-            property "sonar.inclusions", "**/*.java,**/*.groovy"  // We have C code in our repo that trips sonar up.
+            // Global properties. See http://docs.sonarqube.org/display/SONAR/Analysis+Parameters
+            properties["sonar.projectKey"] = "thredds"
+            // properties["sonar.host.url"] = "https://sonarqube.com"
+            // property "sonar.login","62dddbe68f6cd0803ea7c76178bcee93be35bf22"
+            properties["sonar.verbose"] = "true"
             
-            property "sonar.verbose", "true"
+            /*
+             * We want to analyze the code in :buildSrc. Unfortunately, that's doesn't happen by default with the
+             * application of the Sonar plugin because :buildSrc isn't technically part of thredds (Gradle considers
+             * it a completely separate build). Therefore, sonar isn't including it in the "sonar.modules" property.
+             *
+             * Why not just manually edit "sonar.modules" to include :buildSrc? Because the plugin overwrites anything
+             * that the user has set with a computed value: https://goo.gl/n2EIaI. As a result, "sonar.modules" is
+             * effectively read-only.
+             *
+             * So, given that we can't easily influence the value of the "sonar.modules" property (we'd need to
+             * physically create another subproject in the Gradle build), the other option is to assign buildSrc's code
+             * to an existing (Sonar) module. "thredds" (the root project) seems the natural choice, and that's what
+             * we're trying to do here. Unfortunately, this fails with an error:
+             *     A multi-module project can't have source folders, so
+             *     '/Users/cwardgar/dev/projects/thredds/buildSrc/src' won't be used for the analysis.
+             *
+             * See http://stackoverflow.com/questions/39297889. Essentially, only "leaf" modules are allowed to have
+             * source code. However, as stated in the thread, SonarSource is aware of the problem (SONARGRADL-5) and
+             * may fix it. I'll leave this here in the event that they do.
+             */
+            properties["sonar.sources"] = file("buildSrc/src")
+            properties["sonar.java.binaries"] = file("buildSrc/build/classes")
         }
     }
+    
+    allprojects {
+        sonarqube {
+            properties {
+                properties["sonar.inclusions"] = "**/*.java, **/*.groovy"  // Only scan Java and Groovy files.
+                properties["sonar.exclusions"] = "**/*Proto.java"          // Don't analyze protobuf-generated code.
+    
+                // We're already reporting test failures and code coverage in Jenkins; we don't need to do it in Sonar
+                // too. Setting these properties to the empty string effectively disables the associated functionality.
+                properties["sonar.junit.reportsPath"] = ""
+                properties["sonar.surefire.reportsPath"] = ""
+                properties["sonar.jacoco.reportPath"] = ""
+                properties["sonar.groovy.jacoco.reportPath"] = ""
+    
+                // These properties are deprecated, so go ahead and empty them as well.
+                properties["sonar.binaries"] = ""
+                properties["sonar.libraries"] = ""
+            }
+        }
+    }
+    
+    Collection<Project> javaProjects = subprojects.findAll { it.plugins.withType(JavaPlugin) }
+    
+    configure (javaProjects) {  // The 'sourceSets' property will only be found on Java projects.
+        sonarqube {
+            properties {
+                /*
+                 * The only code Sonar actually analyzes is in "sonar.sources". It uses "sonar.java.binaries" and
+                 * "sonar.java.libraries" for inspections that require bytecode. The values of these properties are
+                 * all taken from a Java project's "main" SourceSet.
+                 *
+                 * There are analogous properties for the "test" SourceSet: "sonar.tests", "sonar.java.test.binaries",
+                 * and "sonar.java.test.libraries". If we want our test code to be analyzed along with our main code,
+                 * we need to add the values of the "test" properties to their "main" counterparts.
+                 *
+                 * After that, we set the values of those "test" properties to the empty string, which instructs Sonar
+                 * to not do its normal reporting of test successes and failures. As mentioned before, we don't want
+                 * Sonar doing that; we already have Jenkins.
+                 */
+                def sources = files(properties["sonar.sources"] ?: [],
+                                    properties["sonar.tests"]   ?: []).flatten()
+                properties["sonar.sources"] = nukeDupesAndNonExistent(sources)
+                properties["sonar.tests"] = ""
+    
+                def binaries = files(properties["sonar.java.binaries"]      ?: [],
+                                     properties["sonar.java.test.binaries"] ?: []).flatten()
+                properties["sonar.java.binaries"] = nukeDupesAndNonExistent(binaries)
+                properties["sonar.java.test.binaries"] = ""
+    
+                def libraries = files(properties["sonar.java.libraries"]      ?: [],
+                                      properties["sonar.java.test.libraries"] ?: []).flatten()
+                properties["sonar.java.libraries"] = nukeDupesAndNonExistent(libraries)
+                properties["sonar.java.test.libraries"] = ""
+            }
+        }
+    }
+    
+    /*
+     * :opendap is a module with both source code and a child module. Due to SONARGRADL-5, it will not be analyzed by
+     * Sonar. Again, only "leaf" modules are allowed to have source code. So, if we want both :opendap and
+     * :opendap:dtswar to be analyzed, we must merge them together into one leaf module.
+     *
+     * We do this by assigning all of dtswar's sources, binaries, and libraries to opendap, and then setting dtswar's
+     * "skipProject" property to "true". This effectively deletes dtswar from the the module structure, leaving
+     * opendap as a leaf.
+     */
+    project(":opendap") {
+        sonarqube {
+            properties {
+                // Due to the deferred evaluation of this SonarQubeProperties Action (see https://goo.gl/skuBHE),
+                // many of dtswar's Sonar properties (such as ":opendap:dtswar.sonar.sources") aren't available here.
+                // So, we have to come up with those values ourselves. See https://goo.gl/sAKb3j
+                SourceSetContainer dtswarSourceSets = rootProject.project(":opendap:dtswar").sourceSets
+    
+                // Merge dtswar's source code into opendap's source code.
+                def sources = files(properties["sonar.sources"] ?: [],
+                        dtswarSourceSets.main.allSource.srcDirs ?: [], // :opendap:dtswar.sonar.sources
+                        dtswarSourceSets.test.allSource.srcDirs ?: []  // :opendap:dtswar.sonar.tests
+                ).flatten()
+                properties["sonar.sources"] = nukeDupesAndNonExistent(sources)
+    
+                // Merge dtswar's binaries into opendap's binaries.
+                def binaries = files(properties["sonar.java.binaries"] ?: [],
+                        dtswarSourceSets.main.output.classesDir ?: [], // :opendap:dtswar.sonar.java.binaries
+                        dtswarSourceSets.test.output.classesDir ?: []  // :opendap:dtswar.sonar.java.test.binaries
+                ).flatten()
+                properties["sonar.java.binaries"] = nukeDupesAndNonExistent(binaries)
+    
+                // Merge dtswar's libraries into opendap's libraries.
+                def libraries = files(properties["sonar.java.libraries"] ?: [],
+                        dtswarSourceSets.main.compileClasspath ?: [], // :opendap:dtswar.sonar.java.libraries
+                        dtswarSourceSets.test.compileClasspath ?: []  // :opendap:dtswar.sonar.java.test.libraries
+                ).flatten()
+                properties["sonar.java.libraries"] = nukeDupesAndNonExistent(libraries)
+            }
+        }
+    }
+    
+    // Causes :opendap to become a leaf module.
+    project(":opendap:dtswar").sonarqube.skipProject = true
+    
+    boolean debug = false
+    
+    tasks.sonarqube {
+        // Some inspections require bytecode. 'testClasses' depends on 'classes'.
+        dependsOn = javaProjects*.tasks*.testClasses
+        
+        if (debug) {
+            doFirst {
+                // 'properties' is a dynamic property, recomputed every time it is accessed by
+                // computeSonarProperties(). See https://goo.gl/DkbXfe. This essentially makes it read-only.
+                properties.each{
+                    k, v -> println "$k:$v"
+                }
+                throw new StopExecutionException("Okay, STOP. We just wanted to see the properties.")
+            }
+        }
+    }
+
 }
 
-tasks.sonarqube {
-    println "========== ${it.project.name}:${it.name} =========="
-    doFirst {
-        properties.each{ k, v -> println "${k}:${v}" }
+// Returns the provided files, minus any duplicates or files that don't exist.
+Set<File> nukeDupesAndNonExistent(Iterable<File> files) {
+    Set<File> ret = new LinkedHashSet<File>()
+    files.each {
+        if (it.exists()) {
+            ret << it
+        }
     }
-    println()
-    println()
+    ret
 }

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -1,0 +1,30 @@
+if (name != "thredds") {
+    throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
+}
+
+apply plugin: "org.sonarqube"
+
+allprojects {
+    sonarqube {
+        properties {
+            property "sonar.host.url", "https://sonarqube.com"
+            // Unidata
+            property "sonar.login","62dddbe68f6cd0803ea7c76178bcee93be35bf22"
+            // cwardgar
+            // property "sonar.login", "49fefac6d9c88b2a7eda6ea7ebb41dbfbd4d5a30"
+    
+            property "sonar.inclusions", "**/*.java,**/*.groovy"  // We have C code in our repo that trips sonar up.
+            
+            property "sonar.verbose", "true"
+        }
+    }
+}
+
+tasks.sonarqube {
+    println "========== ${it.project.name}:${it.name} =========="
+    doFirst {
+        properties.each{ k, v -> println "${k}:${v}" }
+    }
+    println()
+    println()
+}

--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -6,6 +6,7 @@ if (name != "thredds") {
 // That's a bit spammy, but at least the code is straightforward.
 // The alternative is to use "gradle.taskGraph.whenReady{}" and only do this config if a Test is in the task graph,
 // but it's not worth the extra complication.
+// LOOK: What about if we only logged warnings in "gradle.taskGraph.whenReady{}"?
 ext {
     // These appear to be the only environment variables that Jenkins defines: http://goo.gl/iCh08k
     // Is there a better way to detect Jenkins?

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -34,8 +34,6 @@ dependencies {
     // we're overlaying tds (see below), so we're already getting the binding that it declares.
 }
 
-test.enabled = false  // We're doing integrationTest instead.
-
 apply plugin: 'org.akhikhl.gretty'
 
 gretty {
@@ -48,7 +46,9 @@ gretty {
     // See http://akhikhl.github.io/gretty-doc/Web-app-overlays.html
     overlay ':tds'
 
-    integrationTestTask = 'integrationTest' // The name of an existing gradle task.
+    // The normal 'test' task added by the Java plugin has nothing to do in this subproject, because every single
+    // test requires a running TDS. Therefore, we're repurposing the 'test' task for integration testing.
+    integrationTestTask = 'test'
 
     // By default, this field is 'false', which causes Gretty to start the embedded Tomcat process with a non-blocking
     // entropy source. It is intended to make startup faster.
@@ -72,14 +72,14 @@ gretty {
 }
 
 // Gretty will start the webapp before this task and shut it down afterward.
-task integrationTest(type: Test, group: 'Verification') {
+test {
     // isContentRootAvailable, isJenkins, and contentRootKey are defined on the root project in testing.gradle.
     if (!isContentRootAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
         logger.warn "Skipping all integration tests (task \'$path\'): " +
                 "\'$contentRootKey\' property not defined."
 
         // We can't stand up a functioning TDS test instance without a valid content root,
-        // so disable the integration test task altogether.
+        // so disable the task altogether.
         enabled = false
     }
 
@@ -98,22 +98,10 @@ task integrationTest(type: Test, group: 'Verification') {
     }
 }
 
-// Propagate all of integrationTest's system properties (which were set in testing.gradle) to the embedded Tomcat
-// instance. org.akhikhl.gretty.ServerConfig.systemProperties is null by default.
+// Propagate all of test's system properties (which were set in testing.gradle) to the embedded Tomcat instance.
+// org.akhikhl.gretty.ServerConfig.systemProperties is null by default.
 // So, we can be sure that we're not trampling over any existing properties by doing this.
-gretty.systemProperties integrationTest.systemProperties
-
-task integrationTestReport(type: JacocoReport, dependsOn: "integrationTest") {
-    // executionData must be closure, because appBeforeIntegrationTest is not defined yet.
-    // We must pass jacoco.destinationFile, not appBeforeIntegrationTest itself,
-    // because otherwise JacocoReport would translate task argument to closure and Project.files(...)
-    // (which is used internally by executionData) is not able to resolve recursive closures.
-    executionData { tasks.appBeforeIntegrationTest.jacoco.destinationFile }
-
-    reports {
-        html.destination = reporting.file("jacoco/integrationTest/html")
-    }
-}
+gretty.systemProperties test.systemProperties
 
 import org.gradle.api.internal.changedetection.TaskArtifactStateRepository
 import org.gradle.api.internal.changedetection.TaskArtifactState
@@ -124,14 +112,14 @@ import org.gradle.api.internal.changedetection.TaskArtifactState
 afterEvaluate {
     // This task starts the embedded Tomcat server. It's expensive to do.
     appBeforeIntegrationTest {
-        // We're trying hard to only execute appBeforeIntegrationTest if integrationTest will execute.
-        // We won't execute if integrationTest is disabled--that's simple.
-        // We also won't execute if integrationTest is considered UP-TO-DATE. That's much harder to determine, and we
+        // We're trying hard to only execute appBeforeIntegrationTest if test will execute.
+        // We won't execute if test is disabled--that's simple.
+        // We also won't execute if test is considered UP-TO-DATE. That's much harder to determine, and we
         // had to dig into internal Gradle APIs to find that info. Expect this to break in the future.
-        // There are still other cases where integrationTest execution could be skipped that we don't or can't check
+        // There are still other cases where test execution could be skipped that we don't or can't check
         // (e.g. one of its onlyIf()s returns false), but those situations are rare.
         onlyIf {
-            Task task = tasks.integrationTest
+            Task task = tasks.test
             if (!task.enabled) {    // May have been disabled above.
                 return false;
             }
@@ -143,13 +131,8 @@ afterEvaluate {
         // "jacoco" extension is created automatically for all AppBeforeIntegrationTest tasks
         // and has type org.gradle.testing.jacoco.plugins.JacocoTaskExtension
         jacoco {
-            // appBeforeIntegrationTest.exec gets larger every run if we don't do this. That breaks UP-TO-DATE
-            // checking. LOOK: The Test tasks have "true" here, yet I don't notice the undesirable behavior. Why?
-            append = false
-
-            // Don't use the same name as our integration test task's execution data.
-            // That data may be useless (is it?), but overwriting it during execution foils UP-TO-DATE checking.
-            // destinationFile = new File(buildDir, 'jacoco/integrationTest.exec')
+            // Don't use the same name as our test task's execution data.
+            destinationFile = file("$buildDir/jacoco/embedded-tds.exec")
         }
 
         doFirst {
@@ -163,5 +146,10 @@ afterEvaluate {
     appAfterIntegrationTest {
         // Only run if appBeforeIntegrationTest did work.
         onlyIf { tasks.appBeforeIntegrationTest.getDidWork() }
+    }
+    
+    jacocoTestReport {
+        executionData = files(tasks.appBeforeIntegrationTest.jacoco.destinationFile,
+                              tasks.test.jacoco.destinationFile)
     }
 }


### PR DESCRIPTION
Reports are being generated by a nightly Jenkins job and being published to Sonar's free-for-open-source server at https://sonarqube.com/dashboard/index/thredds. It's also powered by Gradle.

Other notes:
* Cleaned up test coverage build logic
* We're now running Travis jobs on their "standard infrastructure", which seems to fix an out-of-resources failure we were seeing when launching the embedded TDS. Travis jobs also are completing a lot faster. Woot!
* This PR supersedes #635