### PR TITLE
Use description of DataFormatType in catalog

### DIFF
--- a/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
+++ b/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
@@ -210,7 +210,7 @@ public class InvDatasetFcGrib extends InvDatasetFeatureCollection {
     ThreddsMetadata tmi = result.getInheritableMetadata();  // LOOK should we be allowed to modify this ??
     tmi.set(Dataset.VariableMapLinkURI, makeUriResolved(catURI, makeMetadataLink(tpath, VARIABLES)));
     tmi.set(Dataset.ServiceName, virtualService.getName());
-    tmi.set(Dataset.DataFormatType, fromGc.isGrib1 ? DataFormatType.GRIB1.toString() : DataFormatType.GRIB2.toString());
+    tmi.set(Dataset.DataFormatType, fromGc.isGrib1 ? DataFormatType.GRIB1.getDescription() : DataFormatType.GRIB2.getDescription());
     tmi.set(Dataset.Properties, Property.convertToProperties(fromGc.getGlobalAttributes()));
     tmi.set(Dataset.FeatureType, FeatureType.GRID.toString()); // override GRIB
 


### PR DESCRIPTION
In the THREDDS metadata for a catalog for GRIB1 or GRIB2, we need to use the correct value for `DataFormatType`. For example, a GRIB1 FeatureCollection shows:

~~~xml
<dataFormat>GRIB1</dataFormat>
~~~

when it should be:

~~~xml
<dataFormat>GRIB-1</dataFormat>
~~~

Currently, the code calls `toString()` on the `DataFormatType` `enum` which results in an invalid value for the `DataFormat` metadata element. The correct thing to do would be to call `getDescription()`.