### PR TITLE
Added -D controls for HTTPSession timeouts

### DIFF
--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
@@ -94,7 +94,7 @@ class ToolsUiJnlpBaseTaskSpec extends Specification {
             buildscript {
                 dependencies {
                     // Need this in order to resolve ToolsUiJnlpBaseTask.
-                    String buildSrcClasspathAsCsvString = '${buildSrcClasspath.join(',').replace('\\\\', '/')}'
+                    String buildSrcClasspathAsCsvString = '${buildSrcClasspath.join(',').replace('\\', '/')}'
                     classpath files(buildSrcClasspathAsCsvString.split(','))
                 }
             }

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
@@ -91,7 +91,7 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
             buildscript {
                 dependencies {
                     // Need this in order to resolve ToolsUiJnlpExtensionTask.
-                    String buildSrcClasspathAsCsvString = '${buildSrcClasspath.join(',').replace('\\\\', '/')}'
+                    String buildSrcClasspathAsCsvString = '${buildSrcClasspath.join(',').replace('\\', '/')}'
                     classpath files(buildSrcClasspathAsCsvString.split(','))
                 }
             }

--- a/docs/website/netcdf-java/reference/httpservices.html
+++ b/docs/website/netcdf-java/reference/httpservices.html
@@ -225,6 +225,17 @@ command line using the following JVM parameters.
 This flag is a URL that specifies the proxy.
 <p>
 
+<h4>Miscellaneous -D Flags</h4>
+It is possible to control the value of certain other session
+parameters using the following -D flags as arguments to the
+JVM. These can be set for a client and/or a server.
+
+<table>
+<tr><th>-D Flag<th>Description
+<tr><td>tds.http.conntimeout<td>Connection timeout in seconds
+<tr><td>tds.http.sotimeout<td>Socket timeout in seconds
+</table>
+
 <h3><a name="HTTPMethod">HTTPMethod</a></h3>
 This class encapsulates the information
 about a given method request and response.


### PR DESCRIPTION
Added some JVM -D flags to control the behavior of HTTPSession.
Specifically, added the following two flags:
1. -Dtds.http.conntimeout - set the timout (in seconds) for initial connection to a server
2. -Dtds.http.sotimeout - set the timeout (in seconds) for read requests on a socket

