### PR TITLE
Catch NoSuchMethodError in CoverageDatasetFactory

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
@@ -1,40 +1,8 @@
 /*
- * Copyright 1998-2015 John Caron and University Corporation for Atmospheric Research/Unidata
- *
- *  Portions of this software were developed by the Unidata Program at the
- *  University Corporation for Atmospheric Research.
- *
- *  Access and use of this software shall impose the following obligations
- *  and understandings on the user. The user is granted the right, without
- *  any fee or cost, to use, copy, modify, alter, enhance and distribute
- *  this software, and any derivative works thereof, and its supporting
- *  documentation for any purpose whatsoever, provided that this entire
- *  notice appears in all copies of the software, derivative works and
- *  supporting documentation.  Further, UCAR requests that the user credit
- *  UCAR/Unidata in any publications that result from the use of this
- *  software or in any product that includes this software. The names UCAR
- *  and/or Unidata, however, may not be used in any advertising or publicity
- *  to endorse or promote any products or commercial entity unless specific
- *  written permission is obtained from UCAR/Unidata. The user also
- *  understands that UCAR/Unidata is not obligated to provide the user with
- *  any support, consulting, training or assistance of any kind with regard
- *  to the use, operation and performance of this software nor to provide
- *  the user with any updates, revisions, new versions or "bug fixes."
- *
- *  THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *  INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *  WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
- *
+ * (c) 1998-2017 John Caron and University Corporation for Atmospheric Research/Unidata
  */
 package ucar.nc2.ft2.coverage;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.DatasetUrl;
 import ucar.nc2.ft.FeatureDataset;
@@ -42,11 +10,12 @@ import ucar.nc2.ft2.coverage.adapter.DtCoverageAdapter;
 import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset;
 import ucar.nc2.util.Optional;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Formatter;
+import java.util.List;
 
 /**
  * factory for CoverageDataset
@@ -126,17 +95,33 @@ public class CoverageDatasetFactory {
    * @throws IOException
    */
   static public Optional<FeatureDatasetCoverage> openGrib(String endpoint) throws IOException {
+
+    List<Object> notGribThrowables = Arrays.asList(
+            IllegalAccessException.class,
+            IllegalArgumentException.class,
+            ClassNotFoundException.class,
+            NoSuchMethodException.class,
+            NoSuchMethodError.class);
+
     try {
       Class<?> c = CoverageDatasetFactory.class.getClassLoader().loadClass("ucar.nc2.grib.coverage.GribCoverageDataset");
       Method method = c.getMethod("open", String.class);
       return (Optional<FeatureDatasetCoverage>) method.invoke(null, endpoint);
+    } catch (Exception e) {
+      for (Object noGrib : notGribThrowables) {
+        // check for possible errors that are due to the file not being grib. Need to look
+        // at the error causes too, as reflection error can be buried under a InvorcationTargetException
+        boolean notGribTopLevel = e.getClass().equals(noGrib);
+        boolean notGribBuried = e.getClass().equals(InvocationTargetException.class) &&
+                                e.getCause() != null &&
+                                e.getCause().getClass().equals(noGrib);
 
-    } catch (IllegalAccessException | IllegalArgumentException | ClassNotFoundException | NoSuchMethodException e) {
-      //e.printStackTrace();
-      return Optional.empty(NO_GRIB_CLASS);
-
-    } catch (InvocationTargetException e) {
-      //e.printStackTrace();
+        if (notGribTopLevel || notGribBuried) {
+          return Optional.empty(NO_GRIB_CLASS);
+        }
+      }
+      // Ok, something went wrong, and it does not appear to be related to the file *not* being
+      // a grib file.
       return Optional.empty(e.getCause().getMessage());
     }
 


### PR DESCRIPTION
When trying to load a netCDF file as via FeatureDatasetFactoryManager.open(...), the openGrib method thows a NoSuchMethodError. openGrib is called in the open method as a test to see if the dataset is a Grib file, and because the NoSuchMethodError wasn't being caught, the whole thing stops and the FeatureDatasetFactoryManager returns a null dataset with an error message in the Formatter. Adding this error to the catch allows FeatureDatasetFactoryManager to do the right thing and see that the file isn't a Grib file.