### PR TITLE
Add tests for a fresh installation of TDS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         classpath libraries["gretty"]
         classpath libraries["shadow"]
         classpath libraries["coveralls-gradle-plugin"]
-        classpath libraries["gradle-extra-configurations-plugin"]
         classpath libraries["sonarqube-gradle-plugin"]
         classpath libraries["license-gradle-plugin"]
         

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         //
         // Our solution is to explicitly exclude any other Groovy dependencies whenever localGroovy() is already part
         // of the configuration.
-        exclude group: 'org.codehaus.groovy', module: 'groovy-all'
+        exclude module: "groovy-all"
     }
     
     testCompile libraries["xmlunit-core"]  // For comparing JNLP XML.

--- a/dap4/d4cdm/build.gradle
+++ b/dap4/d4cdm/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     compile project(':cdm')
     compile project(':netcdf4')
     
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
 }

--- a/dap4/d4servlet/build.gradle
+++ b/dap4/d4servlet/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     compile project(':dap4:d4lib')
     compile project(":httpservices")
 
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["slf4j-api"]
 }

--- a/dap4/d4tests/build.gradle
+++ b/dap4/d4tests/build.gradle
@@ -15,11 +15,9 @@ dependencies {
     testCompile project(':dap4:d4cdm')
     testCompile project(':cdm')
     testCompile project(':httpservices')
-
-    def tdsDep = testCompile project(':tds')
-    configure(tdsDep) {
-        // We don't want tds's logger. We'll provide our own (in testing.gradle).
-        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+    
+    testCompile(project(":tds")) {
+        exclude module: "log4j-slf4j-impl"  // We don't want TDS's logger binding.
     }
 
     testCompile libraries["javax.servlet-api"]

--- a/dap4/d4ts/build.gradle
+++ b/dap4/d4ts/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile project(':dap4:d4core')
     compile project(':dap4:d4lib')
     compile project(':dap4:d4servlet')
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["slf4j-api"]
     runtime libraries["log4j-slf4j-impl"]
     runtime libraries["log4j-core"]

--- a/gradle/any/coverage.gradle
+++ b/gradle/any/coverage.gradle
@@ -1,10 +1,12 @@
 // The jacoco plugin adds the jacocoTestReport task, but only if the java plugin is already applied.
 apply plugin: "jacoco"
 
+// Will apply to any task of type Test or type org.akhikhl.gretty.StartBaseTask,
+// including org.akhikhl.gretty.AppBeforeIntegrationTestTask.
 Closure isExtendedByJacoco = { Task task -> task.extensions.findByType(JacocoTaskExtension) }
 Collection<Task> tasksExtendedByJacoco = tasks.matching(isExtendedByJacoco)
 
-tasksExtendedByJacoco.all {  // Will apply to ":<subproject>:test" and ":it:appBeforeIntegrationTest".
+tasksExtendedByJacoco.all {
     // Add the execution data that Jacoco generates as a task output.
     // The data is a record of all the classes visited during test execution. It is self-contained; we don't need to
     // provide any source or class directories for it to "work". Those are only necessary for the report.
@@ -40,12 +42,26 @@ tasksExtendedByJacoco.all {  // Will apply to ":<subproject>:test" and ":it:appB
  * 'integTest' SourceSet to :tds. So in the future, we won't be generating empty Jacoco reports.
  */
 tasks.withType(JacocoReport).all {  // Will apply to ":<subproject>:jacocoTestReport" and ":rootJacocoReport".
-    group = 'Reports'
-    dependsOn tasksExtendedByJacoco
+    group = "Reports"
+    dependsOn tasks.withType(Test)
     
     reports {
         xml.enabled = false
         html.enabled = true
         csv.enabled = false
+    }
+    
+    // By default, JacocoReport runs onlyIf ALL of the executionData exist. We want it to run if ANY exists.
+    setOnlyIf {
+        executionData.any { it.exists() }
+    }
+    
+    // JacocoReport's @TaskAction expects everything in executionData to exist. However, by modifying onlyIf{} above,
+    // we've allowed some potentially non-existent files to creep in. We must filter them out before the task runs.
+    // Unlike most changes to an @Input property during execution, this does not break the task's UP-TO-DATE checking.
+    // Apparently, a snapshot of a FileCollection containing non-existent files is equal to a snapshot of that same
+    // FileCollection with those elements removed.
+    doFirst {
+        executionData = executionData.filter { it.exists() }
     }
 }

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -1,4 +1,4 @@
-// Gradle dependency managment.
+// Gradle dependency management.
 // This technique was inspired by: http://stackoverflow.com/questions/9547170
 
 //================================================ Repositories ================================================//
@@ -37,8 +37,6 @@ libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.3"
 libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
 libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3"
-
-libraries["gradle-extra-configurations-plugin"] = "com.netflix.nebula:gradle-extra-configurations-plugin:3.1.0"
 
 libraries["sonarqube-gradle-plugin"] = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.1"
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -32,7 +32,7 @@ ext {
 
 ////////////////////////////////////////// Plugins //////////////////////////////////////////
 
-libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.3"
+libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.5"
 
 libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
@@ -291,7 +291,7 @@ configurations.all {
                 dep.useTarget libraries["jcl-over-slf4j"]
             }
         }
-
+        
         // Use commons-collections 3.2.2 instead of 3.2.1. Pulled in by the following first-level dependencies:
         //     uk.ac.rdg.resc:edal-graphics:1.2.5-SNAPSHOT
         //     +--- net.sf.json-lib:json-lib:2.4
@@ -299,13 +299,13 @@ configurations.all {
         //     \--- org.apache.velocity:velocity:1.7
         //          +--- commons-collections:commons-collections:3.2.1
         force 'commons-collections:commons-collections:3.2.2'
-    
+        
         // Use xstream 1.4.9 instead of 1.4.8. Pulled in by the following first-level dependency:
         //     net.openhft:chronicle-map:2.4.15
         //     +--- com.thoughtworks.xstream:xstream:1.4.8
         force 'com.thoughtworks.xstream:xstream:1.4.9'
     }
-
+    
     // STAX comes with Java 1.6+. Pulled in by the following first-level dependencies:
     //     net.openhft:chronicle-map:2.4.15
     //     +--- org.codehaus.jettison:jettison:1.3.7
@@ -314,7 +314,7 @@ configurations.all {
     //     org.apache.xmlbeans:xmlbeans:2.6.0
     //     \--- stax:stax-api:1.0.1
     exclude group: 'stax', module: 'stax-api'
-
+    
     // Another SLF4J binding that we don't want. Pulled in by the following first-level dependencies:
     //     uk.ac.rdg.resc:edal-common:1.2.5-SNAPSHOT
     //     +--- org.slf4j:slf4j-log4j12:1.7.2

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -20,6 +20,7 @@ apply plugin: 'org.akhikhl.gretty'
 
 import org.akhikhl.gretty.GradleUtils
 import org.akhikhl.gretty.AppStartTask
+import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 
 gretty {
     servletContainer = 'tomcat8'  // All webapps run on Tomcat 8.
@@ -46,15 +47,20 @@ gretty {
             }
         }
         
-        // Write separate Jacoco exeuction data for the client and server components of the integration test.
+        // Write separate Jacoco execution data for the client and server components of the integration test.
         if (project.extensions.findByName('jacoco')) {  // Is the Jacoco plugin applied to the project?
-            Task integTestTask = tasks.findByName(integrationTestTask)
-            if (integTestTask) {  // Integration task exists.
-                // "jacoco" extension will be applied to these tasks if the Jacoco plugin is applied to the project.
-                integTestTask.jacoco.destinationFile =
-                        file("$buildDir/jacoco/${integrationTestTask}_client.exec")
-                appBeforeIntegrationTest.jacoco.destinationFile =
-                        file("$buildDir/jacoco/${integrationTestTask}_server.exec")
+            tasks.matching { GradleUtils.instanceOf(it, AppBeforeIntegrationTestTask.name) }.each {
+                def integTestTaskName = it.integrationTestTask
+                Task integTestTask = tasks.findByName(integTestTaskName)
+                
+                if (integTestTask) {  // Integration task exists.
+                    // Report on the AppBeforeIntegrationTestTask and integTestTask.
+                    tasks.jacocoTestReport.executionData it, integTestTask
+                    
+                    // "jacoco" extension will be applied to these tasks if the Jacoco plugin is applied to the project.
+                    it.jacoco.destinationFile = file("$buildDir/jacoco/${integTestTaskName}_server.exec")
+                    integTestTask.jacoco.destinationFile = file("$buildDir/jacoco/${integTestTaskName}_client.exec")
+                }
             }
         }
     }

--- a/gradle/any/java.gradle
+++ b/gradle/any/java.gradle
@@ -2,7 +2,6 @@ import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.java.JavaLibrary
 
 apply plugin: 'java'
-apply plugin: 'nebula.provided-base'  // Gives us the "provided" configuration.
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/gradle/any/testing.gradle
+++ b/gradle/any/testing.gradle
@@ -10,10 +10,10 @@ tasks.withType(Test).all {
     // Propagates system properties set on the Gradle process to the test executors.
     addFilteredSysProps(systemProperties)
     
-    if (isTravis) {
-        ignoreFailures = false  // On Travis, abort the build if any tests fail.
+    if (isJenkins) {
+        ignoreFailures = true   // On Jenkins, don't let test failures abort the build; we want the full test report.
     } else {
-        ignoreFailures = true   // In every other environment, don't let test failures abort the build.
+        ignoreFailures = false  // Otherwise, abort at the first sign of failure.
     }
     
     useJUnit {

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -27,45 +27,13 @@ gradle.projectsEvaluated {  // Several statements below rely upon all subproject
         
         // Ditto for class directories.
         classDirectories = files('buildSrc/build/classes/main', allSubprojectClassDirs)
+    
+        Closure isExtendedByJacoco = { Task task -> task.extensions.findByType(JacocoTaskExtension) }
+        Collection<Task> tasksExtendedByJacoco = subprojects*.tasks*.matching(isExtendedByJacoco).flatten()
+        Collection<File> subprojectExeData = tasksExtendedByJacoco*.jacoco*.destinationFile
         
-        // :buildSrc:test always runs and produces execution data, no matter what.
-        assert file('buildSrc/build/jacoco/test.exec').exists(): "Can't find :buildSrc Jacoco execution data."
-        
-        // By default, JacocoReport will be skipped if ANY of its executionData are non-existent: http://goo.gl/pHuwyg
-        // So, we're going to start off with the only executionData we KNOW exists. As for the subprojects'
-        // executionData, we won't know what's available until after they run their 'test' tasks (if they run at all).
-        // So, delay that config until doFirst{}, which will run during Gradle's execution phase.
-        executionData = files('buildSrc/build/jacoco/test.exec')
-        
-        // Causes rootJacocoReport to always be executed. This is necessary because JacocoReport uses executionData as
-        // one of its Inputs, and by assigning an incomplete set above, the normal UP-TO-DATE machinery has been
-        // subverted. As a result, rootJacocoReport can't properly determine when subprojects have generated new
-        // coverage data (it thinks its executionData Inputs are always UP-TO-DATE). We'll try to detect those
-        // changes manually below.
-        outputs.upToDateWhen { false } // Evaluated at configuration time (onlyIf{} is evaluated at execution time)
-        
-        // This closure will be run during the execution phase, after the subproject test tasks.
-        // Therefore, we can trust that execution data for those tasks will have been generated.
-        doFirst {
-            Closure isExtendedByJacoco = { Task task -> task.extensions.findByType(JacocoTaskExtension) }
-            Collection<Task> tasksExtendedByJacoco = subprojects*.tasks*.matching(isExtendedByJacoco).flatten()
-            Collection<File> exeData = tasksExtendedByJacoco*.jacoco*.destinationFile
-            
-            // Add all subproject executionData that actually exist.
-            executionData = executionData + files(exeData.findAll { it.exists() })
-            
-            boolean allOutputsExist = outputs.files.every { it.exists() }
-            boolean anyJacocoTaskDidWork = tasksExtendedByJacoco.any { it.didWork }
-            
-            // Skip task if all outputs exist (previously generated) and no Jacoco tasks did any work (meaning that
-            // the Inputs didn't change). This manual UP-TO-DATE checking is certainly inferior to Gradle's built-in
-            // machinery (this doesn't detect modifications to outputs, for example), but it's good enough given the
-            // circumstances. The long-term solution may be to reimplement JacocoReport with the troublesome elements
-            // removed.
-            if (allOutputsExist && !anyJacocoTaskDidWork) {
-                throw new StopExecutionException("SKIPPING $name: outputs already exist and no Jacoco tasks did work.")
-            }
-        }
+        // Some of subprojectExeData may not exist. That's okay! Only existing executionData are passed to Ant task.
+        executionData = files('buildSrc/build/jacoco/test.exec', subprojectExeData)
     }
     
     apply plugin: "com.github.kt3k.coveralls"

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -1,6 +1,11 @@
-description = "TDS - NetCDF-Java library integration Test module. This module contains all classes and settings " +
-        "needed to test the NetCDF-Java library in a servlet container. Starts up a TDS server and then sends " +
-        "requests to it. Relies on having access to cdmUnitTest directory, so can only be run at Unidata."
+import javax.xml.transform.TransformerFactory
+
+description = """
+    TDS - NetCDF-Java library integration Test module. This module contains all classes and settings
+    needed to test the NetCDF-Java library in a servlet container. Starts up a TDS server and then sends
+    requests to it. Relies on having access to cdmUnitTest directory, so can only be run at Unidata.
+""".replaceAll("\\s+", " ").trim()
+
 ext.title = "Test Integration"
 ext.url = "https://www.unidata.ucar.edu/software/thredds/current/tds/TDS.html"
 
@@ -11,11 +16,15 @@ apply from: "$rootDir/gradle/any/coverage.gradle"
 // 'it' is not published
 apply from: "$rootDir/gradle/any/gretty.gradle"
 
+apply plugin: 'groovy'  // For Spock tests.
+
 dependencies {
     testCompile project(":cdm")
     testCompile project(":httpservices")
     testCompile project(":tdcommon")
-    testCompile project(":tds")
+    testCompile(project(":tds")) {
+        exclude module: "log4j-slf4j-impl"  // We don't want TDS's logger binding.
+    }
     
     testRuntime project(":clcommon")
     testRuntime project(":grib")
@@ -32,8 +41,13 @@ dependencies {
     testCompile libraries["commons-lang3"]
     testCompile libraries["spring-context"]
     testCompile libraries["slf4j-api"]
+    testCompile libraries["xmlunit-core"]  // For comparing catalog XML.
     
     testRuntime libraries["jaxen"]
+    
+    // These are for Spock.
+    testCompile libraries["groovy-all"]
+    testCompile libraries["spock-core"]
     
     // Unlike the other subprojects, we do not need to add an SLF4J binding to testRuntime;
     // we're overlaying tds (see below), so we're already getting the binding that it declares.
@@ -59,4 +73,78 @@ gretty {
     // The normal 'test' task added by the Java plugin has nothing to do in this subproject, because every single
     // test requires a running TDS. Therefore, we're repurposing the 'test' task for integration testing.
     integrationTestTask = 'test'
+}
+
+////////////////////////////////////// Test fresh TDS installation //////////////////////////////////////
+
+// We use this variable in dynamic method and property names below. See https://goo.gl/NKg6tW.
+// It's deep, dark, Groovy magic to be sure. And while cool, it probably hurts readability here.
+// I did it to prove that we could create a custom Test task and its supporting sourceSets and setup/teardown tasks
+// in a generic, reusable way.
+String taskName = "freshInstallTest"
+
+sourceSets {
+    "$taskName" {
+        groovy.srcDir file("src/$taskName/groovy")
+        resources.srcDir file("src/$taskName/resources")
+    
+        // Need 'sourceSets.test.output' because we use TestWithLocalServer in our test.
+        compileClasspath += sourceSets.test.output + configurations.testCompile
+        runtimeClasspath += output + sourceSets.test.output + configurations.testRuntime
+    }
+}
+
+task "before${taskName.capitalize()}"(type: org.akhikhl.gretty.AppBeforeIntegrationTestTask, group: "gretty") {
+    description = "Starts server before $taskName."
+    integrationTestTask taskName
+    
+    gretty.afterEvaluate {
+        mustRunAfter tasks.appAfterIntegrationTest  // Make sure the server is shut down before we start it back up!
+    }
+    
+    debug = false  // Start the embedded sever in debug mode.
+    ext.nonExistentContentDir = new File(temporaryDir, "content")
+    
+    // AppBeforeIntegrationTestTask also has a 'systemProperties' field, but the content of 'gretty.systemProperties'
+    // will take precedence. 'gretty.systemProperties' has a 'tds.content.root.path' value that is appropriate for
+    // :it:test, but not for taskName. The only way to override it is with this closure.
+    // See http://akhikhl.github.io/gretty-doc/Gretty-task-classes.html#_property_inheritance_override
+    prepareServerConfig {
+        // The embedded TDS that this task launches will have a non-existent content root directory.
+        systemProperty "tds.content.root.path", nonExistentContentDir.absolutePath
+    }
+    
+    doFirst {
+        // Before starting the server, delete the content directory if it exists, as it may have been created by a
+        // previous task run. This is safe to use on non-existent files; see GroovyDoc at https://goo.gl/dbxTVZ.
+        // Also, it's okay to put this statement in an assert, because asserts are always enabled in Groovy.
+        assert nonExistentContentDir.deleteDir() : "Couldn't delete $nonExistentContentDir."
+    }
+}
+
+task "$taskName"(type: Test, group: "verification") {
+    description = "Runs tests on a fresh installation of TDS (no existing catalog.xml)."
+    testClassesDir = sourceSets."$taskName".output.classesDir
+    classpath = sourceSets."$taskName".runtimeClasspath
+    mustRunAfter tasks.test
+    
+    // Use built-in Xalan XSLT instead of Saxon-HE, which our 'project(":tds")' dependency drags in.
+    // This works around an error we were seeing in org.xmlunit.builder.DiffBuilder.build():
+    //    java.lang.ClassCastException: net.sf.saxon.value.ObjectValue cannot be cast to net.sf.saxon.om.NodeInfo
+    //        ...
+    //        at thredds.tds.FreshTdsInstallSpec.TDS returns expected client catalog(FreshTdsInstallSpec.groovy:58)
+    // See buildSrc/build.gradle for another example of working around JAXP weirdness.
+    systemProperty TransformerFactory.name,  // See javax.xml.transform.TransformerFactory.newInstance().
+                   "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
+
+    // Replace the system property that was propagated from the Gradle process in any/testing.gradle.
+    // It is meant for :it:test only.
+    systemProperty "tds.content.root.path", tasks."before${taskName.capitalize()}".nonExistentContentDir.absolutePath
+}
+
+check.dependsOn taskName
+
+task "after${taskName.capitalize()}"(type: org.akhikhl.gretty.AppAfterIntegrationTestTask, group: "gretty") {
+    description = "Stops server after $taskName."
+    integrationTestTask taskName
 }

--- a/it/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
+++ b/it/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
@@ -1,0 +1,73 @@
+package thredds.tds
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.xmlunit.builder.DiffBuilder
+import org.xmlunit.builder.Input
+import org.xmlunit.diff.Diff
+import spock.lang.Specification
+import thredds.TestWithLocalServer
+import thredds.util.ContentType
+
+import java.nio.charset.Charset
+
+/**
+ * Tests a fresh installation of TDS. An installation is considered "fresh" if the "tds.content.root.path" property:
+ *   - points to a non-existent directory. In this case, TDS will create that directory, if it can.
+ *   - points to an existing directory that does not contain a "catalog.xml" file.
+ *
+ * @author cwardgar
+ * @since 2017-04-21
+ */
+class FreshTdsInstallSpec extends Specification {
+    static Logger logger = LoggerFactory.getLogger(FreshTdsInstallSpec.name)
+    
+    String propName = "tds.content.root.path"
+    
+    def "TDS copies over default startup files"() {
+        setup: "determine 'threddsDirectory', which is a sub-directory of '$propName'"
+        String contentRootPath = System.properties[propName]
+        assert contentRootPath : "'$propName' wasn't set"
+        File threddsDirectory = new File(contentRootPath, "thredds")
+        
+        expect: "TDS created 'threddsDirectory'"
+        threddsDirectory.exists()
+        
+        and: "it copied over the default startup files"
+        // See TdsContext.afterPropertiesSet(), in the "Copy default startup files, if necessary" section.
+        new File(threddsDirectory, "catalog.xml").exists()
+        new File(threddsDirectory, "enhancedCatalog.xml").exists()
+        new File(new File(threddsDirectory, "public"), "testdata").exists()
+        new File(threddsDirectory, "threddsConfig.xml").exists()
+        new File(threddsDirectory, "wmsConfig.xml").exists()
+        new File(threddsDirectory, "wmsConfig.dtd").exists()
+        
+        and: "it created the 'logs' directory"
+        new File(threddsDirectory, "logs").exists()
+    }
+    
+    def "TDS returns expected client catalog"() {
+        setup: "Identify control file for this test. It's located in src/freshInstallTest/resources/thredds/tds/"
+        String controlFileName = 'enhancedCatalog.xml'
+        
+        and: "retrieve the sever base URI (set by Gretty) and construct catalog endpoint with it"
+        String preferredBaseURI = System.properties["gretty.preferredBaseURI"]
+        assert preferredBaseURI : "'$preferredBaseURI' wasn't set"
+        String endpoint = "$preferredBaseURI/catalog/enhancedCatalog.xml"
+        
+        expect: "server responds with HTTP code 200 and XML content. method contains JUnit assertions"
+        byte[] response = TestWithLocalServer.getContent(endpoint, 200, ContentType.xml)
+        
+        when: "compare expected XML (read from test resource) with server response, ignoring comments and whitespace"
+        Diff diff = DiffBuilder.compare(Input.fromStream(getClass().getResourceAsStream(controlFileName)))
+                               .withTest(Input.fromByteArray(response))
+                               .ignoreComments().normalizeWhitespace().build()
+    
+        then: "there will be no difference between the two"
+        boolean noDiffs = !diff.hasDifferences()
+        if (!noDiffs) {
+            logger.error("Actual XML:\n{}", new String(response, Charset.forName("UTF-8")))
+        }
+        noDiffs
+    }
+}

--- a/it/src/freshInstallTest/resources/thredds/tds/enhancedCatalog.xml
+++ b/it/src/freshInstallTest/resources/thredds/tds/enhancedCatalog.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" xmlns:xlink="http://www.w3.org/1999/xlink" name="Unidata THREDDS-IDD NetCDF-OpenDAP Server" version="1.2">
+  <service name="latest" serviceType="Resolver" base="" />
+  <service name="both" serviceType="Compound" base="">
+    <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/" />
+    <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/" />
+  </service>
+  <dataset name="NCEP Model Data">
+    <metadata inherited="true">
+      <serviceName>both</serviceName>
+      <authority>edu.ucar.unidata</authority>
+      <dataType>Grid</dataType>
+      <dataFormat>NetCDF</dataFormat>
+      <documentation type="rights">Freely available</documentation>
+      <documentation xlink:href="http://www.emc.ncep.noaa.gov/modelinfo/index.html" xlink:title="NCEP Model documentation" />
+      <creator>
+        <name vocabulary="DIF">DOC/NOAA/NWS/NCEP</name>
+        <contact url="http://www.ncep.noaa.gov/" email="http://www.ncep.noaa.gov/mail_liaison.shtml" />
+      </creator>
+      <publisher>
+        <name vocabulary="DIF">UCAR/UNIDATA</name>
+        <contact url="http://www.unidata.ucar.edu/" email="support@unidata.ucar.edu" />
+      </publisher>
+      <timeCoverage>
+        <end>present</end>
+        <duration>14 days</duration>
+      </timeCoverage>
+    </metadata>
+    <catalogRef xlink:href="/thredds/catalog/testEnhanced/catalog.xml" xlink:title="ETA Data" ID="testEnhanced" name="ETA Data" harvest="true">
+      <property name="DatasetScan" value="true" />
+      <metadata inherited="true">
+        <documentation type="summary">NCEP North American Model : AWIPS 211 (Q) Regional - CONUS (Lambert Conformal). Model runs are made at 12Z and 00Z, with analysis and forecasts every 6 hours out to 60 hours. Horizontal = 93 by 65 points, resolution 81.27 km, LambertConformal projection. Vertical = 1000 to 100 hPa pressure levels.</documentation>
+        <geospatialCoverage zpositive="up">
+          <northsouth>
+            <start>26.92475</start>
+            <size>15.9778</size>
+            <units>degrees_north</units>
+          </northsouth>
+          <eastwest>
+            <start>-135.33123</start>
+            <size>103.78772</size>
+            <units>degrees_east</units>
+          </eastwest>
+          <updown>
+            <start>0.0</start>
+            <size>0.0</size>
+            <units>km</units>
+          </updown>
+        </geospatialCoverage>
+        <variables vocabulary="GRIB-1" />
+        <variables vocabulary="">
+          <variable name="Z_sfc" vocabulary_name="" units="gp m">Geopotential height, gpm</variable>
+        </variables>
+      </metadata>
+    </catalogRef>
+  </dataset>
+</catalog>

--- a/netcdf4/build.gradle
+++ b/netcdf4/build.gradle
@@ -35,9 +35,8 @@ sourceSets {
     }
 }
 
-task unloadedTest(type: Test) {
+task unloadedTest(type: Test, group: "verification") {
     description = 'Runs tests without the native C library loaded.'
-    group = 'verification'
     testClassesDir = sourceSets.unloadedTest.output.classesDir
     classpath = sourceSets.unloadedTest.runtimeClasspath
     mustRunAfter tasks.test

--- a/opendap/build.gradle
+++ b/opendap/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':cdm')
     compile project(':httpservices')
 
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["jdom2"]
     compile libraries["httpclient"]
     compile libraries["httpcore"]

--- a/opendap/dtswar/build.gradle
+++ b/opendap/dtswar/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compile project(':cdm')
     compile project(':opendap')
 
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     runtime libraries["taglibs-standard-spec"]
     runtime libraries["taglibs-standard-impl"]
 

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile project(':dap4:d4lib')
 
     // Server stuff
-    providedCompile libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     runtime libraries["taglibs-standard-spec"]
     runtime libraries["taglibs-standard-impl"]
 


### PR DESCRIPTION
An installation is considered "fresh" if the `tds.content.root.path` property:
* points to a non-existent directory. In this case, TDS will create that directory, if it can.
* points to an existing directory that does not contain a "catalog.xml" file.

The tests ensure that default startup files are copied over and we can resolve the top-level catalog.xml.

Also:
* Improved Jacoco reporting.
* Replaced use of 'provided' configuration with 'compileOnly'.

See individual commits for more detail.