### PR TITLE
Tweak generation of ToolsUI JNLP files so they work on our web server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     vendor = "UCAR/Unidata"
 
     // Matches Maven's "project.url". Used in MANIFEST.MF for "Implementation-URL".
-    url = "http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"
+    url = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"
 
     SimpleDateFormat iso_8601_format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
     buildTimestamp = iso_8601_format.format(new Date())

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
@@ -44,30 +44,34 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
     
     @Rule TemporaryFolder tempFolder
     
-    def "test writeNetCDFtoolsExtraJars"() {
-        setup: 'create a temporary file that will be deleted at the end of the test'
-        File tempFile = tempFolder.newFile('netCDFtoolsExtraJars.jnlp')
+    def "just the writer"() {
+        setup: "Identify control file for this test. It's located in src/test/resources/edu/ucar/build/ui/"
+        String controlFileName = 'toolsUiJnlpExtension.jnlp'
     
-        and: 'create a writer with the specified properties'
+        and: "Create a temp file that'll be deleted at the end. It has same name as control file, but different path."
+        File tempFile = tempFolder.newFile(controlFileName)
+    
+        and: "create a writer with the specified properties"
         ToolsUiJnlpExtensionTask.Writer writer = new ToolsUiJnlpExtensionTask.Writer()
         writer.with {
+            codebase = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart"
             applicationVersion = rootProject.version
             applicationJarName = rootProject.jar.archiveName
             dependenciesConfig = rootProject.configurations.runtime
             outputFile = tempFile
         }
     
-        and: 'write JNLP to disk'
+        and: "write JNLP to disk"
         writer.write()
     
-        when: 'compare expected XML (read from test resource) with just-written file, ignoring comments and whitespace'
-        Diff diff = DiffBuilder.compare(Input.fromStream(getClass().getResourceAsStream('netCDFtoolsExtraJars.jnlp')))
+        when: "compare expected XML (read from test resource) with just-written file, ignoring comments and whitespace"
+        Diff diff = DiffBuilder.compare(Input.fromStream(getClass().getResourceAsStream(controlFileName)))
                                .withTest(Input.fromFile(tempFile))
                                .ignoreComments()
                                .normalizeWhitespace()
                                .build()
 
-        then: 'there will be no difference between the two'
+        then: "there will be no difference between the two"
         !diff.hasDifferences()
     }
     
@@ -77,7 +81,7 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
     // into the test build's buildscript classpath.
     List<File> buildSrcClasspath = PluginUnderTestMetadataReading.readImplementationClasspath()
     
-    def "test ToolsUiJnlpExtensionTask in Gradle build"() {
+    def "full Gradle build"() {
         setup: "variables"
         String taskName = 'toolsUiJnlpExtension'
         File outputFile = tempFolder.newFile('testNetCDFtoolsExtraJars.jnlp')
@@ -106,6 +110,7 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
             }
             
             task $taskName(type: edu.ucar.build.ui.ToolsUiJnlpExtensionTask) {
+                codebase = 'https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart'
                 outputFile = file('${outputFile.name}')
             }
         """

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithOptionals.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithOptionals.jnlp
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp spec="7.0" codebase="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart" version="1.5">
+    <information>
+        <title>NetCDF ToolsUI</title>
+        <vendor>Unidata</vendor>
+        <homepage href="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
+        <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
+        <icon href="nc.gif"/>
+        <offline-allowed/>
+    </information>
+    
+    <security>
+        <all-permissions/>
+    </security>
+    
+    <update check="background" policy="prompt-update"/>
+    
+    <resources>
+        <java version="1.7+" max-heap-size="1500m"/>
+        <extension name="netcdfUI Extra" href="netCDFtoolsExtraJars.jnlp"/>
+    </resources>
+    
+    <application-desc main-class="ucar.nc2.ui.ToolsUI">
+        <argument>{catalog}#{dataset}</argument>
+    </application-desc>
+</jnlp>

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithoutOptionals.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithoutOptionals.jnlp
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="7.0" codebase="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart"
-        href="netCDFtools.jnlp" version="1.5">
+<jnlp spec="7.0" version="1.5">
     <information>
         <title>NetCDF ToolsUI</title>
         <vendor>Unidata</vendor>
-        <homepage href="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
+        <homepage href="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
         <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
         <icon href="nc.gif"/>
         <offline-allowed/>

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpExtension.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpExtension.jnlp
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="7.0" codebase="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart"
-        href="netCDFtoolsExtraJars.jnlp" version="1.5">
+<jnlp spec="7.0" codebase="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart" version="1.5">
     <component-desc/>
+    
+    <security>
+        <all-permissions/>
+    </security>
     
     <resources>
         <jar href='root-1.5.jar' main='true' download='eager' />

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -2,7 +2,7 @@ description = "TDS - NetCDF-Java library integration Test module. This module co
         "needed to test the NetCDF-Java library in a servlet container. Starts up a TDS server and then sends " +
         "requests to it. Relies on having access to cdmUnitTest directory, so can only be run at Unidata."
 ext.title = "Test Integration"
-ext.url = "http://www.unidata.ucar.edu/software/thredds/current/tds/TDS.html"
+ext.url = "https://www.unidata.ucar.edu/software/thredds/current/tds/TDS.html"
 
 dependencies {
     testCompile project(":cdm")

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -3,7 +3,7 @@ import edu.ucar.build.ui.ToolsUiJnlpBaseTask
 description = "The THREDDS Data Server (TDS) is a web server that provides catalog and data access services for " +
         "scientific data using OPeNDAP, OGC WCS and WMS, HTTP, and other remote-data-access protocols."
 ext.title = "THREDDS Data Server (TDS)"
-ext.url = "http://www.unidata.ucar.edu/software/thredds/current/tds/TDS.html"
+ext.url = "https://www.unidata.ucar.edu/software/thredds/current/tds/TDS.html"
 
 apply plugin: 'war'
 
@@ -67,7 +67,12 @@ test {
     exclude 'thredds/tds/**'
 }
 
+// Need to evaluate :ui first so that the 'webstartCodebase' property is available.
+Project uiProject = rootProject.project(':ui')
+evaluationDependsOn uiProject.path
+
 task toolsUiJnlpBase(type: ToolsUiJnlpBaseTask) {
+    codebase = uiProject.webstartCodebase
     applicationArgument = '{catalog}#{dataset}'
     outputFile = file("$buildDir/webstart/ToolsUI.jnlp")
 }

--- a/udunits/build.gradle
+++ b/udunits/build.gradle
@@ -3,7 +3,7 @@ description = "The ucar.units Java package is for decoding and encoding formatte
         "and for performing arithmetic operations on units (e.g. dividing one unit by another, " +
         "or raising a unit to a power)."
 ext.title = "UDUNITS"
-ext.url = "http://www.unidata.ucar.edu/software/udunits/"
+ext.url = "https://www.unidata.ucar.edu/software/udunits/"
 
 dependencies {
     compile libraries["joda-time"]

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -42,21 +42,47 @@ dependencies {
 
 //////////////////////////////////////////////////////////
 
+ext {
+    // See http://docs.oracle.com/javase/8/docs/technotes/guides/deploy/manifest.html#CIHJIIHD
+    // See http://docs.oracle.com/javase/8/docs/technotes/guides/javaws/developersguide/syntax.html#jnlp_elements
+    // The Codebase attributes in the JAR manifest and JNLP must match, or else javaws fails to start with the error:
+    // "Application Blocked by Java Security".
+    webstartCodebase = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart/"
+    
+    // Webstart can also work if both Codebase attributes are unspecified.
+    // Setting this property to null will produce a manifest and JNLP files with no Codebase attributes.
+    // LOOK: Use this for local Webstart testing; use the other for deployment to production.
+//     webstartCodebase = null
+    
+    webstartWorkingDir = "build/signed"
+    if (project.hasProperty("webdir")) {
+        webstartDir = new File(webdir, "webstart")
+    }
+    
+    depsToRejar = ['xmlbeans-2.6.0.jar', 'Saxon-HE-9.4.0.6.jar']
+}
+
 jar {
     manifest {
-        attributes 'Main-Class': 'ucar.nc2.ui.ToolsUI',
-                // These are security attributes, necessary for Web Start: http://goo.gl/Ob6Wid
-                // ui.jar is the first jar in the JNLP, so I think its manifest is the only one that needs these.
-                'Application-Name': project.title,
-                'Codebase': 'http://www.unidata.ucar.edu/software/thredds/',
-                'Permissions': 'all-permissions',
-                'Trusted-Only': 'true',
-
-                // MANIFEST.MF is an @Input to the Jar task, so when it changes, Jar will be considered out-of-date.
-                // Here, we're writing an attribute to MANIFEST.MF. When its value changes, MANIFEST.MF will change,
-                // and Jar will be considered out-of-date.
-                // So, indirectly, we've made the "runtime" configuration an @Input to the Jar task.
-                'Class-Path': configurations.runtime.collect { it.name }.join(' ')
+        Map<String,?> attribs = [:]
+        attribs['Main-Class'] = 'ucar.nc2.ui.ToolsUI'
+    
+        // MANIFEST.MF is an @Input to the Jar task, so when it changes, Jar will be considered out-of-date.
+        // Here, we're writing an attribute to MANIFEST.MF. When its value changes, MANIFEST.MF will change,
+        // and Jar will be considered out-of-date.
+        // So, indirectly, we've made the "runtime" configuration an @Input to the Jar task.
+        attribs['Class-Path'] = configurations.runtime.collect { it.name }.join(' ')
+        
+        // The attributes below are necessary for Web Start; see http://goo.gl/Ob6Wid.
+        // ui-<version>.jar is the main jar in the ToolsUI extension JNLP file, so only its manifest needs these.
+        attribs['Application-Name'] = project.title
+        attribs['Permissions'] = 'all-permissions'
+        attribs['Trusted-Only'] = 'true'
+        if (webstartCodebase) {
+            attribs['Codebase'] = webstartCodebase
+        }
+        
+        attributes attribs
     }
 
     // I used to create META-INF/INDEX.LIST here to speedup Web Start loading, but it turns out that Spring and
@@ -65,43 +91,37 @@ jar {
     // LOOK: Does that make the 'Class-Path' manifest attribute and 'download="lazy"' JNLP attributes pointless?
 }
 
-ext {
-    toolsUIjar = 'toolsUI-' + version + '.jar'
-    webstartWorkingDir = "build/signed"
-    if (project.hasProperty("webdir")) {
-        webstartDir = new File(webdir, "webstart")
-    }
-
-    depsToRejar = ['xmlbeans-2.6.0.jar', 'Saxon-HE-9.4.0.6.jar']
-}
-
 task toolsUiJnlpExtension(type: ToolsUiJnlpExtensionTask) {
+    codebase = webstartCodebase
     outputFile = file("$buildDir/webstart/netCDFtoolsExtraJars.jnlp")
 }
 
-task toolsUiJnlpBase(type: ToolsUiJnlpBaseTask) {
-    // Creates an inferred task dependency on toolsUiJnlpExtension.
-    // See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:task_input_output_side_effects
+task toolsUiJnlpBase(type: ToolsUiJnlpBaseTask, dependsOn: toolsUiJnlpExtension) {
     File toolsUiJnlpExtensionFile = Iterables.getOnlyElement(tasks.toolsUiJnlpExtension.outputs.files.files)
     
+    codebase = webstartCodebase
     extensionJnlpFileName = toolsUiJnlpExtensionFile.name
     outputFile = file("$buildDir/webstart/netCDFtools.jnlp")
 }
 
 /*
- * 2017-04-12 note: As of java version "1.8.0_121", I cannot FOR THE LIFE OF ME figure out how to run webstart locally.
- * It used to work with earlier versions of JRE 8, but now I always get an "Application Blocked by Java Security"
- * error dialog. A lot of solutions on the web recommend adding entries to the Java Security Exception Site List
- * (e.g. http://mindprod.com/jgloss/exceptionsitelist.html#LOCALHOST), but nothing works. I even tried hosting the
- * files on a local HTTP server, so that I could reference them with http://localhost URLs. No dice. So, for each
- * release, we just have to make sure that Web Start works once the files are uploaded to the Unidata server.
+ * It's possible to test web start files locally before deploying them.
+ * 1. Open your gradle.properties file (~/.gradle/gradle.properties) and change "webdir" to a local directory,
+ *    such as '/Users/cwardgar/Desktop'
+ * 2. Uncomment the 'webstartCodebase = null' line in the ext{} block above.
+ * 3. Run this task: ./gradlew :ui:clean :ui:releaseWebstart
+ * 4. You may need to white-list web starts from the local file system. Go to Java Control Panel->Security->
+ *    Edit Site List... and add the entry "file:/".
+ * 5. cd to "webdir" and execute "javaws netCDFtools.jnlp". You may also be able to simply double-click that file,
+ *    but I couldn't get that working (and there was no error feedback).
  */
-/* following properties should be in gradle.properties:
-   keystore=name of keystore file
-   keystoreAlias=idv
-   keystorePassword=password of keystore file
-   webdir:parent of conan content directory
-   ftpdir:ftp directory
+/*
+ * The following properties should be in gradle.properties:
+ * keystore=name of keystore file
+ * keystoreAlias=idv
+ * keystorePassword=password of keystore file
+ * webdir:parent of conan content directory
+ * ftpdir:ftp directory
  */
 // TODO: Use the Sync task for this.
 task releaseWebstart(group: 'Release', dependsOn: ['jar', 'toolsUiJnlpExtension', 'toolsUiJnlpBase']) << {
@@ -114,6 +134,7 @@ task releaseWebstart(group: 'Release', dependsOn: ['jar', 'toolsUiJnlpExtension'
             println "copyJnlp"
             from Iterables.getOnlyElement(tasks.toolsUiJnlpExtension.outputs.files.files)
             from Iterables.getOnlyElement(tasks.toolsUiJnlpBase.outputs.files.files)
+            from rootProject.file('docs/website/netcdf-java/nc.gif')  // Referenced in the ToolsUI base JNLP file.
             into webstartWorkingDir
         }
 


### PR DESCRIPTION
ui.jar's 'Codebase' manifest attribute and the `/jnlp/@codebase` attributes of ToolsUI JNLP files are now kept in sync. They are controlled by a single variable in `:ui`: `webstartCodebase`. It turns out that different values for all of these codebases was the principal cause of the "Application Blocked by Java Security" failures we were seeing in javaws.
* The ToolsUiJnlp tasks now have a `codebase` property. Updated unit tests to exercise the new property.
* The aforementioned property may be `null`, which suppresses output of the `/jnlp/@codebase` attribute. This is useful for local Web Start testing.
* Restored my (now simpler) notes about how to test Web Start locally.

Other changes:
* Don't include `/jnlp/@href` attribute in `ToolsUiJnlp*Task` output files.
* `ToolsUiJnlpExtensionTask` outputs must include `<security><all-permissions/></security>` element.
* Refactored `ToolsUiJnlp*Task` tests to be simpler and more consistent.
* For all URLs in our JAR manifests and JNLP files that point to our web sever, use HTTPS instead of HTTP.