### PR TITLE
Fix inconsistent representation for Grib Level

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
@@ -429,13 +429,11 @@ public class Grib2Iosp extends GribIosp {
     Grib2Customizer.Parameter entry = cust.getParameter(vindex.getDiscipline(), vindex.getCategory(), vindex.getParameter());
     if (entry != null) v.addAttribute(new Attribute("Grib2_Parameter_Name", entry.getName()));
 
-    if (vindex.getLevelType() != GribNumbers.MISSING) {
-      String levelTypeName = cust.getLevelName(vindex.getLevelType());
-      if (levelTypeName != null)
-        v.addAttribute(new Attribute("Grib2_Level_Type", levelTypeName));
-      else
-        v.addAttribute(new Attribute("Grib2_Level_Type", vindex.getLevelType()));
-    }
+    if (vindex.getLevelType() != GribNumbers.MISSING)
+      v.addAttribute(new Attribute("Grib2_Level_Type", vindex.getLevelType()));
+    String ldesc = cust.getLevelName(vindex.getLevelType());
+    if (ldesc != null)
+      v.addAttribute(new Attribute("Grib2_Level_Desc", ldesc));
 
     if (vindex.getEnsDerivedType() >= 0)
       v.addAttribute(new Attribute("Grib2_Ensemble_Derived_Type", vindex.getEnsDerivedType()));


### PR DESCRIPTION
Addresses Unidata/thredds#853

Grib1_Level_Type and Grib2_Level_Type were not consistent. Grib2_Level_Type was
the String description of the level, which is actual the analog of Grib1_Level_Desc.

Adds new attribute, Grib2_Level_Desc, and makes Grib2_Level_Type the integer code
value, just link Grib1_Level_Type.