### PR TITLE
Read Fmrc directly from string

### DIFF
--- a/cdm/src/main/java/thredds/inventory/NcmlCollectionReader.java
+++ b/cdm/src/main/java/thredds/inventory/NcmlCollectionReader.java
@@ -38,6 +38,30 @@ public class NcmlCollectionReader {
   static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NcmlCollectionReader.class);
 
   private Namespace ncmlNS;
+  
+  /**
+   * Read an NcML file from a String, and construct a NcmlCollectionReader from its scan or scanFmrc element.
+   *
+   * @param ncmlString the NcML to construct the reader from
+   * @param errlog put error messages here
+   * @return the resulting NetcdfDataset
+   * @throws IOException on read error, or bad referencedDatasetUri URI
+   */
+  static public NcmlCollectionReader readNcML(String ncmlString, Formatter errlog) throws IOException {
+      StringReader reader = new StringReader(ncmlString);
+      
+      org.jdom2.Document doc;
+      try {
+        SAXBuilder builder = new SAXBuilder();
+        if (debugURL) System.out.println(" NetcdfDataset NcML String = <" + ncmlString + ">");
+        doc = builder.build(new StringReader(ncmlString));
+      } catch (JDOMException e) {
+        throw new IOException(e.getMessage());
+      }
+      if (debugXML) System.out.println(" SAXBuilder done");
+
+      return readXML(doc, errlog, null);
+  }
 
   /**
    * Read an NcML file from a URL location, and construct a NcmlCollectionReader from its scan or scanFmrc element.
@@ -63,6 +87,10 @@ public class NcmlCollectionReader {
     }
     if (debugXML) System.out.println(" SAXBuilder done");
 
+    return readXML(doc, errlog, ncmlLocation);
+  }
+  
+  static private NcmlCollectionReader readXML(org.jdom2.Document doc, Formatter errlog, String ncmlLocation) {
     if (showParsedXML) {
       XMLOutputter xmlOut = new XMLOutputter();
       System.out.println("*** NetcdfDataset/showParsedXML = \n" + xmlOut.outputString(doc) + "\n*******");

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
@@ -74,6 +74,14 @@ public class Fmrc implements Closeable {
 
     return new Fmrc(collection, errlog);
   }
+  
+  public static Fmrc readNcML(String ncmlString, Formatter errlog) throws IOException {
+      NcmlCollectionReader ncmlCollection = NcmlCollectionReader.readNcML(ncmlString, errlog);
+      if (ncmlCollection == null) return null;
+      Fmrc fmrc = new Fmrc(ncmlCollection.getCollectionManager(), new FeatureCollectionConfig());
+      fmrc.setNcml(ncmlCollection.getNcmlOuter(), ncmlCollection.getNcmlInner());
+      return fmrc;
+  }
 
   public static Fmrc open(FeatureCollectionConfig config, Formatter errlog) throws IOException {
     if (config.spec.startsWith(MFileCollectionManager.CATALOG)) {


### PR DESCRIPTION
Minor modifications to allow `Fmrc` to read an NcML forecast model run collection directly from a string, in addition to the existing ability to read it from a file.