### PR TITLE
safely combine coordinate attrs in OPeNDAP

### DIFF
--- a/opendap/src/test/java/ucar/nc2/dods/TestAxisAttrCombiner.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestAxisAttrCombiner.java
@@ -1,0 +1,57 @@
+package ucar.nc2.dods;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+import ucar.nc2.Attribute;
+import ucar.nc2.constants._Coordinate;
+
+import static ucar.nc2.dods.DODSNetcdfFile.combineAxesAttrs;
+
+public class TestAxisAttrCombiner extends TestCase {
+
+    @Test
+    public void testAxisAttrCombineSame() {
+        Attribute attr1 = new Attribute(_Coordinate.Axes, "abe bec cid dave");
+        Attribute attr2 = new Attribute(_Coordinate.Axes, "abe bec cid dave");
+        Attribute attr3 = combineAxesAttrs(attr1, attr2);
+
+        assertEquals(attr3.getStringValue(), (attr1.getStringValue()));
+        assertEquals(attr3.getStringValue(), attr2.getStringValue());
+    }
+
+    @Test
+    public void testAxisAttrCombineDiff() {
+        Attribute attr1 = new Attribute(_Coordinate.Axes, "abe bec cid dave");
+        Attribute attr2 = new Attribute(_Coordinate.Axes, "ed fin gabe hedi");
+        Attribute attr3 = combineAxesAttrs(attr1, attr2);
+
+        assertTrue(attr3.getStringValue().contains(attr1.getStringValue()));
+        assertTrue(attr3.getStringValue().contains(attr2.getStringValue()));
+    }
+
+    @Test
+    public void testAxisAttrCombineOverlap() {
+        Attribute attr1 = new Attribute(_Coordinate.Axes, "abe bec cid dave");
+        Attribute attr2 = new Attribute(_Coordinate.Axes, "cid dave ed fin");
+        Attribute attr3 = combineAxesAttrs(attr1, attr2);
+
+        assertTrue(attr3.getStringValue().contains(attr1.getStringValue()));
+        assertTrue(attr3.getStringValue().contains(attr2.getStringValue()));
+
+        assertEquals(attr3.getStringValue().split("\\s").length, 6);
+    }
+
+    public void testAxisAttrCombineOverlapMangled() {
+        Attribute attr1 = new Attribute(_Coordinate.Axes, " abe bec     cid dave    ");
+        Attribute attr2 = new Attribute(_Coordinate.Axes, "cid   dave ed   fin");
+        Attribute attr3 = combineAxesAttrs(attr1, attr2);
+
+        // these will fail, because whitespace is all messed up in the attribute values
+        assertFalse(attr3.getStringValue().contains(attr1.getStringValue()));
+        assertFalse(attr3.getStringValue().contains(attr2.getStringValue()));
+
+        assertEquals(attr3.getStringValue().split("\\s").length, 6);
+    }
+}


### PR DESCRIPTION
When dealing with GOES-16 data, I found that the `_CoordinateAxis` attribute, was getting duplicate entries added to it when reading the dataset through OPeNDAP. For example:

`_CoordinateAxes = "band_id band_wavelength t y x y x ";`

when it should be

`_CoordinateAxes = "band_id band_wavelength t y x";`

This PR fixes the duplication issue by safely combining the attributes listed by the CF attribute `coordinates` and the attribute `_CoordinatesAxis`.

This also happens in 5.0, so if this is approved, I will make a new PR for 5.