### PR TITLE
update unsigned var agg test

### DIFF
--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggUnsignedByte.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggUnsignedByte.java
@@ -63,8 +63,8 @@ public class TestAggUnsignedByte {
     // this worked as of 4.6.7, so no bug here...
     assert v.isUnsigned();
 
-    int[] origin = new int[] {0, 0, 0};
-    Section section = new Section(origin);
+    int[] shape = new int[] {1, 10, 20};
+    Section section = new Section(shape);
     Array data = v.read(section);
     // this is the failure for https://github.com/Unidata/thredds/issues/695
     assert data.isUnsigned();


### PR DESCRIPTION
Changed origin into shape to make consistent with actual API. Also, a shape of {0, 0, 0} does not make too much sense to use, and in fact fails on 5.0 as not being a valid shape (unless all dimensions are unlimited). Not sure if it failed on 4.6 or not.