### PR TITLE
Update com.cwardgar.gretty-fork:gretty to 1.0.2

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -32,7 +32,7 @@ ext {
 
 ////////////////////////////////////////// Plugins //////////////////////////////////////////
 
-libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.1"
+libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.2"
 
 libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 


### PR DESCRIPTION
Our build is configured to fail anytime a duplicate entry is included in a jar/war file (see [here](https://github.com/Unidata/thredds/blob/0e148e134fe74381456f75f44da31c064234d5ae/gradle/any/archiving.gradle#L5)). The old version of Gretty was causing that to happen. See [the gretty commit](https://github.com/cwardgar/gretty/commit/e34eee224c8623290ee5d7525b0457671d7e3acd) for more details.