### PR TITLE
Fix ncml handling of isUnsigned xml atribute

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
@@ -562,6 +562,14 @@ public class NcMLReader {
       if (debugConstruct) System.out.println(" add new att = " + name);
       try {
         ucar.ma2.Array values = readAttributeValues(attElem);
+        // Check for unsigned
+        String signedness = attElem.getAttributeValue("isUnsigned");
+        boolean unsigned = false;
+        if(signedness != null && (
+                signedness.equalsIgnoreCase("true")
+                || signedness.equalsIgnoreCase("1")))
+          unsigned = true;
+        values.setUnsigned(unsigned);
         addAttribute(parent, new ucar.nc2.Attribute(name, values));
       } catch (RuntimeException e) {
         errlog.format("NcML new Attribute Exception: %s att=%s in=%s%n", e.getMessage(), name, parent);


### PR DESCRIPTION
re: issue https://github.com/Unidata/thredds/issues/923
NcMLReader appears to be ignoring the isUnsigned xml attribute.
in the master branch. Added code to make it be recognized.
Note that this change should not be propagated to 5.0.
