### PR TITLE
Make access to the netcdf-c library be synchronized 

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -155,7 +155,7 @@ libraries["jdom2"] = "org.jdom:jdom2:2.0.4"
 
 libraries["je"] = "com.sleepycat:je:4.0.92"
 
-libraries["jna"] = "net.java.dev.jna:jna:4.1.0"
+libraries["jna"] = "net.java.dev.jna:jna:4.2.2"
 
 libraries["joda-time"] = "joda-time:joda-time:2.8.1"
 

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -170,6 +170,8 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
         // jna_path may still be null (the user didn't specify a "jna.library.path"), but try to load anyway;
         // the necessary libs may be on the system PATH.
         nc4 = (Nc4prototypes) Native.loadLibrary(libName, Nc4prototypes.class);
+        // Make the library synchronized
+        nc4 = (Nc4prototypes) Native.synchronizedLibrary(nc4);
 
         startupLog.info("Nc4Iosp: NetCDF-4 C library loaded (jna_path='{}', libname='{}').", jnaPath, libName);
         log.debug("Netcdf nc_inq_libvers='{}' isProtected={}", nc4.nc_inq_libvers(), Native.isProtected());


### PR DESCRIPTION
Upgrade to net.java.dev.jna:jna:4.2.2
so that we can use Native.synchronizedLibrary()
to force synchronized (single-thread) access to
 the netcdf-c library.

This is effectively a back-port of what already was done for 5.0.0
