### PR TITLE
Added "Last-Modified" header to responses of several services

### DIFF
--- a/tds/src/main/java/thredds/server/cdmrfeature/CdmrGridController.java
+++ b/tds/src/main/java/thredds/server/cdmrfeature/CdmrGridController.java
@@ -43,7 +43,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.mvc.LastModified;
 import thredds.core.AllowedServices;
 import thredds.core.StandardService;
 import thredds.core.TdsRequestedDataset;
@@ -57,13 +56,11 @@ import ucar.ma2.Array;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Range;
 import ucar.ma2.Section;
-import ucar.nc2.Variable;
 import ucar.nc2.ft2.coverage.*;
 import ucar.nc2.ft2.coverage.remote.CdmrFeatureProto;
 import ucar.nc2.ft2.coverage.remote.CdmrfWriter;
 import ucar.nc2.iosp.IospHelper;
 import ucar.nc2.stream.NcStream;
-import ucar.nc2.stream.NcStreamCompression;
 import ucar.nc2.stream.NcStreamDataCol;
 import ucar.nc2.stream.NcStreamProto;
 
@@ -87,7 +84,7 @@ import java.util.zip.DeflaterOutputStream;
  */
 @Controller
 @RequestMapping("/cdmrfeature/grid")
-public class CdmrGridController implements LastModified {
+public class CdmrGridController {
   // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CdmrGridController.class);
   private static final boolean showReq = false;
   private static final boolean showRes = false;
@@ -97,12 +94,6 @@ public class CdmrGridController implements LastModified {
 
   @Autowired
   private AllowedServices allowedServices;
-
-  @Override
-  public long getLastModified(HttpServletRequest req) {
-    String path = TdsPathUtils.extractPath(req, "cdmrfeature/");
-    return TdsRequestedDataset.getLastModified(path);
-  }
 
   ////////////////////////////////////////////////////////////////////
 
@@ -139,6 +130,8 @@ public class CdmrGridController implements LastModified {
 
       response.setContentType(ContentType.binary.getContentHeader());
       response.setHeader("Content-Description", "ncstream");
+      response.addDateHeader("Last-Modified", TdsRequestedDataset.getLastModified(datasetPath));
+
       CdmrfWriter writer = new CdmrfWriter();
       long size = writer.sendHeader(out, gridCoverageDataset, ServletUtil.getRequestBase(request));
       out.flush();
@@ -169,6 +162,7 @@ public class CdmrGridController implements LastModified {
 
       responseHeaders = new HttpHeaders();
       responseHeaders.set(ContentType.HEADER, ContentType.text.getContentHeader());
+      responseHeaders.setDate("Last-Modified", TdsRequestedDataset.getLastModified(datasetPath));
       return new ResponseEntity<>(text, responseHeaders, HttpStatus.OK);
 
     }

--- a/tds/src/main/java/thredds/server/fileserver/FileServerController.java
+++ b/tds/src/main/java/thredds/server/fileserver/FileServerController.java
@@ -35,16 +35,15 @@ package thredds.server.fileserver;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.LastModified;
 import thredds.core.TdsRequestedDataset;
 import thredds.servlet.ServletUtil;
 import thredds.util.TdsPathUtils;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 
 /**
  * HTTP File Serving
@@ -53,19 +52,8 @@ import java.io.File;
  */
 @Controller
 @RequestMapping("/fileServer")
-public class FileServerController implements LastModified {
+public class FileServerController {
   protected static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileServerController.class);
-
-  public long getLastModified(HttpServletRequest req) {
-    String reqPath = TdsPathUtils.extractPath(req, "fileServer/");
-    if (reqPath == null) return -1;
-
-    File file = getFile( reqPath);
-    if (file == null)
-      return -1;
-
-    return file.lastModified();
-  }
 
   @RequestMapping("**")
   public void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {

--- a/tds/src/main/java/thredds/server/root/RootController.java
+++ b/tds/src/main/java/thredds/server/root/RootController.java
@@ -37,7 +37,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.LastModified;
 import thredds.server.config.TdsContext;
 import thredds.util.RequestForwardUtils;
 import thredds.util.TdsPathUtils;
@@ -55,17 +54,9 @@ import java.io.IOException;
  * @since 4.0
  */
 @Controller
-public class RootController implements LastModified {
-
+public class RootController {
   @Autowired
   private TdsContext tdsContext;
-
-  // this is to catch old style catalog requests that dont start with catalog LOOK this breaks jsps
-  /* @RequestMapping({"**"})
-  public String wtf(HttpServletRequest req) throws FileNotFoundException {
-    System.out.printf("%s%n", req.getRequestURI());
-    throw new FileNotFoundException(req.getRequestURI());
-  }  */
 
   @RequestMapping(value = {"/", "/catalog.html"}, method = {RequestMethod.GET, RequestMethod.HEAD})
   public String redirectRootCatalog() {
@@ -77,7 +68,7 @@ public class RootController implements LastModified {
     return "redirect:/catalog/catalog.xml";
   }
 
-  @RequestMapping(value = {"*.css", "*.gif", "*.jpg", "*.png, *.jsp"}, method = RequestMethod.GET)
+  @RequestMapping(value = {"*.css", "*.gif", "*.jpg", "*.png", "*.jsp"}, method = RequestMethod.GET)
   public ModelAndView serveFromPublicDirectory(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
     String path = TdsPathUtils.extractPath(req, null);
     File file = tdsContext.getPublicContentDirSource().getFile(path);
@@ -86,16 +77,5 @@ public class RootController implements LastModified {
       return null;
     }
     return new ModelAndView("threddsFileView", "file", file);
-  }
-
-  public long getLastModified(HttpServletRequest req) {
-    String path = TdsPathUtils.extractPath(req, null);
-    File file = tdsContext.getPublicContentDirSource().getFile(path);
-    if (file == null)
-      return -1;
-    long lastModTime = file.lastModified();
-    if (lastModTime == 0L)
-      return -1;
-    return lastModTime;
   }
 }

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -33,20 +33,24 @@
 
 package thredds.servlet;
 
-import java.io.*;
-import java.util.*;
-import java.net.URI;
-import java.net.URISyntaxException;
-import javax.servlet.*;
-import javax.servlet.http.*;
-
 import thredds.core.ConfigCatalogHtmlWriter;
 import thredds.util.ContentType;
-import ucar.nc2.constants.CDM;
-import ucar.nc2.util.IO;
 import thredds.util.RequestForwardUtils;
+import ucar.nc2.constants.CDM;
 import ucar.nc2.util.EscapeStrings;
+import ucar.nc2.util.IO;
 import ucar.unidata.io.RandomAccessFile;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
 
 public class ServletUtil {
   public static final org.slf4j.Logger logServerStartup = org.slf4j.LoggerFactory.getLogger("serverStartup");
@@ -179,6 +183,7 @@ public class ServletUtil {
    */
   public static void returnFile(HttpServletRequest req, HttpServletResponse res, File file, String contentType) throws IOException {
     res.setContentType(contentType);
+    res.addDateHeader("Last-Modified", file.lastModified());
     // res.setHeader("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"");
 
     // see if its a Range Request

--- a/tds/src/test/java/thredds/server/cdmremote/CdmrControllerTest.java
+++ b/tds/src/test/java/thredds/server/cdmremote/CdmrControllerTest.java
@@ -8,6 +8,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -38,14 +40,15 @@ import java.util.Collection;
 @ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml", "/WEB-INF/spring-servlet.xml"}, loader = MockTdsContextLoader.class)
 @Category(NeedsCdmUnitTest.class)
 public class CdmrControllerTest {
+    private static final Logger logger = LoggerFactory.getLogger(CdmrControllerTest.class);
 
   @Autowired
- 	private WebApplicationContext wac;
+  private WebApplicationContext wac;
 
- 	private MockMvc mockMvc;
+  private MockMvc mockMvc;
 
- 	@Before
- 	public void setup(){
+   @Before
+   public void setup(){
  		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
  	}
 
@@ -57,7 +60,7 @@ public class CdmrControllerTest {
             {"/cdmremote/testBuoyFeatureCollection/files/Surface_Buoy_20130804_0000.nc", 5, 2, 58, "meanWind(0:1)"},  // point
             {"/cdmremote/testSurfaceSynopticFeatureCollection/files/Surface_Synoptic_20130804_0000.nc", 5, 2, 46, "humidity(0:1)"},  // point
     });
- 	}
+  }
 
   String path, dataReq;
   int ndims, natts, nvars;
@@ -74,14 +77,12 @@ public class CdmrControllerTest {
      RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path)
    				.param("req", "capabilities");
 
-    System.out.printf("%s?req=capabilities%n", path);
+      logger.debug("{}?req=capabilities", path);
 
      MvcResult result = this.mockMvc.perform( rb )
                .andExpect(MockMvcResultMatchers.status().is(200))
                .andExpect(MockMvcResultMatchers.content().contentType(ContentType.xml.getContentHeader()))
                .andReturn();
-
-    //System.out.printf("content = %s%n", result.getResponse().getContentAsString());
 
     /* String content =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"+
@@ -102,8 +103,10 @@ public class CdmrControllerTest {
               .andExpect(MockMvcResultMatchers.content().contentType(ContentType.text.getContentHeader()))
               .andReturn();
 
-
-    //System.out.printf("content = %s%n", result.getResponse().getContentAsString());
+      // We want this statement to succeed without exception.
+      // Throws NullPointerException if header doesn't exist
+      // Throws IllegalArgumentException if header value is not a valid date.
+      result.getResponse().getDateHeader("Last-Modified");
   }
 
   @Test
@@ -116,18 +119,16 @@ public class CdmrControllerTest {
                .andExpect(MockMvcResultMatchers.content().contentType(ContentType.xml.getContentHeader()))
                .andReturn();
 
-
-    //System.out.printf("content = %s%n", result.getResponse().getContentAsString());
+      // We want this statement to succeed without exception.
+      // Throws NullPointerException if header doesn't exist
+      // Throws IllegalArgumentException if header value is not a valid date.
+      result.getResponse().getDateHeader("Last-Modified");
 
     Document doc = XmlUtil.getStringResponseAsDoc(result.getResponse());
 
     int hasDims = NcmlParserUtil.getNcMLElements("netcdf/dimension", doc).size();
     int hasAtts = NcmlParserUtil.getNcMLElements("netcdf/attribute", doc).size();
     int hasVars = NcmlParserUtil.getNcMLElements("//variable", doc).size();
-
-    System.out.printf("ndims = %s%n", hasDims);
-    System.out.printf("natts = %s%n", hasAtts);
-    System.out.printf("nvars = %s%n", hasVars);
 
     //Not really checking the content just the number of elements
     assertEquals(this.ndims, hasDims);
@@ -145,10 +146,14 @@ public class CdmrControllerTest {
                .andExpect(MockMvcResultMatchers.content().contentType(ContentType.binary.getContentHeader()))
                .andReturn();
 
+      // We want this statement to succeed without exception.
+      // Throws NullPointerException if header doesn't exist
+      // Throws IllegalArgumentException if header value is not a valid date.
+      result.getResponse().getDateHeader("Last-Modified");
+
         //response is a ncstream
     ByteArrayInputStream bais = new ByteArrayInputStream(result.getResponse().getContentAsByteArray());
     CdmRemote cdmr = new CdmRemote(bais, "test");
-    System.out.printf("%s%n", cdmr);
     cdmr.close();
    }
 

--- a/tds/src/test/java/thredds/server/cdmrfeature/CdmrGridControllerTest.java
+++ b/tds/src/test/java/thredds/server/cdmrfeature/CdmrGridControllerTest.java
@@ -1,0 +1,73 @@
+package thredds.server.cdmrfeature;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import thredds.util.ContentType;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+/**
+ * @author cwardgar
+ * @since 2016-10-18
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={"/WEB-INF/applicationContext.xml"})
+@Category(NeedsCdmUnitTest.class)
+public class CdmrGridControllerTest {
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+    private String datasetPath;
+
+    @Before
+    public void setup(){
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+        this.datasetPath = "/cdmrfeature/grid/cdmUnitTest/ncss/CONUS_80km_nc/GFS_CONUS_80km_20120419_0000.nc";
+    }
+
+    @Test
+    public void testHeader() throws Exception {
+        RequestBuilder rb = MockMvcRequestBuilders.get(datasetPath).servletPath(datasetPath)
+                .param("req", "header");
+
+        MvcResult result = this.mockMvc.perform( rb )
+                .andExpect(MockMvcResultMatchers.status().is(200))
+                .andExpect(MockMvcResultMatchers.content().contentType(ContentType.binary.getContentHeader()))
+                .andReturn();
+
+        // We want this statement to succeed without exception.
+        // Throws NullPointerException if header doesn't exist
+        // Throws IllegalArgumentException if header value is not a valid date.
+        result.getResponse().getDateHeader("Last-Modified");
+    }
+
+    @Test
+    public void testForm() throws Exception {
+        RequestBuilder rb = MockMvcRequestBuilders.get(datasetPath).servletPath(datasetPath)
+                .param("req", "form");
+
+        MvcResult result = this.mockMvc.perform( rb )
+                .andExpect(MockMvcResultMatchers.status().is(200))
+                .andExpect(MockMvcResultMatchers.content().contentType(ContentType.text.getContentHeader()))
+                .andReturn();
+
+        // We want this statement to succeed without exception.
+        // Throws NullPointerException if header doesn't exist
+        // Throws IllegalArgumentException if header value is not a valid date.
+        result.getResponse().getDateHeader("Last-Modified");
+    }
+}

--- a/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
+++ b/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
@@ -1,0 +1,47 @@
+package thredds.server.fileserver;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+/**
+ * @author cwardgar
+ * @since 2016-10-18
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={"/WEB-INF/applicationContext.xml"})
+@Category(NeedsCdmUnitTest.class)
+public class FileServerControllerTest {
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(new FileServerController()).build();
+    }
+
+    @Test
+    public void testLastModified() throws Exception {
+        String path = "/fileServer/testNAMfmrc/files/20060925_0600.nc";
+        RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+        MvcResult result = mockMvc.perform(rb).andReturn();
+        Assert.assertEquals(200, result.getResponse().getStatus());
+
+        // We want this statement to succeed without exception.
+        // Throws NullPointerException if header doesn't exist
+        // Throws IllegalArgumentException if header value is not a valid date.
+        result.getResponse().getDateHeader("Last-Modified");
+    }
+}


### PR DESCRIPTION
* These included CdmRemoteController ("/cdmremote"), CdmrGridController ("/cdmrfeature/grid"), and FileServerController ("/fileServer").
* For each affected service, added regression tests that ensure that the header is being set.
* Fixed bug where RootController wasn't handling "*.png" and "*.jsp" requests, as it should.

From [GCE-849369](https://andy.unidata.ucar.edu/esupport/staff/index.php?_m=tickets&_a=viewticket&ticketid=27614), fileServer (and perhaps other controllers) used to return the header, as mentioned [here](http://www.unidata.ucar.edu/mailing_lists/archives/thredds/2012/msg00191.html). However, the last time it did so was v4.3.X. In v4.4.0, we refactored the Servlets and made them Spring Controllers. Little did we know, we lost "Last-Modified" in the process.

It turns out that `org.springframework.web.servlet.mvc.LastModified.getLastModified()` (which all those controllers implemented) doesn't do what we hoped it did. I've removed it from all controllers, since it has no purpose in our current Spring configuration.