### PR TITLE
Add support for basic iso format

### DIFF
--- a/cdm/src/main/java/ucar/nc2/time/CalendarDateFormatter.java
+++ b/cdm/src/main/java/ucar/nc2/time/CalendarDateFormatter.java
@@ -206,7 +206,7 @@ public class CalendarDateFormatter {
   }
 
   //                                                   1                  2            3
-  static public final String isodatePatternString = "([\\+\\-\\d]+)([ t]([\\.\\:\\d]*)([ \\+\\-]\\S*)?z?)?$"; // public for testing
+  static public final String isodatePatternString = "([\\+\\-?\\d]+)([ t]([\\.\\:?\\d]*)([ \\+\\-]\\S*)?z?)?$"; // public for testing
   // private static final String isodatePatternString = "([\\+\\-\\d]+)[ Tt]([\\.\\:\\d]*)([ \\+\\-]\\S*)?z?)?$";
   private static final Pattern isodatePattern = Pattern.compile(isodatePatternString);
 
@@ -241,17 +241,64 @@ public class CalendarDateFormatter {
          dateString = dateString.substring(1);
        }
 
-      StringTokenizer dateTokenizer = new StringTokenizer(dateString, "-");
-      if (dateTokenizer.hasMoreTokens()) year = Integer.parseInt(dateTokenizer.nextToken());
-      if (dateTokenizer.hasMoreTokens()) month = Integer.parseInt(dateTokenizer.nextToken());
-      if (dateTokenizer.hasMoreTokens()) day = Integer.parseInt(dateTokenizer.nextToken());
+      if (dateString.contains("-")) {
+        StringTokenizer dateTokenizer = new StringTokenizer(dateString, "-");
+        if (dateTokenizer.hasMoreTokens()) year = Integer.parseInt(dateTokenizer.nextToken());
+        if (dateTokenizer.hasMoreTokens()) month = Integer.parseInt(dateTokenizer.nextToken());
+        if (dateTokenizer.hasMoreTokens()) day = Integer.parseInt(dateTokenizer.nextToken());
+      } else {
+        int dateLength = dateString.length();
+        if (dateLength % 2 != 0) {
+          throw new IllegalArgumentException(dateString + " is ambiguous. Cannot parse uneven " +
+                  "length date strings when no date delimiter is used.");
+        } else {
+          // dateString length must be even - only four digit year, two digit month, and
+          // two digit day values are allowed when there is no date delimiter.
+          if (dateLength > 3) year = Integer.parseInt(dateString.substring(0, 4));
+          if (dateLength > 5) month = Integer.parseInt(dateString.substring(4, 6));
+          if (dateLength > 7) day = Integer.parseInt(dateString.substring(6, 8));
+        }
+      }
 
       // Parse the time if present
       if (timeString != null && timeString.length() > 0) {
-        StringTokenizer timeTokenizer = new StringTokenizer(timeString, ":");
-        if (timeTokenizer.hasMoreTokens()) hour = Integer.parseInt(timeTokenizer.nextToken());
-        if (timeTokenizer.hasMoreTokens()) minute = Integer.parseInt(timeTokenizer.nextToken());
-        if (timeTokenizer.hasMoreTokens()) second = Double.parseDouble(timeTokenizer.nextToken());
+        if (timeString.contains(":")) {
+          StringTokenizer timeTokenizer = new StringTokenizer(timeString, ":");
+          if (timeTokenizer.hasMoreTokens()) hour = Integer.parseInt(timeTokenizer.nextToken());
+          if (timeTokenizer.hasMoreTokens()) minute = Integer.parseInt(timeTokenizer.nextToken());
+          if (timeTokenizer.hasMoreTokens()) second = Double.parseDouble(timeTokenizer.nextToken());
+        } else {
+          int timeLengthNoSubseconds = timeString.length();
+          // possible this contains a seconds value with subseconds (i.e. 25.125 seconds)
+          // since the seconds value can be a Double, let's check check the length of the
+          // time, without the subseconds (if they exist)
+          if (timeString.contains(".")) {
+            timeLengthNoSubseconds = timeString.split("\\.")[0].length();
+          }
+          // Ok, so this is a little tricky.
+          // First: A udunit date of 1992-10-8t7 is valid. We want to make sure this still work, so
+          // there is a special case of timeString.length() == 1;
+          //
+          // Second: We have the length of the timeString, without
+          // any subseconds. Given that the values for hour, minute, and second must be two
+          // digit numbers, the length of the timeString, without subseconds, should be even.
+          // However, if someone has encoded time as hhms, there is no way we will be able to tell.
+          // So, this is the best we can do to ensure we are parsing the time properly.
+          // Known failure here: hhms will be interpreted as hhmm, but hhms is not following iso, and
+          // a bad idea to use anyway.
+          if (timeLengthNoSubseconds == 1) {
+            hour = Integer.parseInt(timeString);
+          } else if (timeLengthNoSubseconds % 2 != 0) {
+            throw new IllegalArgumentException(timeString + " is ambiguous. Cannot parse uneven " +
+                    "length time strings (ignoring subseconds) when no time delimiter is used.");
+          } else {
+            // dateString length must be even - only four digit year, two digit month, and
+            // two digit day values are allowed when there is no date delimiter.
+            if (timeString.length() > 1) hour = Integer.parseInt(timeString.substring(0, 2));
+            if (timeString.length() > 3) minute = Integer.parseInt(timeString.substring(2, 4));
+            if (timeString.length() > 5) second = Double.parseDouble(timeString.substring(4));
+          }
+        }
       }
 
       if (isMinus) year = -year;

--- a/cdm/src/test/java/ucar/nc2/time/TestCalendarDateFormatter.java
+++ b/cdm/src/test/java/ucar/nc2/time/TestCalendarDateFormatter.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.Date;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test CalendarDateFormatter
@@ -13,6 +15,8 @@ import org.junit.Test;
  * @since 5/3/12
  */
 public class TestCalendarDateFormatter {
+
+  private static final Logger logger = LoggerFactory.getLogger(TestCalendarDateFormatter.class);
 
   @Test
   public void testBad() {
@@ -27,6 +31,28 @@ public class TestCalendarDateFormatter {
     claimGood("1997-07-16T19:20+01:00");
     claimGood("1997-07-16T19:20:30+01:00");
 
+  }
+
+  @Test
+  public void testBasicFormatIso() {
+    claimGood("19500101T000000Z"); // from https://github.com/Unidata/thredds/issues/772
+    claimGood("199707");
+    claimGood("19970716");
+    claimGood("19970716T1920");
+    claimGood("19970716T192030");
+    claimGood("19970716T192030.1");
+    claimGood("19970716T1920+01:00");
+    claimGood("19970716T192030+0100");
+    claimGood("19970716T192030+01");
+    claimGood("19970716T192030.1+0100");
+    claimGood("19970716T192030Z");
+    claimGood("19970716T192030.1Z");
+    // these should fail
+    claimBad("19970716T192030.1UTC");
+    claimBad("19501"); // fail because ambiguous
+    claimBad("1950112"); // fail because ambiguous
+    claimBad("19501120T121"); // fail because ambiguous
+    claimBad("19501120T12151"); // fail because ambiguous
   }
 
   @Test
@@ -97,9 +123,9 @@ public class TestCalendarDateFormatter {
   private void claimGood(String s) {
     try {
       CalendarDate result = CalendarDateFormatter.isoStringToCalendarDate(null, s);
-      System.out.printf("%s == %s%n", s, result);
+      logger.debug("%s == %s%n", s, result);
     } catch (Exception e) {
-      System.out.printf("FAIL %s%n", s);
+      logger.error("FAIL %s%n", s);
       e.printStackTrace();
       CalendarDateFormatter.isoStringToCalendarDate(null, s);
       assert false;
@@ -109,9 +135,10 @@ public class TestCalendarDateFormatter {
   private void claimBad(String s) {
     try {
       CalendarDate result = CalendarDateFormatter.isoStringToCalendarDate(null, s);
-      System.out.printf("%s == %s%n", s, result);
+      logger.error("FAIL %s%n", s);
       assert false;
     } catch (Exception e) {
+      logger.debug("Expected fail = %s%n", s);
       return;
     }
   }


### PR DESCRIPTION
cherry-pick from master

Add support for the basic iso format, which is like the iso string we all know
and love, but without any date or time delimiters (that is, no '-' or ':'
characters).

Fixes Unidata/thredds#772