### PR TITLE
Allow NcML with https in URI

### DIFF
--- a/cdm/src/main/java/thredds/client/catalog/Catalog.java
+++ b/cdm/src/main/java/thredds/client/catalog/Catalog.java
@@ -59,7 +59,9 @@ public class Catalog extends DatasetNode {
   static public final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
   static public final Namespace defNS = Namespace.getNamespace(CATALOG_NAMESPACE_10);
   static public final String NJ22_NAMESPACE = "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
+  static public final String NJ22_NAMESPACE_HTTPS = "https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
   static public final Namespace ncmlNS = Namespace.getNamespace("ncml", NJ22_NAMESPACE);
+  static public final Namespace ncmlNSHttps = Namespace.getNamespace("ncml", NJ22_NAMESPACE_HTTPS);
   static public final String XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
   static public final Namespace xlinkNS = Namespace.getNamespace("xlink", XLINK_NAMESPACE);
   static public final Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");

--- a/cdm/src/test/data/ncml/testReadHttps.xml
+++ b/cdm/src/test/data/ncml/testReadHttps.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nc:netcdf xmlns:nc="https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+  location="file:src/test/data/example1.nc">
+
+  <nc:explicit/>
+
+  <nc:dimension name="time" length="2" isUnlimited="true"/>
+  <nc:dimension name="lat" length="3"/>
+  <nc:dimension name="lon" length="4"/>
+
+  <nc:variable name="rh" type="int" shape="time lat lon">
+    <nc:attribute name="long_name" type="string" value="relative humidity"/>
+    <nc:attribute name="units" type="string" value="percent"/>
+  </nc:variable>
+  <nc:variable name="T" type="double" shape="time lat lon">
+    <nc:attribute name="long_name" type="string" value="surface temperature"/>
+    <nc:attribute name="units" type="string" value="degC"/>
+  </nc:variable>
+  <nc:variable name="lat" type="float" shape="lat">
+    <nc:attribute name="units" type="string" value="degrees_north"/>
+    <nc:values separator=" ">41.0 40.0 39.0</nc:values>
+  </nc:variable>
+  <nc:variable name="lon" type="float" shape="lon">
+    <nc:attribute name="units" type="string" value="degrees_east"/>
+    <nc:values separator=" ">-109.0 -107.0 -105.0 -103.0</nc:values>
+  </nc:variable>
+  <nc:variable name="time" type="int" shape="time">
+    <nc:attribute name="units" type="string" value="hours"/>
+    <nc:values separator=" ">6 18</nc:values>
+  </nc:variable>
+
+  <nc:attribute name="title" type="string" value="Example Data"/>
+  <nc:attribute name="testByte" type="byte" value="1 2 3 4"/>
+  <nc:attribute name="testShort" type="short" value="1 2 3 4"/>
+  <nc:attribute name="testInt" type="int" value="1 2 3 4"/>
+  <nc:attribute name="testFloat" type="float" value="1 2 3 4"/>
+  <nc:attribute name="testDouble" type="double" value="1 2 3 4"/>
+
+
+</nc:netcdf>

--- a/cdm/src/test/java/ucar/nc2/ncml/TestNcMLRead.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestNcMLRead.java
@@ -286,5 +286,15 @@ public class TestNcMLRead extends TestCase {
       location = "file:"+TestNcML.topDir + "readMetadata.xml";
     }
   }
-  
+
+  static public class TestReadHttps extends TestNcMLRead {
+
+    // equivalent dataset using "readMetadata"
+    public TestReadHttps( String name) {
+      super(name);
+      ncfile = null;
+      location = "file:"+TestNcML.topDir + "testReadHttps.xml";
+    }
+  }
+
 }


### PR DESCRIPTION
Enable the use of https in the URI for the NcML namespace when reading NcML files.

For example, this works as it should:

~~~xml
<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
~~~

but this fails:

~~~xml
<netcdf xmlns="https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
~~~

with the following:

~~~java
Exception in thread "main" java.lang.IllegalArgumentException: Incorrect namespace specified in NcML= https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2
   must be=http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2
        at ucar.nc2.ncml.NcMLReader.readNetcdf(NcMLReader.java:489)
        at ucar.nc2.ncml.NcMLReader._readNcML(NcMLReader.java:456)
        at ucar.nc2.ncml.NcMLReader.readNcML(NcMLReader.java:256)
        at ucar.nc2.ncml.NcMLReader.readNcML(NcMLReader.java:206)
        at ucar.nc2.dataset.NetcdfDataset.acquireNcml(NetcdfDataset.java:1081)
        at ucar.nc2.dataset.NetcdfDataset.openOrAcquireFile(NetcdfDataset.java:723)
        at ucar.nc2.dataset.NetcdfDataset.openFile(NetcdfDataset.java:572)
        at ucar.nc2.NCdumpW.print(NCdumpW.java:251)
~~~