### PR TITLE
ENH: Set grid_mapping for GINI data

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/gini/TestGini.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/gini/TestGini.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
+import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.constants.CDM;
@@ -102,6 +103,14 @@ public class TestGini{
             Assert.assertNotNull(v);
             Assert.assertNotNull(v.getDimension(0));
             Assert.assertNotNull(v.getDimension(1));
+
+            // Make sure the variable has a grid mapping set and that it points
+            // to a valid variable
+            Attribute grid_mapping = v.findAttribute("grid_mapping");
+            Assert.assertNotNull(grid_mapping);
+            Variable proj_var = ncfile.findVariable(grid_mapping.getStringValue());
+            Assert.assertNotNull(proj_var);
+            Assert.assertNotNull(proj_var.findAttribute("grid_mapping_name"));
 
             // Check size
             Assert.assertEquals(ySize,

--- a/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/clcommon/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -219,18 +219,7 @@ class Giniheader {
     bos.get();   /* skip a byte for hundreds of seconds */
 
     nv = bos.get();
-    att = new Attribute("ProjIndex", nv);
-    ncfile.addAttribute(null, att);
     proj = nv.intValue();
-    if (proj == 1) {
-      att = new Attribute("ProjName", "MERCATOR");
-    } else if (proj == 3) {
-      att = new Attribute("ProjName", "LAMBERT_CONFORNAL");
-    } else if (proj == 5) {
-      att = new Attribute("ProjName", "POLARSTEREOGRAPHIC");
-    }
-
-    ncfile.addAttribute(null, att);
 
     /*
     ** Get grid dimensions
@@ -558,6 +547,8 @@ class Giniheader {
 
     ncfile.addVariable(null, ct);
     ncfile.addAttribute(null, new Attribute(CDM.CONVENTIONS, _Coordinate.Convention));
+
+    var.addAttribute(new Attribute(CF.GRID_MAPPING, ct.getFullName()));
 
     // finish
     ncfile.finish();


### PR DESCRIPTION
Previously it was only setting a file level attribute, which isn't CF-compatible.

I don't have the test data handy, but I can confirm that other GINI files I have locally work fine.