### PR TITLE
set content length for NCSS grid return

### DIFF
--- a/tdcommon/src/main/java/thredds/util/Constants.java
+++ b/tdcommon/src/main/java/thredds/util/Constants.java
@@ -1,37 +1,11 @@
 /*
- * Copyright 1998-2014 University Corporation for Atmospheric Research/Unidata
- *
- *   Portions of this software were developed by the Unidata Program at the
- *   University Corporation for Atmospheric Research.
- *
- *   Access and use of this software shall impose the following obligations
- *   and understandings on the user. The user is granted the right, without
- *   any fee or cost, to use, copy, modify, alter, enhance and distribute
- *   this software, and any derivative works thereof, and its supporting
- *   documentation for any purpose whatsoever, provided that this entire
- *   notice appears in all copies of the software, derivative works and
- *   supporting documentation.  Further, UCAR requests that the user credit
- *   UCAR/Unidata in any publications that result from the use of this
- *   software or in any product that includes this software. The names UCAR
- *   and/or Unidata, however, may not be used in any advertising or publicity
- *   to endorse or promote any products or commercial entity unless specific
- *   written permission is obtained from UCAR/Unidata. The user also
- *   understands that UCAR/Unidata is not obligated to provide the user with
- *   any support, consulting, training or assistance of any kind with regard
- *   to the use, operation and performance of this software nor to provide
- *   the user with any updates, revisions, new versions or "bug fixes."
- *
- *   THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *   DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *   INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *   FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *   NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *   WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Copyright (c) 1998-2017 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
  */
 
 package thredds.util;
+
+import java.io.File;
 
 /**
  * Server side constants
@@ -42,9 +16,22 @@ package thredds.util;
 public class Constants {
   public static final String Content_Disposition = "Content-Disposition";
 
+  public static final String Content_Length = "Content-Length";
+
   //       res.setHeader("Content-Disposition", "attachment; filename=" + path + ".nc");
   public static String setContentDispositionValue(String filename) {
     return "attachment; filename=" + filename;
+  }
+
+  /**
+   *
+   * Get the string value of the file size in bytes
+   *
+   * @param file file object of the file to be returned
+   * @return size of file in bytes
+   */
+  public static String getContentLengthValue(File file) {
+    return Long.toString(file.length());
   }
 
     //       res.setHeader("Content-Disposition", "attachment; filename=" + path + ".nc");

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -1,35 +1,8 @@
 /*
- * Copyright 1998-2015 John Caron and University Corporation for Atmospheric Research/Unidata
- *
- *  Portions of this software were developed by the Unidata Program at the
- *  University Corporation for Atmospheric Research.
- *
- *  Access and use of this software shall impose the following obligations
- *  and understandings on the user. The user is granted the right, without
- *  any fee or cost, to use, copy, modify, alter, enhance and distribute
- *  this software, and any derivative works thereof, and its supporting
- *  documentation for any purpose whatsoever, provided that this entire
- *  notice appears in all copies of the software, derivative works and
- *  supporting documentation.  Further, UCAR requests that the user credit
- *  UCAR/Unidata in any publications that result from the use of this
- *  software or in any product that includes this software. The names UCAR
- *  and/or Unidata, however, may not be used in any advertising or publicity
- *  to endorse or promote any products or commercial entity unless specific
- *  written permission is obtained from UCAR/Unidata. The user also
- *  understands that UCAR/Unidata is not obligated to provide the user with
- *  any support, consulting, training or assistance of any kind with regard
- *  to the use, operation and performance of this software nor to provide
- *  the user with any updates, revisions, new versions or "bug fixes."
- *
- *  THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *  INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *  WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Copyright (c) 1998-2017 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
  */
+
 package thredds.server.ncss.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,6 +125,10 @@ public class NcssGridController extends AbstractNcssController {
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.set(ContentType.HEADER, sf.getMimeType());
     httpHeaders.set(Constants.Content_Disposition, Constants.setContentDispositionValue(filename));
+
+    // set content length
+    httpHeaders.set(Constants.Content_Length, Constants.getContentLengthValue(netcdfResult));
+
     setResponseHeaders(res, httpHeaders);
 
     IO.copyFileB(netcdfResult, res.getOutputStream(), 60000);


### PR DESCRIPTION
Fixes one part of Unidata/thredds#849

It is not clear how to go about setting content-length on the Grid As Point service of NCSS, as the content headers appear to be set [before](https://github.com/Unidata/thredds/blob/5.0.0/tds/src/main/java/thredds/server/ncss/controller/NcssPointController.java#L123) the file is generated.

