### PR TITLE
Allow default cache sizes of Variables to be modified by user.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/Variable.java
+++ b/cdm/src/main/java/ucar/nc2/Variable.java
@@ -66,8 +66,8 @@ public class Variable extends CDMNode implements VariableIF, ProxyReader, Attrib
    */
   static public boolean permitCaching = true;
 
-  static public final int defaultSizeToCache = 4000; // bytes  cache any variable whose size() < defaultSizeToCache
-  static public final int defaultCoordsSizeToCache = 40 * 1000; // bytes cache coordinate variable whose size() < defaultSizeToCache
+  static public int defaultSizeToCache = 4000; // bytes  cache any variable whose size() < defaultSizeToCache
+  static public int defaultCoordsSizeToCache = 40 * 1000; // bytes cache coordinate variable whose size() < defaultSizeToCache
 
   static protected boolean debugCaching = false;
   static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Variable.class);

--- a/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis.java
@@ -73,7 +73,7 @@ import java.util.Formatter;
 
 public class CoordinateAxis extends VariableDS {
   static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CoordinateAxis.class);
-  static private final int axisSizeToCache = 100 * 1000; // bytes
+  static public int axisSizeToCache = 100 * 1000; // bytes
 
   protected NetcdfDataset ncd; // container dataset
   protected AxisType axisType = null;


### PR DESCRIPTION
* Variables need to be static, public, and non-final.
* From the [mailing list](http://www.unidata.ucar.edu/mailing_lists/archives/netcdf-java/2017/msg00054.html).