### PR TITLE
BUG: Fix geostationary projection (Fixes #799)

### DIFF
--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
@@ -71,6 +71,7 @@ public class GEOSTransform {
 
   double sub_lon;
   double sub_lon_degrees;
+  double sat_height;
 
   public String scan_geom = GEOS;
 
@@ -148,6 +149,7 @@ public class GEOSTransform {
     } else if (scan_geom.equals(GOES)) {
       h = h_goesr;
     }
+    this.sat_height = h - r_eq;
 
     d = h * h - r_eq * r_eq;
   }
@@ -156,6 +158,7 @@ public class GEOSTransform {
     this.sub_lon_degrees = subLonDegrees;
     this.sub_lon = sub_lon_degrees * DEG_TO_RAD;
     this.scan_geom = scan_geom;
+    this.sat_height = perspective_point_height;
 
     r_pol = geoid.r_pol;
     r_eq = geoid.r_eq;

--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -147,7 +147,7 @@ public class Geostationary extends ProjectionImpl {
     addParameter(CF.GRID_MAPPING_NAME, NAME);
     addParameter(CF.LONGITUDE_OF_PROJECTION_ORIGIN, navigation.sub_lon_degrees);
     addParameter(CF.LATITUDE_OF_PROJECTION_ORIGIN, 0.0);
-    // addParameter(CF.PERSPECTIVE_POINT_HEIGHT, navigation.sub_lon_degrees);   LOOK NOT USED ??
+    addParameter(CF.PERSPECTIVE_POINT_HEIGHT, navigation.sat_height * 1000.0);
     addParameter(CF.SWEEP_ANGLE_AXIS, navigation.scan_geom.equals(GEOSTransform.GOES) ? "x" : "y");
     addParameter(CF.SEMI_MAJOR_AXIS, navigation.r_eq * 1000.0);
     addParameter(CF.SEMI_MINOR_AXIS, navigation.r_pol * 1000.0);


### PR DESCRIPTION
While files with this projection would show their coordinate system
properly understood by toolsUI, NCSS would complain as the projection
was recreated from the internal object--dropping the perspective point.

Of course this problem traces back to a LOOK line.

cherry-pick of Unidata/thredds#869