### PR TITLE
Convert SC_UNAUTHORIZED (401)   return codes to SC_FORBIDDEN (403)

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -34,6 +34,7 @@
 package ucar.nc2.dataset;
 
 import org.apache.http.Header;
+import org.apache.http.HttpStatus;
 import thredds.client.catalog.ServiceType;
 import thredds.client.catalog.tools.DataFactory;
 import ucar.httpservices.HTTPFactory;
@@ -372,7 +373,7 @@ public class DatasetUrl {
     try (HTTPMethod method = HTTPFactory.Head(location + "?req=header")) {
       int statusCode = method.execute();
       if (statusCode >= 300) {
-        if (statusCode == 401)
+        if (statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN)
           throw new IOException("Unauthorized to open dataset " + location);
         else
           throw new IOException(location + " is not a valid URL, return status=" + statusCode);
@@ -416,7 +417,7 @@ public class DatasetUrl {
             throw new IOException("OPeNDAP Server Error= " + method.getResponseAsString());
         }
       }
-      if (status == 401)
+      if (status == HttpStatus.SC_UNAUTHORIZED || status == HttpStatus.SC_FORBIDDEN)
         throw new IOException("Unauthorized to open dataset " + location);
 
       // not dods
@@ -444,7 +445,7 @@ public class DatasetUrl {
             return ServiceType.DAP4;
         }
       }
-      if (status == 401)
+      if (status == HttpStatus.SC_UNAUTHORIZED || status == HttpStatus.SC_FORBIDDEN)
         throw new IOException("Unauthorized to open dataset " + location);
 
       // not dods

--- a/it/src/test/java/thredds/server/services/TestAdminDebug.java
+++ b/it/src/test/java/thredds/server/services/TestAdminDebug.java
@@ -1,5 +1,6 @@
 package thredds.server.services;
 
+import org.apache.http.HttpStatus;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.junit.Test;
@@ -56,7 +57,8 @@ public class TestAdminDebug {
 
     @Test public void testOpenHtmlFail() {
         String endpoint = urlPrefix + path;
-        byte[] response = TestWithLocalServer.getContent(badCred, endpoint, new int[] { 401, 403 }, ContentType.html);
+        byte[] response = TestWithLocalServer.getContent(badCred, endpoint, new int[] { HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN }, ContentType.html);
+
         if (response != null) {
             logger.debug(new String(response, CDM.utf8Charset));
         }

--- a/it/src/test/java/thredds/server/services/TestMetadataService.java
+++ b/it/src/test/java/thredds/server/services/TestMetadataService.java
@@ -1,6 +1,7 @@
 /* Copyright */
 package thredds.server.services;
 
+import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -29,7 +30,7 @@ public class TestMetadataService {
     List<Object[]> result = new ArrayList<>(10);
     result.add(new Object[]{"metadata/gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1?metadata=variableMap", null});
     result.add(new Object[]{"metadata/gribCollection/GFS_CONUS_80km/Best?metadata=variableMap", null});
-    result.add(new Object[]{"metadata/restrictCollection/GFS_CONUS_80km/TwoD?metadata=variableMap", new int[] {401, 403}});
+    result.add(new Object[]{"metadata/restrictCollection/GFS_CONUS_80km/TwoD?metadata=variableMap", new int[] {HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN}});
 
     return result;
   }

--- a/it/src/test/java/thredds/tds/TestRestrictDataset.java
+++ b/it/src/test/java/thredds/tds/TestRestrictDataset.java
@@ -91,7 +91,7 @@ public class TestRestrictDataset {
   @Test
   public void testFailNoAuth() {
     String endpoint = TestWithLocalServer.withPath(path);
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       HTTPMethod method = HTTPFactory.Get(session);
@@ -110,7 +110,7 @@ public class TestRestrictDataset {
   @Test
   public void testFailBadUser() {
     String endpoint = TestWithLocalServer.withPath(path);
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("baadss", "changeme"));
@@ -130,7 +130,7 @@ public class TestRestrictDataset {
   @Test
   public void testFailBadPassword() {
     String endpoint = TestWithLocalServer.withPath(path);
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("tiggeUser", "changeme"));
@@ -153,7 +153,7 @@ public class TestRestrictDataset {
   @Test
   public void testSuccess() {
     String endpoint = TestWithLocalServer.withPath(path);
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("tds", "secret666"));
@@ -175,12 +175,12 @@ public class TestRestrictDataset {
   @Test
   public void testRestriction() {
     String endpoint = TestWithLocalServer.withPath(path);
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
     try {
       try (HTTPMethod method = HTTPFactory.Get(endpoint)) {
         int statusCode = method.execute();
         if (statusCode != HttpStatus.SC_UNAUTHORIZED && statusCode != HttpStatus.SC_FORBIDDEN) {
-          logger.error("statuscode=%d expected HttpStatus.SC_UNAUTHORIZED or HttpStatus.SC_FORBIDDEN; actual=%d", statusCode);
+          logger.error(String.format("statuscode=%d expected HttpStatus.SC_UNAUTHORIZED or HttpStatus.SC_FORBIDDEN", statusCode));
           assert false;
         }
       }

--- a/it/src/test/java/thredds/tds/TestRestrictDataset.java
+++ b/it/src/test/java/thredds/tds/TestRestrictDataset.java
@@ -42,6 +42,8 @@ import org.junit.runners.Parameterized;
 import thredds.TestWithLocalServer;
 import ucar.httpservices.*;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,6 +57,8 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 @Category(NeedsCdmUnitTest.class)
 public class TestRestrictDataset {
+    private static Logger logger = LoggerFactory.getLogger(TestRestrictDataset.class);
+
   @Parameterized.Parameters(name="{0}")
   public static Collection<Object[]> getTestParameters() {
     return Arrays.asList(new Object[][]{
@@ -87,7 +91,7 @@ public class TestRestrictDataset {
   @Test
   public void testFailNoAuth() {
     String endpoint = TestWithLocalServer.withPath(path);
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       HTTPMethod method = HTTPFactory.Get(session);
@@ -96,21 +100,17 @@ public class TestRestrictDataset {
       Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
-
-      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
-      assert false;
-
+      Assert.fail(e.getMessage());
     } catch (Exception e) {
-
       e.printStackTrace();
-      assert false;
+      Assert.fail(e.getMessage());
     }
   }
 
   @Test
   public void testFailBadUser() {
     String endpoint = TestWithLocalServer.withPath(path);
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("baadss", "changeme"));
@@ -120,19 +120,17 @@ public class TestRestrictDataset {
       Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
-      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
-      assert false;
-
+      Assert.fail(e.getMessage());
     } catch (Exception e) {
       e.printStackTrace();
-      assert false;
+      Assert.fail(e.getMessage());
     }
   }
 
   @Test
   public void testFailBadPassword() {
     String endpoint = TestWithLocalServer.withPath(path);
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("tiggeUser", "changeme"));
@@ -145,21 +143,17 @@ public class TestRestrictDataset {
       Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
-
-      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
-      assert false;
-
+      Assert.fail(e.getMessage());
     } catch (Exception e) {
-
       e.printStackTrace();
-      assert false;
+      Assert.fail(e.getMessage());
     }
   }
 
   @Test
   public void testSuccess() {
     String endpoint = TestWithLocalServer.withPath(path);
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       session.setCredentials(new UsernamePasswordCredentials("tds", "secret666"));
@@ -170,12 +164,8 @@ public class TestRestrictDataset {
       Assert.assertEquals(200, statusCode);
 
     } catch (ucar.httpservices.HTTPException e) {
-
-      System.out.printf("Should return 200 err=%s%n", e.getMessage());
-      assert false;
-
+      Assert.fail(e.getMessage());
     } catch (Exception e) {
-
       e.printStackTrace();
       Assert.fail(e.getMessage());
     }
@@ -185,12 +175,12 @@ public class TestRestrictDataset {
   @Test
   public void testRestriction() {
     String endpoint = TestWithLocalServer.withPath(path);
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
     try {
       try (HTTPMethod method = HTTPFactory.Get(endpoint)) {
         int statusCode = method.execute();
         if (statusCode != HttpStatus.SC_UNAUTHORIZED && statusCode != HttpStatus.SC_FORBIDDEN) {
-          System.out.printf("statuscode=%d expected HttpStatus.SC_UNAUTHORIZED or HttpStatus.SC_FORBIDDEN%n", statusCode);
+          logger.error("statuscode=%d expected HttpStatus.SC_UNAUTHORIZED or HttpStatus.SC_FORBIDDEN; actual=%d", statusCode);
           assert false;
         }
       }

--- a/it/src/test/java/thredds/tds/TestRestrictDataset.java
+++ b/it/src/test/java/thredds/tds/TestRestrictDataset.java
@@ -32,6 +32,7 @@
  */
 package thredds.tds;
 
+import org.apache.http.HttpStatus;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.junit.Assert;
 import org.junit.Test;
@@ -92,11 +93,11 @@ public class TestRestrictDataset {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
 
-      Assert.assertEquals(401, statusCode);
+      Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
 
-      System.out.printf("Should return 401 err=%s%n", e.getMessage());
+      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
       assert false;
 
     } catch (Exception e) {
@@ -116,10 +117,10 @@ public class TestRestrictDataset {
 
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
-      Assert.assertEquals(401, statusCode);
+      Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
-      System.out.printf("Should return 401 err=%s%n", e.getMessage());
+      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
       assert false;
 
     } catch (Exception e) {
@@ -139,13 +140,13 @@ public class TestRestrictDataset {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
 
-      //if (statusCode != 401 && statusCode != 403)
+      //if (statusCode != HttpStatus.SC_UNAUTHORIZED && statusCode != HttpStatus.SC_FORBIDDEN)
       //  assert false;
-      Assert.assertEquals(401, statusCode);
+      Assert.assertTrue(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
 
-      System.out.printf("Should return 401 err=%s%n", e.getMessage());
+      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
       assert false;
 
     } catch (Exception e) {
@@ -188,8 +189,8 @@ public class TestRestrictDataset {
     try {
       try (HTTPMethod method = HTTPFactory.Get(endpoint)) {
         int statusCode = method.execute();
-        if (statusCode != 401 && statusCode != 403) {
-          System.out.printf("statuscode=%d expected 401 or 403%n", statusCode);
+        if (statusCode != HttpStatus.SC_UNAUTHORIZED && statusCode != HttpStatus.SC_FORBIDDEN) {
+          System.out.printf("statuscode=%d expected HttpStatus.SC_UNAUTHORIZED or HttpStatus.SC_FORBIDDEN%n", statusCode);
           assert false;
         }
       }

--- a/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
+++ b/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
@@ -24,7 +24,7 @@ public class TestRestrictNoAuth {
   @Test
   public void testFailNoAuth() {
     String endpoint = TestWithLocalServer.withPath("/dodsC/testRestrictedDataset/testData2.nc.dds");
-    logger.info("testRestriction req = '%s'", endpoint);
+    logger.info(String.format("testRestriction req = '%s'", endpoint));
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       HTTPMethod method = HTTPFactory.Get(session);

--- a/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
+++ b/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
@@ -1,6 +1,7 @@
 /* Copyright */
 package thredds.tds;
 
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
 import thredds.TestWithLocalServer;
@@ -25,11 +26,11 @@ public class TestRestrictNoAuth {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
 
-      Assert.assertEquals(401, statusCode);
+      Assert.assertTrue(statusCode== HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
 
-      System.out.printf("Should return 401 err=%s%n", e.getMessage());
+      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
       assert false;
 
     } catch (Exception e) {

--- a/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
+++ b/it/src/test/java/thredds/tds/TestRestrictNoAuth.java
@@ -2,6 +2,8 @@
 package thredds.tds;
 
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import thredds.TestWithLocalServer;
@@ -17,26 +19,25 @@ import ucar.httpservices.HTTPSession;
  */
 public class TestRestrictNoAuth {
 
+  private static Logger logger = LoggerFactory.getLogger(TestRestrictNoAuth.class);
+
   @Test
   public void testFailNoAuth() {
     String endpoint = TestWithLocalServer.withPath("/dodsC/testRestrictedDataset/testData2.nc.dds");
-    System.out.printf("testRestriction req = '%s'%n", endpoint);
+    logger.info("testRestriction req = '%s'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
       HTTPMethod method = HTTPFactory.Get(session);
       int statusCode = method.execute();
 
-      Assert.assertTrue(statusCode== HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
+      Assert.assertTrue("Expected HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN",
+			statusCode== HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN);
 
     } catch (ucar.httpservices.HTTPException e) {
-
-      System.out.printf("Should return HttpStatus.SC_UNAUTHORIZED|HttpStatus.SC_FORBIDDEN err=%s%n", e.getMessage());
-      assert false;
-
+      Assert.fail(e.getMessage());
     } catch (Exception e) {
-
       e.printStackTrace();
-      assert false;
+      Assert.fail(e.getMessage());
     }
   }
 }

--- a/it/src/test/java/ucar/nc2/util/net/TestTomcatAuth.java
+++ b/it/src/test/java/ucar/nc2/util/net/TestTomcatAuth.java
@@ -33,6 +33,7 @@
 
 package ucar.nc2.util.net;
 
+import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -392,7 +393,7 @@ public class TestTomcatAuth extends UnitTestCommon
             session.setCredentialsProvider(provider);
             result = invoke(session, data.url);
             report(result,provider.counter);
-            Assert.assertTrue("Incorrect return code: " + result.status, result.status == 401);
+            Assert.assertTrue("Incorrect return code: " + result.status, result.status == HttpStatus.SC_UNAUTHORIZED || result.status == HttpStatus.SC_FORBIDDEN);
             Assert.assertTrue("Credentials provider called: " + provider.counter, provider.counter == 1);
 
             // retry with correct password;
@@ -424,7 +425,7 @@ public class TestTomcatAuth extends UnitTestCommon
                 result = invoke(session, data.url);
                 report(result);
             }
-            Assert.assertTrue("Incorrect return code: " + result.status, result.status == 401);
+            Assert.assertTrue("Incorrect return code: " + result.status, result.status == HttpStatus.SC_UNAUTHORIZED || result.status == HttpStatus.SC_FORBIDDEN);
             // retry with correct password;
             // AuthCache should automatically clear bad one from cache.
             try (HTTPSession session = HTTPFactory.newSession(data.url)) {

--- a/opendap/src/main/java/opendap/dap/DConnect2.java
+++ b/opendap/src/main/java/opendap/dap/DConnect2.java
@@ -289,7 +289,7 @@ public class DConnect2 implements Closeable
                     throw new DAP2Exception(DAP2Exception.NO_SUCH_FILE, method.getStatusText() + ": " + urlString);
                 }
 
-                if(statusCode == HttpStatus.SC_UNAUTHORIZED) {
+                if(statusCode == HttpStatus.SC_UNAUTHORIZED || statusCode == HttpStatus.SC_FORBIDDEN) {
                     throw new InvalidCredentialsException(method.getStatusText());
                 }
 

--- a/tds/src/main/java/thredds/server/reify/ReifyController.java
+++ b/tds/src/main/java/thredds/server/reify/ReifyController.java
@@ -500,7 +500,7 @@ public class ReifyController
         } else {
             relpath = HTTPUtil.relpath(HTTPUtil.canonicalpath(relpath));
             if(!TdsRequestedDataset.resourceControlOk(this.req, this.res, relpath)) {
-                codep[0] = res.SC_UNAUTHORIZED;
+                codep[0] = res.SC_FORBIDDEN;
                 return null;
             }
             file = TdsRequestedDataset.getFile(relpath);

--- a/tds/src/main/java/thredds/servlet/restrict/CAMSAuthorizer.java
+++ b/tds/src/main/java/thredds/servlet/restrict/CAMSAuthorizer.java
@@ -86,7 +86,7 @@ public class CAMSAuthorizer extends TomcatAuthorizer {
       }
     }
 
-    res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authorized to access this dataset.");
+    res.sendError(HttpServletResponse.SC_FORBIDDEN, "Not authorized to access this dataset.");
   }
 
   private boolean hasCAMSrole(HttpServletRequest req, String role) {

--- a/tds/src/main/java/thredds/servlet/restrict/TomcatAuthorizer.java
+++ b/tds/src/main/java/thredds/servlet/restrict/TomcatAuthorizer.java
@@ -116,7 +116,7 @@ public class TomcatAuthorizer implements Authorizer {
       }
     }
 
-    res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authorized to access this dataset.");
+    res.sendError(HttpServletResponse.SC_FORBIDDEN, "Not authorized to access this dataset.");
   }
 
 }


### PR DESCRIPTION
re: issues 551
supercedes pr: 552

1. Convert all generation of SC_UNAUTHORIZED (401)
   return codes to SC_FORBIDDEN (403).
2. Fix tests to accept SC_FORBIDDEN as well as SC_UNAUTHORIZED

I think issue 551 is still outstanding.