### PR TITLE
Grib1Record.readDataRaw() now actually does what it claims

### DIFF
--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath libraries["gretty"]  // We want to import GradleUtils and StartBaseTask.
+        classpath libraries["gretty"]  // We want to import GradleUtils and AppStartTask.
     }
 }
 

--- a/gradle/any/properties.gradle
+++ b/gradle/any/properties.gradle
@@ -9,7 +9,7 @@ ext {
     // Used to publish static analysis report to https://sonarqube.com/dashboard/index/thredds
     SONARQUBE_USER_TOKEN_KEY = 'sonarqube.user.token'
     
-    // Do not propagate these system properties to the Gradle test executors.
+    // Do not propagate these system properties to the Gretty web-apps or Gradle test executors.
     systemPropertiesBlackList = [
             // Passing this causes "java.lang.ClassNotFoundException: org.jacoco.agent.rt.internal_932a715.PreMain"
             // See https://discuss.gradle.org/t/jacoco-related-failure-in-multiproject-build/6216

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -160,7 +160,7 @@ configure(fatJarTasks - buildTdmFat) {
     exclude '*.xml'
 }
 
-// See: http://gradle.org/docs/current/userguide/standard_plugins.html#N11EE8
+// See: https://docs.gradle.org/current/userguide/standard_plugins.html#sec:base_plugins
 apply plugin: 'base'
 
 // The base-plugin's "assemble" task automatically creates all artifacts added to the "archives" configuration.

--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Record.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Record.java
@@ -167,12 +167,12 @@ public class Grib1Record {
   }
 
   // dont convertQuasiGrid
-  public float[] readDataRaw(RandomAccessFile raf, GribData.InterpolationMethod method) throws IOException {
-    return readData(raf, method);
+  public float[] readDataRaw(RandomAccessFile raf) throws IOException {
+    return readData(raf, GribData.InterpolationMethod.none);
   }
 
   // isolate dependencies here - in case we have a "minimal I/O" mode where not all fields are available
-  private float[] readData(RandomAccessFile raf, GribData.InterpolationMethod method) throws IOException {
+  public float[] readData(RandomAccessFile raf, GribData.InterpolationMethod method) throws IOException {
     Grib1Gds gds = getGDS();
     Grib1DataReader reader = new Grib1DataReader(pdss.getDecimalScale(), gds.getScanMode(), gds.getNxRaw(), gds.getNyRaw(), gds.getNpts(), dataSection.getStartingPosition());
     byte[] bm = (bitmap == null) ? null : bitmap.getBitmap(raf);

--- a/grib/src/test/java/ucar/nc2/grib/grib1/TestGrib1Unpack.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib1/TestGrib1Unpack.java
@@ -97,7 +97,7 @@ public class TestGrib1Unpack {
 
   private float[] getData(ucar.unidata.io.RandomAccessFile raf, Grib1Record gr, GribData.InterpolationMethod method, int lineno) throws IOException {
     float[] data;
-    data = gr.readDataRaw(raf, method);
+    data = gr.readData(raf, method);
 
     System.out.printf("%s%n", method);
     Grib1Gds gds = gr.getGDS();

--- a/ui/src/main/java/ucar/nc2/ui/grib/Grib1DataTable.java
+++ b/ui/src/main/java/ucar/nc2/ui/grib/Grib1DataTable.java
@@ -911,7 +911,7 @@ public class Grib1DataTable extends JPanel {
       MFile mfile = fileList.get(fileno);
       try (ucar.unidata.io.RandomAccessFile raf = new ucar.unidata.io.RandomAccessFile(mfile.getPath(), "r")) {
         raf.order(ucar.unidata.io.RandomAccessFile.BIG_ENDIAN);
-        return gr.readDataRaw(raf, method);              // use interpolation passed in
+        return gr.readData(raf, method);              // use interpolation passed in
       }
     }
 


### PR DESCRIPTION
* This resolves #758.
* Made `Grib1Record.readData(RandomAccessFile, GribData.InterpolationMethod)` public.
* Two spots where `readDataRaw()` was (confusingly) used now call the newly-available `readData()` instead.