### PR TITLE
misc. changes from dap4 work

### DIFF
--- a/cdm/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/src/main/java/ucar/nc2/Attribute.java
@@ -54,7 +54,14 @@ import java.util.Map;
  * @author caron
  */
 
-public class Attribute extends CDMNode {
+public class Attribute extends CDMNode
+{
+
+  static final String SPECIALPREFIX = "_";
+  static final String[] SUPPRESS = new String[]{
+          "_NCProperties", "_DAP4_Little_Endian", "_edu.ucar"
+  };
+
 
   /**
    * Turn a list into a map
@@ -62,14 +69,28 @@ public class Attribute extends CDMNode {
    * @param atts list of attributes
    * @return map of attributes by name
    */
-  static public Map<String, Attribute> makeMap(List<Attribute> atts) {
+  static public Map<String, Attribute> makeMap(List<Attribute> atts)
+  {
     int size = (atts == null) ? 1 : atts.size();
     Map<String, Attribute> result = new HashMap<>(size);
-    if (atts == null) return result;
-    for (Attribute att : atts) result.put(att.getShortName(), att);
+    if(atts == null) return result;
+    for(Attribute att : atts) result.put(att.getShortName(), att);
     return result;
   }
 
+  static public boolean
+  suppress(Attribute a, boolean strict)
+  {
+    String nm = a.getShortName();
+    if(strict && nm.startsWith(SPECIALPREFIX)) {
+      /* Suppress  selected special attributes */
+      for(String s : SUPPRESS) {
+        if(nm.startsWith(s))
+          return true; /* Suppress it */
+      }
+    }
+    return false;
+  }
   ///////////////////////////////////////////////////////////////////////////////////
 
   /**

--- a/cdm/src/main/java/ucar/nc2/CDMNode.java
+++ b/cdm/src/main/java/ucar/nc2/CDMNode.java
@@ -36,6 +36,9 @@ import ucar.nc2.dataset.StructureDS;
 import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.util.Indent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Define a superclass for all the CDM node classes: Group, Dimension, etc.
  * Define the sort of the node {@link CDMSort} so that we can
@@ -57,7 +60,7 @@ public abstract class CDMNode
     protected boolean immutable = false;
     protected String shortName = null;
 
-    protected Object annotation = null;
+    protected Map<Object,Object> annotations = null;
 
     //String fullName = null; // uses backslash escaping
 
@@ -336,15 +339,17 @@ public abstract class CDMNode
         return inner;
     }
 
-    public Object annotation()
+    public Object annotation(Object id)
     {
-        return annotation;
+        return (this.annotations == null ? null : this.annotations.get(id));
     }
 
-    public Object annotate(Object value)
+    public Object annotate(Object id, Object value)
     {
-        Object old = annotation;
-        annotation = value;
+        if(annotations ==  null)
+            annotations = new HashMap<>();
+        Object old = annotations.get(id);
+        annotations.put(id,value);
         return old;
     }
 

--- a/cdm/src/main/java/ucar/nc2/Dimension.java
+++ b/cdm/src/main/java/ucar/nc2/Dimension.java
@@ -104,18 +104,23 @@ public class Dimension extends CDMNode implements Comparable {
    * @return list of dimensions
    * @throws IllegalArgumentException if cant find dimension or parse error.
    */
-  static public List<Dimension> makeDimensionsList(Group parentGroup, String dimString) throws IllegalArgumentException {
-
+  static public List<Dimension> makeDimensionsList(Group parentGroup, String dimString)
+          throws IllegalArgumentException {
     List<Dimension> newDimensions = new ArrayList<>();
-
-    if ((dimString == null) || (dimString.length() == 0)) { // scalar
-      return newDimensions; // empty list
-    }
+    if (dimString == null) // scalar
+         return newDimensions; // empty list
+    dimString = dimString.trim();
+    if (dimString.length() == 0) // scalar
+         return newDimensions; // empty list
 
     StringTokenizer stoke = new StringTokenizer(dimString);
     while (stoke.hasMoreTokens()) {
       String dimName = stoke.nextToken();
-      Dimension d = dimName.equals("*") ? Dimension.VLEN : parentGroup.findDimension(dimName);
+      Dimension d;
+      if(dimName.equals("*"))
+        d = Dimension.VLEN;
+      else
+        d = parentGroup.findDimension(dimName);
       if (d == null) {
         // if numeric - then its anonymous dimension
         try {

--- a/cdm/src/main/java/ucar/nc2/Group.java
+++ b/cdm/src/main/java/ucar/nc2/Group.java
@@ -429,11 +429,13 @@ public class Group extends CDMNode implements AttributeContainer {
       //indent.incr();
       for (Attribute att : attributes.getAttributes()) {
         //String name = strict ? NetcdfFile.escapeNameCDL(getShortName()) : getShortName();
-        out.format("%s:", indent);
-        att.writeCDL(out, strict);
-        out.format(";");
-        if (!strict && (att.getDataType() != DataType.STRING)) out.format(" // %s", att.getDataType());
-        out.format("%n");
+        if(!Attribute.suppress(att,strict)) {
+          out.format("%s:", indent);
+          att.writeCDL(out, strict);
+          out.format(";");
+          if(!strict && (att.getDataType() != DataType.STRING)) out.format(" // %s", att.getDataType());
+          out.format("%n");
+        }
       }
       //indent.decr();
     }

--- a/cdm/src/main/java/ucar/nc2/NCdumpW.java
+++ b/cdm/src/main/java/ucar/nc2/NCdumpW.java
@@ -213,6 +213,8 @@ public class NCdumpW {
     boolean strict = false;
     String varNames = null;
     useUnsigned = false;
+    String trueDataset = null;
+    String fakeDataset = null;
 
     if (command != null) {
       StringTokenizer stoke = new StringTokenizer(command);
@@ -234,12 +236,23 @@ public class NCdumpW {
           useUnsigned = true;
         if (toke.equalsIgnoreCase("-cdl") || toke.equalsIgnoreCase("-strict"))
           strict = true;
-        if (toke.equalsIgnoreCase("-v") && stoke.hasMoreTokens())
+        if(toke.equalsIgnoreCase("-v") && stoke.hasMoreTokens())
           varNames = stoke.nextToken();
+        if (toke.equalsIgnoreCase("-datasetname") && stoke.hasMoreTokens()) {
+          fakeDataset = stoke.nextToken();
+          if(fakeDataset.length() == 0) fakeDataset = null;
+          if(fakeDataset != null) {
+            trueDataset = nc.getLocation();
+            nc.setLocation(fakeDataset);
+          }
+        }
       }
     }
 
-    return print(nc, out, showValues, ncml, strict, varNames, ct);
+    boolean ok = print(nc, out, showValues, ncml, strict, varNames, ct);
+    if(trueDataset != null && fakeDataset != null)
+      nc.setLocation(trueDataset);
+    return ok;
   }
 
   /**
@@ -592,7 +605,7 @@ public class NCdumpW {
     if(last < 0)
         out.printf("00");
     else
-        for (int i = 0; i <= last; i++) {
+        for (int i = bb.position(); i <= last; i++) {
           out.printf("%02x", bb.get(i));
         }
   }

--- a/cdm/src/main/java/ucar/nc2/Structure.java
+++ b/cdm/src/main/java/ucar/nc2/Structure.java
@@ -89,6 +89,24 @@ public class Structure extends Variable {
     memberHash = new HashMap<>();
   }
 
+  /**
+   * Create a Structure "from scratch". Also must call setDimensions().
+   * @param ncfile
+   * @param group
+   * @param parent
+   * @param shortName
+   * @param dimset
+     */
+    public Structure(NetcdfFile ncfile, Group group, Structure parent,
+                     String shortName, List<Dimension> dimset) {
+     super(ncfile, group, parent, shortName);
+     setDataType(DataType.STRUCTURE);
+      setDimensions(dimset);
+     this.elementSize = -1; // gotta wait before calculating
+     members = new ArrayList<>();
+     memberHash = new HashMap<>();
+   }
+
   /** Copy constructor.
    * @param from  copy from this
    */
@@ -405,7 +423,7 @@ public class Structure extends Variable {
   }
 
   /**
-   * Get an efficient iterator over all the data in the Structure. 
+   * Get an efficient iterator over all the data in the Structure.
    *
    * This is the efficient way to get all the data, it can be much faster than reading one record at a time,
    *   and is optimized for large datasets.
@@ -597,12 +615,13 @@ public class Structure extends Variable {
     buf.format(";%s%n", extraInfo());
 
     for (Attribute att : getAttributes()) {
+      if(Attribute.suppress(att,strict)) continue;
       buf.format("%s  ", indent);
-      if (strict) buf.format( NetcdfFile.makeValidCDLName(getShortName()));
+      if(strict) buf.format(NetcdfFile.makeValidCDLName(getShortName()));
       buf.format(":");
-      att.writeCDL(buf,  strict);
+      att.writeCDL(buf, strict);
       buf.format(";");
-      if (!strict && (att.getDataType() != DataType.STRING))
+      if(!strict && (att.getDataType() != DataType.STRING))
         buf.format(" // %s", att.getDataType());
       buf.format("%n");
     }

--- a/cdm/src/main/java/ucar/nc2/Structure.java
+++ b/cdm/src/main/java/ucar/nc2/Structure.java
@@ -90,21 +90,17 @@ public class Structure extends Variable {
   }
 
   /**
-   * Create a Structure "from scratch". Also must call setDimensions().
-   * @param ncfile
-   * @param group
-   * @param parent
-   * @param shortName
-   * @param dimset
+   * Create a Structure "from scratch".
+   * @param ncfile    the containing NetcdfFile.
+   * @param group     the containing group; if null, use rootGroup
+   * @param parent    parent Structure, may be null
+   * @param shortName variable shortName, must be unique within the Group
+   * @param dimList   list of Dimensions
      */
     public Structure(NetcdfFile ncfile, Group group, Structure parent,
-                     String shortName, List<Dimension> dimset) {
-     super(ncfile, group, parent, shortName);
-     setDataType(DataType.STRUCTURE);
-      setDimensions(dimset);
-     this.elementSize = -1; // gotta wait before calculating
-     members = new ArrayList<>();
-     memberHash = new HashMap<>();
+                     String shortName, List<Dimension> dimList) {
+      this(ncfile, group, parent, shortName);
+      setDimensions(dimList);
    }
 
   /** Copy constructor.

--- a/cdm/src/main/java/ucar/nc2/Variable.java
+++ b/cdm/src/main/java/ucar/nc2/Variable.java
@@ -1039,6 +1039,7 @@ public class Variable extends CDMNode implements VariableIF, ProxyReader, Attrib
 
     indent.incr();
     for (Attribute att : getAttributes()) {
+      if(Attribute.suppress(att,strict)) continue;
       buf.format("%s", indent);
       if (strict) buf.format(NetcdfFile.makeValidCDLName(getShortName()));
       buf.format(":");
@@ -1181,10 +1182,29 @@ public class Variable extends CDMNode implements VariableIF, ProxyReader, Attrib
    * @param dims      space delimited list of dimension names. may be null or "" for scalars.
    */
   public Variable(NetcdfFile ncfile, Group group, Structure parent, String shortName, DataType dtype, String dims) {
+    this(ncfile, group, parent, shortName, dtype, (List<Dimension>)null);
+    if(group == null)
+      group = ncfile.getRootGroup();
+    setDimensions(Dimension.makeDimensionsList(group, dims));
+  }
+
+  /**
+   * Create a Variable. Also must call setDataType() and setDimensions()
+   *
+   * @param ncfile    the containing NetcdfFile.
+   * @param group     the containing group; if null, use rootGroup
+   * @param parent    parent Structure, may be null
+   * @param shortName variable shortName, must be unique within the Group
+   * @param dtype     the Variable's DataType
+   * @param dims      dimension names.
+   */
+  public Variable(NetcdfFile ncfile, Group group, Structure parent,
+                  String shortName, DataType dtype, List<Dimension> dims) {
     this(ncfile, group, parent, shortName);
     setDataType(dtype);
     setDimensions(dims);
   }
+
 
   /**
    * Copy constructor.
@@ -1370,7 +1390,8 @@ public class Variable extends CDMNode implements VariableIF, ProxyReader, Attrib
   public void setDimensions(String dimString) {
     if (immutable) throw new IllegalStateException("Cant modify");
     try {
-      this.dimensions = Dimension.makeDimensionsList(getParentGroup(), dimString);
+      setDimensions(Dimension.makeDimensionsList(getParentGroup(), dimString));
+      //this.dimensions = Dimension.makeDimensionsList(getParentGroup(), dimString);
       resetShape();
     } catch (IllegalStateException e) {
       throw new IllegalArgumentException("Variable " + getFullName() + " setDimensions = '" + dimString +

--- a/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -57,6 +57,7 @@ import java.util.*;
 public class DatasetUrl {
   static final protected String alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   static final protected String slashalpha = "\\/" + alpha;
+  static final String[] FRAGPROTOCOLS = {"dap4", "dap2"};
 
   /**
    * Return the set of leading protocols for a url; may be more than one.
@@ -205,6 +206,11 @@ public class DatasetUrl {
     Map<String, String> map = parseFragment(fragment);
     if (map == null) return null;
     String protocol = map.get("protocol");
+    if(protocol == null) {
+      for(String p: FRAGPROTOCOLS) {
+        if(map.get(p) != null) {protocol = p; break;}
+      }
+    }
     if (protocol != null) {
       if (protocol.equalsIgnoreCase("dap") || protocol.equalsIgnoreCase("dods"))
         return ServiceType.OPENDAP;

--- a/cdm/src/main/java/ucar/nc2/util/EscapeStrings.java
+++ b/cdm/src/main/java/ucar/nc2/util/EscapeStrings.java
@@ -50,10 +50,19 @@ public class EscapeStrings {
   static protected final String _allowableInDAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_!~*'-\"./";
   static protected final String _allowableInOGC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()";
   static protected final char _URIEscape = '%';
+  static protected final char _JavaEscape = '\\';
   static final byte blank = ((byte) ' ');
   static final byte plus = ((byte) '+');
 
-  private static String xescapeString(String in, String allowable, char esc, boolean spaceplus) {
+  /**
+   *
+   * @param in   String to escape
+   * @param allowable  allowedcharacters
+   * @param esc   escape char prefix
+   * @param spaceplus  true =>convert ' ' to '+'
+     * @return
+     */
+    private static String xescapeString(String in, String allowable, char esc, boolean spaceplus) {
     try {
       StringBuffer out = new StringBuffer();
       if (in == null) return null;
@@ -532,5 +541,23 @@ public class EscapeStrings {
     return buf.toString();
   }
 
+  /**
+     * Given a CDM string, insert backslashes
+     * before <toescape> characters.
+     */
+    static public String backslashEscapeCDMString(String s, String toescape)
+    {
+      if(toescape == null || toescape.length() == 0) return s;
+      if(s == null || s.length() == 0) return s;
+      StringBuilder buf = new StringBuilder();
+      for(int i=0;i<s.length();i++) {
+        int c = s.charAt(i);
+        if(toescape.indexOf(c) >= 0) {
+          buf.append('\\');
+        }
+        buf.append((char)c);
+      }
+      return buf.toString();
+    }
 
 }

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
@@ -190,6 +190,7 @@ public interface Nc4prototypes extends Library {
   int nc_inq_nvars(int ncid, IntByReference nvarsp);
   int nc_inq_varids(int ncid, IntByReference nvars, int[] varids);  
   int nc_inq_var(int ncid, int varid, byte[] name, IntByReference xtypep, IntByReference ndimsp, int[] dimidsp, IntByReference nattsp);
+  int nc_inq_var(int ncid, int varid, byte[] name, IntByReference xtypep, IntByReference ndimsp, Pointer dimids, IntByReference nattsp);
 
   // user types
   int nc_inq_typeids(int ncid, IntByReference ntypes, Pointer np); // allow to pass NULL

--- a/opendap/src/test/java/opendap/test/TestGrid1.java
+++ b/opendap/src/test/java/opendap/test/TestGrid1.java
@@ -38,6 +38,7 @@ import org.junit.experimental.categories.Category;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.UnitTestCommon;
 import ucar.unidata.util.test.category.NeedsExternalResource;
 
 /**
@@ -102,12 +103,12 @@ public class TestGrid1 extends TestSources
         String metadata = null;
         String data = null;
 
-        metadata = ncdumpmetadata(ncfile);
+        metadata = ncdumpmetadata(ncfile,null);
 
         if(prop_visual)
             visual(getTitle() + ".dds", metadata);
         if(true) {
-            data = ncdumpdata(ncfile);
+            data = ncdumpdata(ncfile,null);
             if(prop_visual)
                 visual(getTitle() + ".dods", data);
 

--- a/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
+++ b/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
@@ -153,7 +153,7 @@ loop:        for(int i = 0; i < ntestsets && pass; i++) {
                     ncfile = NetcdfDataset.openFile(file.getPath(), null);
                     if(ncfile == null) throw new FileNotFoundException(path);
                     if(DEBUG)
-                        visual("cdm file",ncdumpmetadata(ncfile));
+                        visual("cdm file",ncdumpmetadata(ncfile,null));
 
                     ds = new GuardedDatasetCacheAndClone(path, ncfile, false);
                     dds = ds.getDDS();

--- a/testUtil/src/main/java/ucar/unidata/util/test/TestDir.java
+++ b/testUtil/src/main/java/ucar/unidata/util/test/TestDir.java
@@ -128,8 +128,6 @@ public class TestDir {
 
   static public String dap4TestServer = "localhost:8083";
 
-  static public final String testingDap4TestServer = "localhost:8081";
-
   // Are we running under travis or jenkins? (from testing.gradle)
   static final public boolean isTravis;
   static final public boolean isJenkins;
@@ -207,8 +205,6 @@ public class TestDir {
     String d4ts = System.getProperty(dap4TestServerPropName);
     if(d4ts != null && d4ts.length() > 0)
       	dap4TestServer = d4ts;
-    else if(isTravisOrJenkins)
-	dap4TestServer = testingDap4TestServer; // from testing.gradle
 
     AliasTranslator.addAlias("${cdmUnitTest}", cdmUnitTestDir);
   }

--- a/visad/src/main/java/ucar/nc2/iosp/gempak/GempakSurfaceIOSP.java
+++ b/visad/src/main/java/ucar/nc2/iosp/gempak/GempakSurfaceIOSP.java
@@ -480,7 +480,7 @@ public class GempakSurfaceIOSP extends GempakStationFileIOSP {
 
     // time
     Variable timeVar = new Variable(ncfile, null, null, TIME_VAR,
-            DataType.DOUBLE, null);
+            DataType.DOUBLE, (String)null);
     timeVar.addAttribute(
             new Attribute(CDM.UNITS, "seconds since 1970-01-01 00:00:00"));
     timeVar.addAttribute(new Attribute("long_name", TIME_VAR));


### PR DESCRIPTION
As a result of the dap4 work, it was necessary/desirable
to make small mods to other, non-dap4, code. This changeset
encapsulates them.
1. add nc_inq_var to Nc4prototypes.java
2. fix naming bug for structs in Nc4Iosp.java
3. Add annotation map to CDMNode
5. Add ability to suppress certain special/reserved attributes
   (primarily Attribute.java, but also the writeCDL methods elsewhere).
6. Fix the parsing of string dimension lists in Dimension.java
7. Add another constructor for Structure; will be used by dap4 code
8. Add another constructor for Variable; will be used by dap4 code
9. Add another option to NcDumpW: -datasetname to force
   the use of a particular dataset name; convenient for avoiding
   spurious text differences in comparing two cdl files.
10. Add a new IOprovider registration function: registerIOproviderPreferred
    to NetcdfFile.java. This function allows one to insert
    an IOSP in the registration list just in front of another IOSP.
    Primarily used to support overriding HDF5 IOSP with Netcdf4 IOSP.
11. Add a backslash escape function to EscapeStrings.java.
12. Add "dap4" as a possible entry in a url fragment. This parallels
    the existing "dap2" case (DatasetUrl.java).