### PR TITLE
Projection fixes

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/conv/M3IOConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/M3IOConvention.java
@@ -156,7 +156,7 @@ public class M3IOConvention extends CoordSysBuilder {
 
     double start = .001 * findAttributeDouble(ds, startName); // km
     double incr = .001 * findAttributeDouble(ds, incrName); // km
-
+    start = start + incr / 2.; // shifting x and y to central
     CoordinateAxis v = new CoordinateAxis1D(ds, null, name, DataType.DOUBLE, dimName, unitName,
             "synthesized coordinate from " + startName + " " + incrName + " global attributes");
     v.setValues(n, start, incr);

--- a/cdm/src/main/java/ucar/nc2/dataset/conv/WRFConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/WRFConvention.java
@@ -244,7 +244,7 @@ map_proj =  1: Lambert Conformal
           // System.out.println(" using LC "+proj.paramsToString());
           break;
         case 1:
-          proj = new LambertConformal(standardLat, standardLon, lat1, lat2);
+          proj = new LambertConformal(standardLat, standardLon, lat1, lat2, 0.0, 0.0, 6370);
           projCT = new ProjectionCT("Lambert", "FGDC", proj);
           // System.out.println(" using LC "+proj.paramsToString());
           break;
@@ -254,11 +254,11 @@ map_proj =  1: Lambert Conformal
           double lat0 = (Double.isNaN(centralLat)) ? lat2 : centralLat;  // ?? 7/20/2010
           double scaleFactor = (1 + Math.abs( Math.sin(Math.toRadians(lat1)))) / 2.;  // R Schmunk 9/10/07
           // proj = new Stereographic(lat2, lon0, scaleFactor);
-          proj = new Stereographic(lat0, lon0, scaleFactor);
+          proj = new Stereographic(lat0, lon0, scaleFactor, 0.0, 0.0, 6370);
           projCT = new ProjectionCT("Stereographic", "FGDC", proj);
           break;
         case 3:
-          proj = new Mercator(standardLon, standardLat); // thanks to Robert Schmunk
+          proj = new Mercator(standardLon, lat1, 0.0, 0.0, 6370); // thanks to Robert Schmunk with edits for non-MOAD grids
           projCT = new ProjectionCT("Mercator", "FGDC", proj);
           // proj = new TransverseMercator(standardLat, standardLon, 1.0);
           //projCT = new ProjectionCT("TransverseMercator", "FGDC", proj);


### PR DESCRIPTION
I have modified the WRFConvention.java and M3IOConvention.java files to better represent these projections. 

commit 79c8f0e6dae96bb85c3b22b2f911482dd8eaa0a6
    Fixing x/y Coordinate variables
    x/y coordinates for rasters should be cell centered; edges of cells are described by the x_bounds or y_bounds as described in Section 7 of the metdot files for which this treatment is not right, but they are the exception to the rule and a smaller number of files.
    Without this fix, visualization softwares IDV and Panoply will display rasters spatially shifted half a grid cell to the southwest.

commit a5fef4eea91544c899c8818f20dcc30ff961e81e

    Improving WRF Projections
    1. Adding earth radius 6370 consistent with WRF documentation. Addresses issue 753
    2. Updating reference latitude for Mercator projections to improve treatment of nested grids. Addresses issue 752