### PR TITLE
Fix bug in NCheader checkFileType.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/NCheader.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/NCheader.java
@@ -5,16 +5,11 @@
 
 package ucar.nc2.iosp;
 
-import ucar.ma2.*;
-import ucar.nc2.*;
-import ucar.nc2.constants.CDM;
-import ucar.unidata.io.RandomAccessFile;
-
-import java.util.*;
 import java.io.IOException;
 
 /**
  * Common header for netcdf3, netcdf4, hdf5, hdf4.
+ *
  * @author dmh
  */
 
@@ -24,20 +19,20 @@ public class NCheader
     // Constants
 
     // Constants for check_file_type
-    static private final int MAGIC_NUMBER_LEN = 4;
+    static private final int MAGIC_NUMBER_LEN = 8;
     static private final long MAXHEADERPOS = 50000; // header's gotta be within this range
 
-    static private final byte[] H5HEAD = {(byte)0x89, 'H', 'D', 'F'};
+    static private final byte[] H5HEAD = {(byte) 0x89, 'H', 'D', 'F', '\r', '\n', (byte) 0x1a, '\n'};
 
     // These should match the constants in netcdf-c/include/netcdf.h
-    static public final int  NC_FORMAT_NETCDF3 = (1);
-    static public final int  NC_FORMAT_64BIT_OFFSET = (2);
-    static public final int  NC_FORMAT_NETCDF4 = (3);
-    static public final int  NC_FORMAT_NETCDF4_CLASSIC = (4);
-    static public final int  NC_FORMAT_64BIT_DATA = (5);
+    static public final int NC_FORMAT_NETCDF3 = (1);
+    static public final int NC_FORMAT_64BIT_OFFSET = (2);
+    static public final int NC_FORMAT_NETCDF4 = (3);
+    static public final int NC_FORMAT_NETCDF4_CLASSIC = (4);
+    static public final int NC_FORMAT_64BIT_DATA = (5);
 
     // Extensions
-    static public final int  NC_FORMAT_HDF4 = (0x7005);
+    static public final int NC_FORMAT_HDF4 = (0x7005);
 
     // Aliases
     static public final int NC_FORMAT_CLASSIC = (NC_FORMAT_NETCDF3);
@@ -50,50 +45,54 @@ public class NCheader
 
     static public int
     checkFileType(ucar.unidata.io.RandomAccessFile raf)
-	throws IOException
+            throws IOException
     {
         byte[] magic = new byte[MAGIC_NUMBER_LEN];
 
-	// If this is not an HDF5 file, then the magic number is at
-	// position 0; If it is an HDF5/4 file, then we need to search
-	// forward for it.
+        // If this is not an HDF5 file, then the magic number is at
+        // position 0; If it is an HDF5/4 file, then we need to search
+        // forward for it.
 
-	// Look for the relevant leading tag
-	raf.seek(0);
-	if(raf.readBytes(magic, 0, MAGIC_NUMBER_LEN) < MAGIC_NUMBER_LEN)
-	return 0; // unknown
-	// Some version of CDF
-	if(magic[0] == (byte)'C'
-	   && magic[1] == (byte)'D'
-	   && magic[2] == (byte)'F') {
-	    if(magic[3] == 0x01) return NC_FORMAT_CLASSIC;
-	    if(magic[3] == 0x02) return NC_FORMAT_64BIT_OFFSET;
-	    if(magic[3] == 0x05) return NC_FORMAT_CDF5;
-	    return 0; // unknown
-	}
-	// For HDF5/4, we need to search forward
-	long filePos = 0;
-	long size = raf.length();
-	while ((filePos < size - 8) && (filePos < MAXHEADERPOS)) {
-	    raf.seek(filePos);
-	    if(raf.readBytes(magic, 0, MAGIC_NUMBER_LEN) < MAGIC_NUMBER_LEN)
-		return 0; // unknown
-	    // Test for HDF5
-	    if(magic[0] == (byte)0x89
-	       && magic[1] == (byte)'H'
-	       && magic[2] == (byte)'D'
-	       && magic[3] == (byte)'F') {
-		return NC_FORMAT_HDF5;
-	    }
-	    // HDF4
-	    if(magic[0] == (byte)0x0e
-	       && magic[1] == (byte)0x03
-	       && magic[2] == (byte)0x13
-	       && magic[3] == (byte)0x01) {
-		return NC_FORMAT_HDF4;
-	    }
-	    filePos = (filePos == 0) ? 512 : 2 * filePos;
-	}
-	return 0;
+        // Look for the relevant leading tag
+        raf.seek(0);
+        if(raf.readBytes(magic, 0, MAGIC_NUMBER_LEN) < MAGIC_NUMBER_LEN)
+            return 0; // unknown
+        // Some version of CDF
+        if(magic[0] == (byte) 'C'
+                && magic[1] == (byte) 'D'
+                && magic[2] == (byte) 'F') {
+            if(magic[3] == 0x01) return NC_FORMAT_CLASSIC;
+            if(magic[3] == 0x02) return NC_FORMAT_64BIT_OFFSET;
+            if(magic[3] == 0x05) return NC_FORMAT_CDF5;
+            return 0; // unknown
+        }
+        // For HDF5/4, we need to search forward
+        long filePos = 0;
+        long size = raf.length();
+        while((filePos < size - 8) && (filePos < MAXHEADERPOS)) {
+            boolean match;
+            raf.seek(filePos);
+            if(raf.readBytes(magic, 0, MAGIC_NUMBER_LEN) < MAGIC_NUMBER_LEN)
+                return 0; // unknown
+            // Test for HDF5; Need to use full set of Header bytes
+            match = true;
+            for(int i = 0; i < H5HEAD.length; i++) {
+                if(magic[i] != H5HEAD[i]) {
+                    match = false;
+                    break;
+                }
+            }
+            if(match)
+                return NC_FORMAT_HDF5;
+            // Try HDF4
+            if(magic[0] == (byte) 0x0e
+                    && magic[1] == (byte) 0x03
+                    && magic[2] == (byte) 0x13
+                    && magic[3] == (byte) 0x01) {
+                return NC_FORMAT_HDF4;
+            }
+            filePos = (filePos == 0) ? 512 : 2 * filePos;
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
Currently we check for a subset of the HDF5 magic header bytes,
but (re e-support (UBS-599337) bug) apparently it is possible,
though unlikely, that this is not enough to detect a corrupted HDF5 file.
Hence change NCheader to do the full check for HDF5.