### PR TITLE
Inherit metadata from parent

### DIFF
--- a/cdm/src/main/java/thredds/client/catalog/Catalog.java
+++ b/cdm/src/main/java/thredds/client/catalog/Catalog.java
@@ -272,7 +272,7 @@ public class Catalog extends DatasetNode {
     }
 
     result.setName( dataset.getName() );
-    result.transferMetadata( dataset, false );  // make a copy of all local metadata
+    result.transferMetadata(dataset, copyInherited);  // make a copy of all local metadata
     return result;
   }
 


### PR DESCRIPTION
if the client catalogs says to inherit metadata, make sure it is actually inherited.

fixes Unidata/thredds#649