### PR TITLE
Fix test failures stemming from #733

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
@@ -56,7 +56,7 @@ public class TestN4reading {
 
   @Test
   public void testGodivaFindsDataHole() throws IOException, InvalidRangeException {
-    // this pattern of reads from godiva is finding a data hole - missing data where therre shouldnt be any
+    // this pattern of reads from godiva is finding a data hole - missing data where there shouldn't be any
     Section[] sections = {
       new Section("14:14,0:0,13:170,0:20"),
       new Section("14:14,0:0,170:194,21:167"),

--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -799,6 +799,14 @@ public class HTTPSession implements Closeable
         setGlobalCredentialsProvider(provider, scope);
     }
 
+    /**
+     * Remove any global credentials that have been previosly set with the {@link #setGlobalCredentials(Credentials)}
+     * or {@link #setCredentialsProviderFactory} methods.
+     */
+    public static void clearGlobalCredentials() {
+        globalcredfactories.clear();
+    }
+
     static synchronized public void setGlobalRetryCount(int n)
     {
         if(n < 0) //validate
@@ -1173,7 +1181,7 @@ public class HTTPSession implements Closeable
 
         // Second, Construct a CredentialsProvider that is
         // the union of the Proxy credentials plus
-        // either the global local credentials; local overrides global
+        // either the global or local credentials; local overrides global
         // Unfortunately, we cannot either clone or extract the contents
         // of the client supplied provider, so we are forced (for now)
         // to modify the client supplied provider.

--- a/it/src/test/java/thredds/TestWithLocalServer.java
+++ b/it/src/test/java/thredds/TestWithLocalServer.java
@@ -45,6 +45,7 @@ import ucar.nc2.util.IO;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Arrays;
 
 /**
  * Describe
@@ -87,7 +88,8 @@ public class TestWithLocalServer {
         boolean ok = false;
         for (int expectCode : expectCodes)
           if (expectCode == statusCode) ok = true;
-        Assert.assertTrue(ok);
+        Assert.assertTrue(String.format(
+                "Expected one of %s, but got %s.", Arrays.toString(expectCodes), statusCode), ok);
       }
 
       if (statusCode != 200) {

--- a/it/src/test/java/thredds/server/services/TestAdminDebug.java
+++ b/it/src/test/java/thredds/server/services/TestAdminDebug.java
@@ -1,15 +1,16 @@
 package thredds.server.services;
 
+import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import thredds.TestWithLocalServer;
 import thredds.util.ContentType;
-import ucar.httpservices.HTTPSession;
 import ucar.nc2.constants.CDM;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,14 +22,11 @@ import java.util.List;
  */
 @RunWith(Parameterized.class)
 public class TestAdminDebug {
-    static private org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestWithLocalServer.class);
+    private static Logger logger = LoggerFactory.getLogger(TestAdminDebug.class);
 
-    static final String DEFAULT_HOST = "localhost:8443";
-
-    // Defined in it/src/test/resources/auth/keystore
-    static final String DEFAULT_USER = "tds";
-    static final String DEFAULT_PASSWORD = "secret666";
-    static final String DEFAULT_USERPWD = DEFAULT_USER + ":" + DEFAULT_PASSWORD;
+    private static String urlPrefix =  "https://localhost:8443/thredds/";
+    private static Credentials goodCred = new UsernamePasswordCredentials("tds", "secret666");
+    private static Credentials badCred = new UsernamePasswordCredentials("bad", "worse");
 
     @Parameterized.Parameters(name = "{0}") public static List<Object[]> getTestParameters() {
         List<Object[]> result = new ArrayList<>(10);
@@ -42,38 +40,23 @@ public class TestAdminDebug {
 
     ///////////////////////////////
 
-    String url = null;
-    UsernamePasswordCredentials cred = null;
+    String path;
 
     public TestAdminDebug(String path) {
-        String url = "https://" + DEFAULT_USERPWD + "@" + DEFAULT_HOST + "/thredds/" + path;
-        setup(url);
-    }
-
-    void setup(String url) {
-        //this.result = getTestParameters();
-        this.url = url;
-        try {
-            URL u = new URL(url);
-            if (u.getUserInfo() == null) {
-                throw new Exception("No user:password specified");
-            }
-            cred = new UsernamePasswordCredentials(u.getUserInfo());
-            HTTPSession.setGlobalCredentials(cred);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        this.path = path;
     }
 
     @Test public void testOpenHtml() {
-        byte[] response = TestWithLocalServer.getContent(cred, url, new int[] { 200 }, ContentType.html);
+        String endpoint = urlPrefix + path;
+        byte[] response = TestWithLocalServer.getContent(goodCred, endpoint, new int[] { 200 }, ContentType.html);
         if (response != null) {
             logger.debug(new String(response, CDM.utf8Charset));
         }
     }
 
     @Test public void testOpenHtmlFail() {
-        byte[] response = TestWithLocalServer.getContent(cred, url, new int[] { 200 }, ContentType.html);
+        String endpoint = urlPrefix + path;
+        byte[] response = TestWithLocalServer.getContent(badCred, endpoint, new int[] { 401, 403 }, ContentType.html);
         if (response != null) {
             logger.debug(new String(response, CDM.utf8Charset));
         }

--- a/it/src/test/java/thredds/tds/TestRestrictDataset.java
+++ b/it/src/test/java/thredds/tds/TestRestrictDataset.java
@@ -57,6 +57,8 @@ public class TestRestrictDataset {
   @Parameterized.Parameters(name="{0}")
   public static Collection<Object[]> getTestParameters() {
     return Arrays.asList(new Object[][]{
+            // These first 3 actually don't require cdmUnitTest/. Could be broken out into separate class that can
+            // run on Travis.
             {"/dodsC/testRestrictedDataset/testData2.nc.dds"},
             {"/cdmremote/testRestrictedDataset/testData2.nc?req=header"},
             {"/fileServer/testRestrictedDataset/testData2.nc"},
@@ -159,7 +161,7 @@ public class TestRestrictDataset {
     System.out.printf("testRestriction req = '%s'%n", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
-      session.setCredentials(new UsernamePasswordCredentials("tiggeUser", "tigge"));
+      session.setCredentials(new UsernamePasswordCredentials("tds", "secret666"));
 
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();

--- a/it/src/test/java/thredds/tds/TestWaveModel.java
+++ b/it/src/test/java/thredds/tds/TestWaveModel.java
@@ -1,7 +1,8 @@
 package thredds.tds;
 
-import junit.framework.TestCase;
 import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import thredds.client.catalog.Catalog;
 import thredds.client.catalog.Dataset;
@@ -31,12 +32,9 @@ import java.text.ParseException;
  * @since Sep 24, 2010
  */
 @Category(NeedsCdmUnitTest.class)
-public class TestWaveModel extends TestCase {
-
-  public TestWaveModel( String name) {
-    super(name);
-  }
-
+@Ignore("FeatureCollection is empty because cdmUnitTest/tds/hioos is empty.")
+public class TestWaveModel {
+  @Test
   public void testNcml() throws IOException, InvalidRangeException {
     String catalog = "/catalog/hioos/model/wav/swan/oahu/catalog.xml";
     Catalog cat = TdsLocalCatalog.open(catalog);
@@ -74,6 +72,7 @@ public class TestWaveModel extends TestCase {
     }
   }
 
+  @Test
   public void testOffset() throws IOException, InvalidRangeException, ParseException {
     String catalog = "/catalog/hioos/model/wav/swan/oahu/offset/catalog.xml";
     Catalog cat = TdsLocalCatalog.open(catalog);

--- a/tds/src/test/resources/auth/tomcat-users.xml
+++ b/tds/src/test/resources/auth/tomcat-users.xml
@@ -9,8 +9,9 @@
   <role rolename="tdsTrigger" description="can trigger feature collections, eg from tdm"/>
   <role rolename="manager-gui"/>
   <role rolename="containerauth"/>
+  <role rolename="tiggeData"/>
 
   <user username="tds" 
         password="secret666" 
-        roles="restrictedDatasetUser,tdsConfig,tdsMonitor,tdsTrigger,manager-gui,containerauth"/>
+        roles="restrictedDatasetUser,tdsConfig,tdsMonitor,tdsTrigger,manager-gui,containerauth,tiggeData"/>
 </tomcat-users>


### PR DESCRIPTION
In #733, I added back some tests to our suite that had been excluded. They belonged to the `thredds.tds` package in `:it`. There were two classes with failures:
* Fixed `TestRestrictDataset` by giving it the proper credentials, and adding the necessary "tiggeData" role to the embedded Tomcat's tomcat-users.xml.
* `TestWaveModel` couldn't be fixed because the files it needs are not present in `cdmUnitTest/`. So I `@Ignore`-ed it. What happened here?

Other changes:
* Added `HTTPSession.clearGlobalCredentials()`, which our tests must call any time they set global credentials. Otherwise, they're ruining the global state for other tests.
* Refactored `TestAdminDebug`. A recent commit caused it to be unnecessarily complex and `testOpenHtmlFail()` wasn't even doing what it was supposed to be doing.
* `TestTomcatAuth` unsets global credentials after it's finished. Also, converted console output to logger.

I gave this a go [on Jenkins](https://jenkins-aws.unidata.ucar.edu/job/cwardgar/43/testReport/) and it eliminated the new failures we've been seeing [on 5.0.0](https://jenkins-aws.unidata.ucar.edu/job/thredds5.0/265/testReport/).

@DennisHeimbigner I'm mostly modifying your code again here. Give it a look, please.