### PR TITLE
Don't include Gretty overlays in final project archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![THREDDS icon](http://www.unidata.ucar.edu/images/logos/thredds_netcdf-75x75.png)
 [![Travis Build Status](https://secure.travis-ci.org/Unidata/thredds.svg?branch=master)](http://travis-ci.org/Unidata/thredds)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/388/badge.svg)](https://scan.coverity.com/projects/388)
-
+[![SonarCloud Gate](https://sonarcloud.io/api/badges/gate?key=thredds)](https://sonarcloud.io/dashboard?id=thredds)
+[![Coverage Status](https://coveralls.io/repos/github/Unidata/thredds/badge.svg?branch=origin%2F5.0.0)](https://coveralls.io/github/Unidata/thredds?branch=origin%2F5.0.0)
 # Unidata's THREDDS Project
 
 The THREDDS project is developing middleware to bridge the gap between data

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -8,29 +8,29 @@
    - Detailed instructions can be found in `ncwms/docs/internal/release.txt and threddsIso/docs/internal/release.txt`.
    - The instructions for the two are very similar.
 
-2. Ensure that there are no uncommitted changes.
+1. Ensure that there are no uncommitted changes.
    - `git checkout master`
    - `git status`
 
-3. Pull all of the latest changes from upstream.
+1. Pull all of the latest changes from upstream.
    - `git pull`
 
-4. Create a new branch for the release and switch to it.
+1. Create a new branch for the release and switch to it.
    - `git checkout -b ${releaseMinor}`
 
-5. In `/build.gradle`, update the project's version for the release.
+1. In `/build.gradle`, update the project's version for the release.
    Likely, this means removing the `-SNAPSHOT` prefix, e.g. `4.6.6-SNAPSHOT` to `4.6.6`.
 
-6. In `/gradle/any/dependencies.gradle`, update the `uk.ac.rdg.resc:ncwms` and `EDS:threddsIso` dependencies to the
+1. In `/gradle/any/dependencies.gradle`, update the `uk.ac.rdg.resc:ncwms` and `EDS:threddsIso` dependencies to the
    versions deployed in step 1. Also, remove any dependencies on SNAPSHOT versions of libraries.
 
-7. Publish the artifacts to Nexus.
+1. Publish the artifacts to Nexus.
    - You need the correct `nexus.username` and `nexus.password` properties defined in your
      `~/.gradle/gradle.properties` file. Ask Christian for those.
    - `./gradlew clean publish`
    - Check artifacts at http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/
 
-8. On `www`, prepare environment variables for scripts that follow:
+1. On `www`, prepare environment variables for scripts that follow:
     ```bash
     ssh www
     bash
@@ -38,7 +38,7 @@
     export releaseMinor="4.6.8"  # Replace with appropriate value
     ```
 
-9. Prepare the FTP directory for the new version of TDS and TDM (best to do from SSH)
+1. Prepare the FTP directory for the new version of TDS and TDM (best to do from SSH)
     ```bash
     cd /web/ftp/pub/thredds/${releaseMajor}
     mkdir ${releaseMinor}
@@ -49,14 +49,14 @@
     ln -s ${releaseMinor} current
     ```
 
-10. Copy over the TDS war and its security hashes from Nexus, renaming them in the process.
+1. Copy over the TDS war and its security hashes from Nexus, renaming them in the process.
     ```bash
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war -O ${releaseMinor}/thredds.war
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.md5 -O ${releaseMinor}/thredds.war.md5
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.sha1 -O ${releaseMinor}/thredds.war.sha1
     ```
 
-11. Copy over the TDM fat jar and its security hashes from Nexus, renaming them in the process.
+1. Copy over the TDM fat jar and its security hashes from Nexus, renaming them in the process.
    When renaming, "tdmFat" should become "tdm".
     ```bash
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar -O ${releaseMinor}/tdm-${releaseMajor}.jar
@@ -64,7 +64,7 @@
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar.md5 -O ${releaseMinor}/tdm-${releaseMajor}.jar.md5
     ```
 
-12. Change permissions of the files you just copied.
+1. Change permissions of the files you just copied.
     ```bash
     cd /web/ftp/pub/thredds/${releaseMajor}/${releaseMinor}
     chmod 775 .
@@ -72,7 +72,7 @@
     ```
 
 
-13. Copy over ncIdv, netcdfAll, toolsUI and their security hashes from Nexus
+1. Copy over ncIdv, netcdfAll, toolsUI and their security hashes from Nexus
     ```bash
     cd /web/ftp/pub/netcdf-java/v${releaseMajor}
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar
@@ -86,7 +86,7 @@
     wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar.sha1
     ```
 
-14. Remove symlinks to old versions and create ones to new versions
+1. Remove symlinks to old versions and create ones to new versions
     ```bash
     cd /web/ftp/pub/netcdf-java/v${releaseMajor}
     rm toolsUI-${releaseMajor}.jar netcdfAll-${releaseMajor}.jar ncIdv-${releaseMajor}.jar
@@ -95,17 +95,17 @@
     ln -s ncIdv-${releaseMinor}.jar ncIdv-${releaseMajor}.jar
     ```
 
-15. Change permissions of the files you just copied.
+1. Change permissions of the files you just copied.
     ```bash
     cd /web/ftp/pub/netcdf-java/v${releaseMajor}
     chmod 664 *
     ```
 
-16. Mount the `www.unidata.ucar.edu:/web/` Samba share to a local directory, if it's not mounted already.
+1. Mount the `www.unidata.ucar.edu:/web/` Samba share to a local directory, if it's not mounted already.
     Let's call that directory `webMountDir`. The details of this will vary based on your OS.
     - On OS X do: Finder->Go->Connect to Server...  Then connect to `smb://www/web`.
 
-17. Set the `webdir` and `ftpdir` Gradle properties
+1. Set the `webdir` and `ftpdir` Gradle properties
     - Open `~/.gradle/gradle.properties`
     - Set `webdir` to `${webMountDir}/content/software/thredds/v${releaseMajor}/netcdf-java`
     - Set `ftpdir` to `${webMountDir}/ftp/pub/netcdf-java/v${releaseMajor}`
@@ -116,7 +116,7 @@
       ftpdir=/Volumes/web/ftp/pub/netcdf-java/v4.6
       ```
 
-18. Release Web Start to `www:/content/software/thredds/v${releaseMajor}/netcdf-java/webstart`
+1. Release Web Start to `www:/content/software/thredds/v${releaseMajor}/netcdf-java/webstart`
     - Test Web Start locally. There are notes above `:ui:releaseWebstart` about how to do that.
     - Make sure that you have the correct gradle.properties (see Christian for info). In particular, you'll need the
       `keystore`, `keystoreAlias`, `keystorePassword`, `webdir`, and `ftpdir` properties defined.
@@ -128,7 +128,7 @@
     - Test the new Web Start. If there were no errors, delete the old stuff.
       * `rm -r webstartOld`
 
-19. Release Javadoc to `www:/content/software/thredds/v${releaseMajor}/netcdf-java/javadoc` and `javadocAll`
+1. Release Javadoc to `www:/content/software/thredds/v${releaseMajor}/netcdf-java/javadoc` and `javadocAll`
     - Rename old directories
       * `cd /content/software/thredds/v${releaseMajor}/netcdf-java/`
       * `mv javadoc javadocOld`
@@ -140,7 +140,7 @@
       * `rm -r javadocOld`
       * `rm -r javadocAllOld`
 
-20. Change permissions of the files you just copied.
+1. Change permissions of the files you just copied.
     ```bash
     cd /content/software/thredds/v${releaseMajor}/netcdf-java/
     find webstart -type d -exec chmod 775 {} \;
@@ -151,42 +151,42 @@
     find javadocAll -type f -exec chmod 664 {} \;
     ```
 
-21. Update Unidata download page(s)
+1. Update Unidata download page(s)
     - check http://www.unidata.ucar.edu/downloads/thredds/index.jsp
       * modify `www:/content/downloads/thredds/toc.xml` as needed
     - check http://www.unidata.ucar.edu/downloads/netcdf/netcdf-java-4/index.jsp
       * modify `www:/content/downloads/netcdf/netcdf-java-4/toc.xml` as needed
 
-22. Edit `www:/content/software/thredds/latest.xml` to reflect the correct
+1. Edit `www:/content/software/thredds/latest.xml` to reflect the correct
     releaseMinor version for stable and development. This file is read by all
     TDS > v4.6 to make log entries regarding current stable and development versions
     to give users a heads-up of the need to update.
 
-23. Commit the changes you've made.
+1. Commit the changes you've made.
     - At the very least, `project.version` in the root build script should have been modified.
     - `git add ...`
     - `git commit -m "Release ${releaseMinor}"`
 
-24. Prepare for next round of development.
+1. Prepare for next round of development.
     - Update the project version. Increment it and add the "-SNAPSHOT" suffix.
       * For example, `if ${releaseMinor} == "4.6.6"`, the next version will be "4.6.7-SNAPSHOT".
     - Commit the change.
       * `git add ...`
       * `git commit -m "Begin work on 4.6.7-SNAPSHOT"`
 
-25. Push the commits upstream.
+1. Push the commits upstream.
     - `git push --set-upstream <your-repo> ${releaseMinor}`
 
-26. Create a pull request on GitHub and wait for it to be merged.
+1. Create a pull request on GitHub and wait for it to be merged.
     - It should pull your changes on `<your-repo>/${releaseMinor}` into `Unidata/master`.
     - Alternatively, merge it yourself. As long as the changeset is small and non-controversial, nobody will care.
 
-27. Once merged, pull down the latest changes from master. You can also delete the release branch.
+1. Once merged, pull down the latest changes from master. You can also delete the release branch.
     - `git checkout master`
     - `git pull`
     - `git branch -d ${releaseMinor}`
 
-28. In the git log, find the "Release ${releaseMinor}" commit and tag it with the version number.
+1. In the git log, find the "Release ${releaseMinor}" commit and tag it with the version number.
     - `git log`
     - `git tag v${releaseMinor} <commit-id>`
         * `HEAD~1` is usually the right commit, so you can probably do `git tag v${releaseMinor} HEAD~1`
@@ -194,20 +194,20 @@
       commits, creating brand new commits in the process. We want to apply the tag to the new commit,
       because it will actually be part of `master`'s history.
 
-29. Push the release tag upstream.
+1. Push the release tag upstream.
     -  `git push origin v${releaseMinor}`
 
-30. Create a release on GitHub using the tag you just pushed.
+1. Create a release on GitHub using the tag you just pushed.
     - Example: https://github.com/Unidata/thredds/releases/tag/v4.6.7
     - To help create the changelog, examine the pull requests on GitHub. For example, this URL shows all PRs that
       have been merged into `master` since 2016-02-12:
       https://github.com/Unidata/thredds/pulls?q=base%3Amaster+merged%3A%3E%3D2016-02-12
 
-31. Make blog post for the release.
+1. Make blog post for the release.
     - Example: http://www.unidata.ucar.edu/blogs/news/entry/netcdf-java-library-and-tds4
     - Best to leave it relatively short and just link to the GitHub release.
 
-32. Make a release announcement to the mailing lists: netcdf-java@unidata.ucar.edu and thredds@unidata.ucar.edu
+1. Make a release announcement to the mailing lists: netcdf-java@unidata.ucar.edu and thredds@unidata.ucar.edu
     - Example: http://www.unidata.ucar.edu/mailing_lists/archives/netcdf-java/2017/msg00000.html
     - Best to leave it relatively short and just link to the GitHub release.
 

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -84,6 +84,14 @@ void overlayAndApplyConfigOf(String projectPath) {
     
     // See http://akhikhl.github.io/gretty-doc/Web-app-overlays.html
     gretty.overlay projectPath
+    
+    gretty.afterEvaluate {
+        // Remove the 'assemble' task's dependency on 'overlayArchive', which was established in
+        // GrettyPlugin.addTasks() (see https://goo.gl/cJYmuU). Essentially, 'overlayArchive' modifies the archive
+        // produced by a project (i.e. its JAR or WAR) to include the artifacts of the overlaid projects.
+        // I can't imagine why we'd ever want that, because we only use overlays for testing.
+        project.tasks.assemble.dependsOn.remove project.tasks.overlayArchive
+    }
 }
 
 // It isn't possible to share methods, but we can share extra properties containing a closure, which boils down to

--- a/gradle/any/publishing.gradle
+++ b/gradle/any/publishing.gradle
@@ -13,13 +13,13 @@ publishing {
             maven {
                 name = 'snapshots'
                 url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots/'
-                // Set credentials in root/coverage.gradle.
+                // Set credentials in root/publishing.gradle.
             }
         } else {
             maven {
                 name = 'releases'
                 url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/'
-                // Set credentials in root/coverage.gradle.
+                // Set credentials in root/publishing.gradle.
             }
         }
     }


### PR DESCRIPTION
Fixes issue from https://github.com/Unidata/thredds/pull/908#issuecomment-328892503

Other miscellaneous changes:
* Use Markdown's automatic list numbering, instead of doing it manually.
* Add SonarQube and Coveralls badges to README.