### PR TITLE
Fix GitHub issue #715 (5.0.0)

### DIFF
--- a/cdm/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/src/main/java/ucar/nc2/Attribute.java
@@ -353,7 +353,7 @@ public class Attribute extends CDMNode {
     DataType dt = DataType.getType(val.getClass(), isUnsigned);
     Array vala = Array.factory(dt, shape);
     Index ima = vala.getIndex();
-    vala.setDouble(ima.set0(0), val.doubleValue());
+    vala.setObject(ima.set0(0), val);
     setValues(vala);
     setImmutable();
   }

--- a/cdm/src/test/java/ucar/nc2/TestAttributes.java
+++ b/cdm/src/test/java/ucar/nc2/TestAttributes.java
@@ -32,16 +32,19 @@
  */
 package ucar.nc2;
 
-import junit.framework.*;
-import ucar.ma2.*;
+import org.junit.Assert;
+import org.junit.Test;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.nc2.iosp.netcdf3.N3iosp;
 import ucar.unidata.util.test.TestDir;
 
 import java.io.IOException;
 
 /** Test reading attributes */
 
-public class TestAttributes extends TestCase {
-
+public class TestAttributes {
+  @Test
   public void testNC3ReadAttributes() throws IOException {
     NetcdfFile ncfile = TestDir.openFileLocal("testWrite.nc");
 
@@ -141,5 +144,12 @@ public class TestAttributes extends TestCase {
     return Math.abs((d1-d2)/d1) < 1.0e-5;
   }
 
+  // Demonstrates GitHub issue #715: https://github.com/Unidata/thredds/issues/715
+  @Test
+  public void testLargeLongValue() {
+    Attribute att = new Attribute("name", N3iosp.NC_FILL_INT64); // which is -9223372036854775806L
+    long result = att.getNumericValue().longValue();             // returned -9223372036854775808L, before bug fix.
 
+    Assert.assertEquals(N3iosp.NC_FILL_INT64, result);
+  }
 }


### PR DESCRIPTION
* Added a regression test too.

Also, removed `N3iosp.NC_FILL_LONG`.
* We already have `NC_FILL_INT64`, which has the same value. Plus, we're trying to mirror netcdf.h in netcdf-c here, and netcdf.h has no `NC_FILL_LONG` variable.
* Added some comments that explain the values we chose for `NC_FILL_INT64` and `NC_FILL_UINT64`.

