### PR TITLE
Allow debug flags to be set at TDS startup

### DIFF
--- a/cdm/src/main/java/ucar/nc2/util/DebugFlags.java
+++ b/cdm/src/main/java/ucar/nc2/util/DebugFlags.java
@@ -53,4 +53,10 @@ public interface DebugFlags {
    */
   void set(String flagName, boolean value);
 
+  /**
+   *  Return the string representing the current debug flag(s) set. Flags can be either
+   *  or false - they just need to be set.
+   */
+  String getSetFlags();
+
 }

--- a/cdm/src/main/java/ucar/nc2/util/DebugFlagsImpl.java
+++ b/cdm/src/main/java/ucar/nc2/util/DebugFlagsImpl.java
@@ -71,4 +71,8 @@ public class DebugFlagsImpl implements DebugFlags {
     map.put(flagName, value);
   }
 
+  public String getSetFlags() {
+    return map.keySet().toString();
+  }
+
 }

--- a/tds/src/main/java/thredds/server/config/TdsContext.java
+++ b/tds/src/main/java/thredds/server/config/TdsContext.java
@@ -36,6 +36,7 @@ import java.util.Formatter;
  * - creates, if don't exist, log and public dirs in content directory
  * - Get default and jsp dispatchers from servletContext
  * - Creates and initializes the TdsConfigMapper
+ * - check for debug flags to enable
  * <p>
  * LOOK would be nice to make Immutable
  *
@@ -76,6 +77,9 @@ public final class TdsContext implements ServletContextAware, InitializingBean, 
 
     @Value("${tds.download.dir}")
     private String downloadDirProperty;
+
+    @Value("${tds.debug.flags:}") // :} indicates an empty string if tds.debugflags prop is not set
+    private String tdsDebugFlagsProperty; // space sep debug flags to enable
 
     private ServletContext servletContext;
 
@@ -441,6 +445,8 @@ public final class TdsContext implements ServletContextAware, InitializingBean, 
     {
         return downloadDir;
     }
+
+    public String getTdsDebugFlags() { return tdsDebugFlagsProperty; }
 
     /////////////////////////////////////////////////////
 

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -60,6 +60,9 @@ import ucar.nc2.grib.GribIndexCache;
 import ucar.nc2.grib.collection.GribCdmIndex;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.nc2.ncml.Aggregation;
+import ucar.nc2.stream.CdmRemote;
+import ucar.nc2.util.DebugFlags;
+import ucar.nc2.util.DebugFlagsImpl;
 import ucar.nc2.util.DiskCache;
 import ucar.nc2.util.DiskCache2;
 import ucar.nc2.util.cache.FileCache;
@@ -134,6 +137,13 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
           startupLog.info("TdsInit: {}", event);
           startupLog.info("TdsInit: getContentRootPathAbsolute= " + tdsContext.getContentRootPathProperty());
 
+          // set debug flags passed into the JVM, as long as flags are actually passed in
+          String tdsDebugFlags = tdsContext.getTdsDebugFlags();
+          if (!tdsDebugFlags.isEmpty()) {
+            startupLog.info(String.format("Setting the following debug flags: %s", tdsDebugFlags));
+            setDebugFlags(new DebugFlagsImpl(tdsDebugFlags));
+          }
+
           readState();
           initThreddsConfig();
           readThreddsConfig();
@@ -148,6 +158,20 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
         }
       }
     }
+  }
+
+  private void setDebugFlags(DebugFlags debugFlags) {
+    NetcdfFile.setDebugFlags(debugFlags);
+    ucar.nc2.iosp.hdf5.H5iosp.setDebugFlags(debugFlags);
+    ucar.nc2.ncml.NcMLReader.setDebugFlags(debugFlags);
+    ucar.nc2.dods.DODSNetcdfFile.setDebugFlags(debugFlags);
+    CdmRemote.setDebugFlags(debugFlags);
+    Nc4Iosp.setDebugFlags(debugFlags);
+    DataFactory.setDebugFlags(debugFlags);
+
+    ucar.nc2.FileWriter2.setDebugFlags(debugFlags);
+    ucar.nc2.ft.point.standard.PointDatasetStandardFactory.setDebugFlags(debugFlags);
+    ucar.nc2.grib.collection.Grib.setDebugFlags(debugFlags);
   }
 
   private void readState() {


### PR DESCRIPTION
Set debug flags using -Dtds.debug.flags="flag1 flag2 ... flagN"
(example: -Dtds.debug.flags="H5iosp/read H5iosp/filePos")