### PR TITLE
Attempt to fix proxy handling

### DIFF
--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -1182,6 +1182,11 @@ public class HTTPSession implements Closeable
                 connmgr.setDefaultMaxPerRoute((Integer) value);
             } /* else ignore */
         }
+        // Add proxy, if any
+        if(httpproxy != null)
+            rcb.setProxy(httpproxy);
+        else if(httpsproxy != null)
+            rcb.setProxy(httpsproxy);
         RequestConfig cfg = rcb.build();
         return cfg;
     }


### PR DESCRIPTION
re esupport RAN-171087

It appears that I forgot to actually use the proxy information if a proxy
was specified. This bug also needs to be fixed in 5.0.0.
This is a bug, but it is unknown if this actually fixes the specified esupport
problem because I have no way to test it.