### PR TITLE
Fixed dependency issues discovered by 'gradle-lint-plugin'

### DIFF
--- a/bufr/build.gradle
+++ b/bufr/build.gradle
@@ -14,4 +14,5 @@ dependencies {
     compile libraries["jcommander"]
     compile libraries["protobuf-java"]
     compile libraries["slf4j-api"]
+    compile libraries["guava"]
 }

--- a/cdm-test/build.gradle
+++ b/cdm-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testCompile libraries["commons-compress"]
     testCompile libraries["jj2000"]
     testCompile libraries["jdom2"]
+    testCompile libraries["guava"]
 
     testCompile libraries["slf4j-api"]
 }

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCrossSeamWriteFile.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCrossSeamWriteFile.java
@@ -1,7 +1,7 @@
 /* Copyright Unidata */
 package ucar.nc2.ft.coverage;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -17,8 +17,8 @@ import ucar.nc2.util.Misc;
 import ucar.nc2.util.Optional;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.File;
 import java.io.IOException;

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageMisc.java
@@ -33,7 +33,7 @@
  */
 package ucar.nc2.ft.coverage;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,8 +47,8 @@ import ucar.nc2.util.Optional;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.ProjectionImpl;
 import ucar.unidata.geoloc.ProjectionRect;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 

--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile libraries["protobuf-java"]
     compile libraries["guava"]
     compile libraries["jcommander"]
+    compile libraries["httpcore"]
 
     compile libraries["jsr305"]  // Nonnull
 

--- a/dap4/d4cdm/build.gradle
+++ b/dap4/d4cdm/build.gradle
@@ -5,8 +5,10 @@ apply from: "$rootDir/gradle/any/archiving.gradle"
 apply from: "$rootDir/gradle/any/publishing.gradle"
 
 dependencies {
+    compile project(':dap4:d4core')
     compile project(':dap4:d4lib')
     compile project(':cdm')
     compile project(':netcdf4')
+    
     provided libraries["javax.servlet-api"]
 }

--- a/dap4/d4servlet/build.gradle
+++ b/dap4/d4servlet/build.gradle
@@ -7,6 +7,7 @@ apply from: "$rootDir/gradle/any/publishing.gradle"
 dependencies {
     compile project(':dap4:d4core')
     compile project(':dap4:d4lib')
+    compile project(":httpservices")
 
     provided libraries["javax.servlet-api"]
     compile libraries["slf4j-api"]

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -9,6 +9,7 @@ repositories {
     // Prefer JCenter to Maven Central. See
     // https://blog.bintray.com/2015/02/09/android-studio-migration-from-maven-central-to-jcenter/
     jcenter()
+    mavenCentral()  // JCenter isn't quite a superset of Maven Central.
     maven {
         url "https://artifacts.unidata.ucar.edu/content/repositories/unidata"
     }
@@ -118,8 +119,6 @@ libraries["junit"] = "junit:junit:4.12"
 libraries["spring-test"] = "org.springframework:spring-test:${versions["spring"]}"
 
 libraries["hamcrest-core"] = "org.hamcrest:hamcrest-core:1.3"
-
-libraries["com.eclipsesource.restfuse"] = "com.restfuse:com.eclipsesource.restfuse:1.2.0"
 
 libraries["httpunit"] = "httpunit:httpunit:1.7"
 

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -34,6 +34,7 @@ dependencies {
     ncIdv project(':opendap')
     ncIdv project(':visadCdm')
     ncIdv project(':httpservices')
+    ncIdv project(':legacy')
     
     tdmFat project(':tdm')
     

--- a/grib/build.gradle
+++ b/grib/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile libraries["jsr305"]
     compile libraries["jj2000"]
     compile libraries["guava"]
+    compile libraries["jcommander"]
     compile libraries["slf4j-api"]
     testCompile libraries["jsoup"]
 }

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -12,24 +12,26 @@ apply from: "$rootDir/gradle/any/coverage.gradle"
 
 dependencies {
     testCompile project(":cdm")
+    testCompile project(":httpservices")
+    testCompile project(":tdcommon")
+    
     testRuntime project(":clcommon")
     testRuntime project(":grib")
-    testCompile project(":httpservices")
     testRuntime project(":opendap")
     testRuntime project(":visadCdm")
-
     testRuntime project(':dap4:d4cdm')
-
-    testRuntime libraries["jaxen"]
+    
     testCompile libraries["jdom2"]
     testCompile libraries["commons-io"]
     testCompile libraries["joda-time"]
     testCompile libraries["httpcore"]
     testCompile libraries["httpclient"]
     testCompile libraries["commons-lang3"]
-
-    testCompile libraries["com.eclipsesource.restfuse"]
-
+    testCompile libraries["spring-context"]
+    testCompile libraries["slf4j-api"]
+    
+    testRuntime libraries["jaxen"]
+    
     // Unlike the other subprojects, we do not need to add an SLF4J binding to testRuntime;
     // we're overlaying tds (see below), so we're already getting the binding that it declares.
 }

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -14,6 +14,10 @@ apply plugin: 'groovy'  // For Spock tests.
 dependencies {
     compile project(":cdm")
     compile project(":opendap")
+    
+    compile libraries["guava"]
+    compile libraries["jdom2"]
+    compile libraries["jsr305"]
     compile libraries["aws-java-sdk-s3"]  // For CrawlableDatasetAmazonS3.
     compile libraries["slf4j-api"]
 

--- a/legacy/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
+++ b/legacy/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
@@ -3,7 +3,6 @@ package thredds.crawlabledataset.s3;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
-import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
             logger.debug(e.getMessage());
             return null;
         } catch (AmazonServiceException e) {
-            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            if (e.getStatusCode() == 404) {
                 logger.debug(String.format(
                         "There is no S3 bucket '%s' that has key '%s'.", s3uri.getBucket(), s3uri.getKey()));
                 return null;
@@ -87,7 +86,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
                 return objectListing;
             }
         } catch (AmazonServiceException e) {
-            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            if (e.getStatusCode() == 404) {
                 logger.debug(String.format("No S3 bucket named '%s' exists.", s3uri.getBucket()));
                 return null;
             } else {
@@ -107,7 +106,7 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
             logger.debug(e.getMessage());
             return null;
         } catch (AmazonServiceException e) {
-            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            if (e.getStatusCode() == 404) {
                 logger.debug(String.format(
                         "There is no S3 bucket '%s' that has key '%s'.", s3uri.getBucket(), s3uri.getKey()));
                 return null;

--- a/legacy/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
+++ b/legacy/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
@@ -5,7 +5,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.ObjectListing
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.S3ObjectSummary
-import org.apache.http.HttpStatus
 import spock.lang.Specification
 
 /**
@@ -36,7 +35,7 @@ class ThreddsS3ClientImplSpec extends Specification {
 
         // Create exception that stubbed methods will throw.
         amazonServiceException = new AmazonServiceException("error")
-        amazonServiceException.setStatusCode(HttpStatus.SC_NOT_FOUND)
+        amazonServiceException.setStatusCode(404)
     }
 
     def "null key"() {

--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -15,7 +15,9 @@ dependencies {
     compile libraries["spring-core"]
     compile libraries["quartz"]
     compile libraries["chronicle-map"]
-    // compile libraries["openhft-lang"]
+    compile libraries["jsr305"]
+    compile libraries["guava"]
+    compile libraries["protobuf-java"]
 
     compile libraries["slf4j-api"]
     compile libraries["log4j-api"]

--- a/tdm/build.gradle
+++ b/tdm/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     compile libraries["jdom2"]
     compile libraries["spring-core"]
     compile libraries["spring-context"]
+    compile libraries["protobuf-java"]
+    compile libraries["jcommander"]
+    compile libraries["guava"]
 
     compile libraries["slf4j-api"]
     runtime libraries["log4j-slf4j-impl"]

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile project(":cdm")
     compile project(":clcommon")
     compile project(":grib")
+    compile project(":httpservices")
     compile project(":netcdf4")
     compile project(":opendap")
     compile project(":tdcommon")
@@ -26,6 +27,8 @@ dependencies {
     // DAP4 Dependencies (technically forward)
     compile project(":dap4:d4cdm")
     compile project(":dap4:d4servlet")
+    compile project(':dap4:d4core')
+    compile project(':dap4:d4lib')
 
     // Server stuff
     provided libraries["javax.servlet-api"]
@@ -42,7 +45,11 @@ dependencies {
     compile libraries["jsr305"]
     compile libraries["guava"]
     compile libraries["joda-time"]
+    
+    // WaterML
     compile libraries["52n-xml-waterML-v20"]
+    compile libraries["52n-xml-om-v20"]
+    compile libraries["xmlbeans"]
 
     // Spring
     compile libraries["spring-core"]
@@ -84,6 +91,8 @@ dependencies {
     testCompile libraries["spring-test"]
     testCompile libraries["hamcrest-core"]
     testCompile libraries["httpunit"]
+    
+    testCompile libraries["commons-io"]
 
     // Logging
     compile libraries["slf4j-api"]
@@ -142,10 +151,14 @@ war {
 // None of those are necessary at runtime: http://stackoverflow.com/a/5135151/3874643.
 // Even worse, the JARs are *huge*, and inflated the size of tds.war by ~59 MB.
 
+configurations {
+    gwt
+}
+
 dependencies {
-    // These are needed at compile-time by the GWT Compiler, but aren't necessary at runtime.
-    provided libraries["gwt-user"]
-    provided libraries["gwt-dev"]
+    // These are needed by the compileGwt task but nowhere else, which is why we place them in their own config.
+    gwt libraries["gwt-user"]
+    gwt libraries["gwt-dev"]
 }
 
 ext {
@@ -166,10 +179,9 @@ task compileGwt (dependsOn: classes, type: JavaExec) {
 
     classpath {
         [
-            // For com.google.gwt.dev.Compiler in "gwt-dev" and 'uk/ac/rdg/resc/godiva/Godiva.gwt.xml' in "edal-java".
-            sourceSets.main.compileClasspath,
-            // For Godiva3.gwt.xml in 'tds/src/main/resources'.
-            sourceSets.main.resources.srcDirs
+            configurations.gwt,                // For com.google.gwt.dev.Compiler in "gwt-dev".
+            sourceSets.main.compileClasspath,  // For 'uk/ac/rdg/resc/godiva/Godiva.gwt.xml' in "edal-java".
+            sourceSets.main.resources.srcDirs  // For Godiva3.gwt.xml in 'tds/src/main/resources'.
         ]
     }
 

--- a/testUtil/build.gradle
+++ b/testUtil/build.gradle
@@ -8,5 +8,8 @@ apply from: "$rootDir/gradle/any/java.gradle"
 
 dependencies {
     compile project(":cdm")
+    compile project(":httpservices")
+    
     compile libraries["junit"]
+    compile libraries["slf4j-api"]
 }


### PR DESCRIPTION
* Most issues were related to dependencies that were needed at compile time (directly), but weren't marked as such. Instead, those deps were being pulled in transitively (usually through 'cdm').
* Some classes in cdm-test were inadvertently using an internal method from jcommander when they were intended to use a same-named method from Guava. I modified those usages and was able to remove jcommander as a dep from cdm-test as a result.
* Eliminated use of 'httpcore' from legacy.
* Eliminated two cases of multiple jars on the classpath containing the same class. One was "com.eclipsesource.restfuse" (now removed from project) and the other was the GWT deps (they belong to their own Configuration now; no reason for them to be in "provided").
* Added 'legacy' to ncIdv at Yuan's request.