### PR TITLE
Use new Nexus v3 repos at artifacts.unidata.ucar.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Source code for each of these is available from GitHub at
 The latest released and snapshot software artifacts (.jar and .war files e.g.)
 are available from Unidata's Maven repositories
 
-* https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/
-* https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots/
+* https://artifacts.unidata.ucar.edu/repository/unidata-releases/
+* https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/
 
 To build the software yourself, follow [this tutorial](docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc).
 

--- a/docker/tds-base/Dockerfile
+++ b/docker/tds-base/Dockerfile
@@ -40,7 +40,7 @@ COPY tomcat-files/bash_logout /usr/local/tomcat/.bash_logout
 #
 # get the latest stable THREDDS Data Server (TDS)
 #
-#RUN wget -O /usr/local/tomcat/webapps/thredds##04.06.02.war https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/4.6.2/tds-4.6.2.war
+#RUN wget -O /usr/local/tomcat/webapps/thredds##04.06.02.war https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/4.6.2/tds-4.6.2.war
 
 #
 # Copy thredds.war

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -28,7 +28,7 @@
    - You need the correct `nexus.username` and `nexus.password` properties defined in your
      `~/.gradle/gradle.properties` file. Ask Christian for those.
    - `./gradlew clean publish`
-   - Check artifacts at http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/
+   - Check artifacts at http://artifacts.unidata.ucar.edu/repository/unidata-releases/
 
 8. On `www`, prepare environment variables for scripts that follow:
     ```bash
@@ -51,17 +51,17 @@
 
 10. Copy over the TDS war and its security hashes from Nexus, renaming them in the process.
     ```bash
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war -O ${releaseMinor}/thredds.war
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.md5 -O ${releaseMinor}/thredds.war.md5
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.sha1 -O ${releaseMinor}/thredds.war.sha1
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war -O ${releaseMinor}/thredds.war
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.md5 -O ${releaseMinor}/thredds.war.md5
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/${releaseMinor}/tds-${releaseMinor}.war.sha1 -O ${releaseMinor}/thredds.war.sha1
     ```
 
 11. Copy over the TDM fat jar and its security hashes from Nexus, renaming them in the process.
    When renaming, "tdmFat" should become "tdm".
     ```bash
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar -O ${releaseMinor}/tdm-${releaseMajor}.jar
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar.sha1 -O ${releaseMinor}/tdm-${releaseMajor}.jar.sha1
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar.md5 -O ${releaseMinor}/tdm-${releaseMajor}.jar.md5
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar -O ${releaseMinor}/tdm-${releaseMajor}.jar
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar.sha1 -O ${releaseMinor}/tdm-${releaseMajor}.jar.sha1
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tdmFat/${releaseMinor}/tdmFat-${releaseMinor}.jar.md5 -O ${releaseMinor}/tdm-${releaseMajor}.jar.md5
     ```
 
 12. Change permissions of the files you just copied.
@@ -75,15 +75,15 @@
 13. Copy over ncIdv, netcdfAll, toolsUI and their security hashes from Nexus
     ```bash
     cd /web/ftp/pub/netcdf-java/v${releaseMajor}
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar.md5
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar.sha1
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar.md5
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar.sha1
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar.md5
-    wget https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar.sha1
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar.md5
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/ncIdv/${releaseMinor}/ncIdv-${releaseMinor}.jar.sha1
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar.md5
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/netcdfAll/${releaseMinor}/netcdfAll-${releaseMinor}.jar.sha1
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar.md5
+    wget https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/toolsUI/${releaseMinor}/toolsUI-${releaseMinor}.jar.sha1
     ```
 
 14. Remove symlinks to old versions and create ones to new versions

--- a/docs/website/netcdf-java/documentation.htm
+++ b/docs/website/netcdf-java/documentation.htm
@@ -52,7 +52,7 @@ To build the latest stable version from source or contribute code  to the THREDD
   <li><a href="javadocAll/index.html">All javadoc</a>. This is the javadoc for all packages and all methods except private. CAREFUL, much of this will
     change. </li>
   <li>Try out the <strong> 4.6</strong> version of ToolsUI application: <a href="webstart/netCDFtools.jnlp">launch from webstart</a>.</li>
-  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
+  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
   <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
 </ul>
 <h3 id="v45">Previous release version 4.5 (requires Java 7) </h3>
@@ -67,7 +67,7 @@ To build the latest stable version from source or contribute code  to the THREDD
   <li><a href="http://www.unidata.ucar.edu/software/thredds/v4.5/netcdf-java/javadocAll/index.html">All javadoc</a>. This is the javadoc for all packages and all methods except private. CAREFUL, much of this will
     change. </li>
   <li>Try out the <strong> 4.5</strong> version of ToolsUI application: <a href="http://www.unidata.ucar.edu/software/thredds/v4.5/netcdf-java/webstart/netCDFtools.jnlp">launch from webstart</a>.</li>
-  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
+  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
   <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
 </ul>
 <h3 id="v">Previous release version 4.3 (requires Java 6) </h3>
@@ -83,7 +83,7 @@ To build the latest stable version from source or contribute code  to the THREDD
     This is the javadoc for all packages and all methods except private. CAREFUL, much of this will
     change. </li>
   <li>Try out the <strong> 4.3</strong> version of ToolsUI application: <a href="http://www.unidata.ucar.edu/software/thredds/netcdf-java/v4.3/webstart/netCDFtools.jnlp">launch from webstart</a>.</li>
-  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
+  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
   <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
 </ul>
 <h3>File format<a name="formats"></a> types</h3>

--- a/docs/website/netcdf-java/reference/BuildDependencies.adoc
+++ b/docs/website/netcdf-java/reference/BuildDependencies.adoc
@@ -14,9 +14,9 @@ Releases repository:
 <!-- In Maven -->
 <repositories>
     <repository>
-        <id>unidata-releases</id>
-        <name>Unidata Releases</name>
-        <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</url>
+        <id>unidata-all</id>
+        <name>Unidata All</name>
+        <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
     </repository>
 </repositories>
 ----
@@ -26,7 +26,7 @@ Releases repository:
 // In Gradle
 repositories {
     maven {
-        url "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"
+        url "https://artifacts.unidata.ucar.edu/repository/unidata-all/"
     }
 }
 ----
@@ -138,7 +138,7 @@ dependencies {
 
 This is the appropriate option if you're not using a dependency management tool like Maven or Gradle and you don't
 care about jar size or compatibility with other libraries. Simply include
-https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/[netcdfAll-${netcdfJavaVersion}.jar]
+https://artifacts.unidata.ucar.edu/repository/unidata-all/edu/ucar/netcdfAll/[netcdfAll-${netcdfJavaVersion}.jar]
 on the classpath when you run your program. You'll also need a <<Logging,logger>>.
 
 == Logging

--- a/docs/website/netcdf-java/reference/BuildDependencies.html
+++ b/docs/website/netcdf-java/reference/BuildDependencies.html
@@ -26,9 +26,9 @@ Releases repository:</p>
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="comment">&lt;!-- In Maven --&gt;</span>
 <span class="tag">&lt;repositories&gt;</span>
     <span class="tag">&lt;repository&gt;</span>
-        <span class="tag">&lt;id&gt;</span>unidata-releases<span class="tag">&lt;/id&gt;</span>
-        <span class="tag">&lt;name&gt;</span>Unidata Releases<span class="tag">&lt;/name&gt;</span>
-        <span class="tag">&lt;url&gt;</span>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/<span class="tag">&lt;/url&gt;</span>
+        <span class="tag">&lt;id&gt;</span>unidata-all<span class="tag">&lt;/id&gt;</span>
+        <span class="tag">&lt;name&gt;</span>Unidata All<span class="tag">&lt;/name&gt;</span>
+        <span class="tag">&lt;url&gt;</span>https://artifacts.unidata.ucar.edu/repository/unidata-all/<span class="tag">&lt;/url&gt;</span>
     <span class="tag">&lt;/repository&gt;</span>
 <span class="tag">&lt;/repositories&gt;</span></code></pre>
 </div>
@@ -38,7 +38,7 @@ Releases repository:</p>
 <pre class="CodeRay highlight"><code data-lang="java"><span class="comment">// In Gradle</span>
 repositories {
     maven {
-        url <span class="string"><span class="delimiter">&quot;</span><span class="content">https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</span><span class="delimiter">&quot;</span></span>
+        url <span class="string"><span class="delimiter">&quot;</span><span class="content">https://artifacts.unidata.ucar.edu/repository/unidata-all/</span><span class="delimiter">&quot;</span></span>
     }
 }</code></pre>
 </div>
@@ -172,7 +172,7 @@ dependencies {
 <div class="paragraph">
 <p>This is the appropriate option if you&#8217;re not using a dependency management tool like Maven or Gradle and you don&#8217;t
 care about jar size or compatibility with other libraries. Simply include
-<a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/netcdfAll/">netcdfAll-${netcdfJavaVersion}.jar</a>
+<a href="https://artifacts.unidata.ucar.edu/repository/unidata-all/edu/ucar/netcdfAll/">netcdfAll-${netcdfJavaVersion}.jar</a>
 on the classpath when you run your program. You&#8217;ll also need a <a href="#_logging">logger</a>.</p>
 </div>
 </div>

--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.adoc
@@ -41,7 +41,7 @@ such as toolsUI.jar and netcdfAll.jar, will be found in `build/libs/`.
 
 NetCDF-Java is comprised of several modules, many of which you can use within your own projects, as described
 link:../reference/BuildDependencies.html[here]. At Unidata, we publish the artifacts that those modules generate to
-our link:https://artifacts.unidata.ucar.edu/index.html#view-repositories[Nexus repository].
+our link:https://artifacts.unidata.ucar.edu[Nexus repository].
 
 However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don't
 upload to Nexus. Never fear: you can build them yourself and publish them to your local Maven repository!

--- a/docs/website/netcdf-java/tutorial/SourceCodeBuild.html
+++ b/docs/website/netcdf-java/tutorial/SourceCodeBuild.html
@@ -70,7 +70,7 @@ such as toolsUI.jar and netcdfAll.jar, will be found in <code>build/libs/</code>
 <div class="paragraph">
 <p>NetCDF-Java is comprised of several modules, many of which you can use within your own projects, as described
 <a href="../reference/BuildDependencies.html">here</a>. At Unidata, we publish the artifacts that those modules generate to
-our <a href="https://artifacts.unidata.ucar.edu/index.html#view-repositories">Nexus repository</a>.</p>
+our <a href="https://artifacts.unidata.ucar.edu">Nexus repository</a>.</p>
 </div>
 <div class="paragraph">
 <p>However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don&#8217;t

--- a/docs/website/tds/TDS.html
+++ b/docs/website/tds/TDS.html
@@ -73,7 +73,7 @@
   <li>Download the latest release: [<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war">thredds.war</a> (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war.md5">MD5</a>)]
     (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/thredds.war.sha1">SHA1</a>)]
     [<a href="https://github.com/Unidata/thredds">source on GitHub</a>]
-    [<a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>] </li>
+    [<a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>] </li>
   <li>The THREDDS Data Manager (TDM)  <a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.6/current/tdm-4.6.jar">tdm.jar</a></li>
   <li>Documentation:
     <ul>
@@ -89,7 +89,7 @@
 <p><strong>TDS 4.3 is the previous release. It requires Tomcat 6+ and Java 6+.</strong></p>
 <ul>
   <li>Download the latest  release: [<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.3/current/thredds.war">thredds.war</a> (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.3/current/thredds.war.md5">MD5</a>)] (<a href="ftp://ftp.unidata.ucar.edu/pub/thredds/4.3/current/thredds.war.sha1">SHA1</a>)]
-    [<a href="https://github.com/Unidata/thredds">source on GitHub</a>] [<a href="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>]</li>
+    [<a href="https://github.com/Unidata/thredds">source on GitHub</a>] [<a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>]</li>
   <li>Documentation:
     <ul>
       <li><a href="http://www.unidata.ucar.edu/software/thredds/v4.3/tds/tds4.3/reference/index.html">Reference</a></li>

--- a/docs/website/tds/faq.html
+++ b/docs/website/tds/faq.html
@@ -133,7 +133,7 @@
     &lt;repository&gt;
         &lt;id&gt;unidata-releases&lt;/id&gt;
         &lt;name>UNIDATA Releases&lt;/name&gt;
-        &lt;url&gt;https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/&lt;/url&gt;
+        &lt;url&gt;https://artifacts.unidata.ucar.edu/repository/unidata-releases/&lt;/url&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;
 </pre>

--- a/docs/website/tds/tutorial/workshop2014.html
+++ b/docs/website/tds/tutorial/workshop2014.html
@@ -91,7 +91,7 @@
   <ul>
   <li>Source on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
   <li> Issue Tracking with <a href="http://www.unidata.ucar.edu/jira/">JIRA</a></li>
-  <li>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu/index.html#view-repositories">Nexus</a></li>
+  <li>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu">Nexus</a></li>
   <li>CDM/TDS Nightly Build/Test System (<a href="images/jenkins.png">Jenkins</a>)</li>
   <li>Continuous Integration on <a href="https://travis-ci.org/Unidata/thredds">Travis</a></li>
   <li>Static code analysis on <a href="https://scan.coverity.com/projects/388?tab=overview">Coverity</a></li>
@@ -198,7 +198,7 @@
   <ul>
     <li>Source on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
     <li> Issue Tracking with <a href="http://www.unidata.ucar.edu/jira/">JIRA</a></li>
-    <li>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu/index.html#view-repositories">Nexus</a></li>
+    <li>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu">Nexus</a></li>
     <li>CDM/TDS Nightly Build/Test System (<a href="images/jenkins.png">Jenkins</a>)</li>
     <li>Continuous Integration on <a href="https://travis-ci.org/Unidata/thredds">Travis</a></li>
     <li>Static code analysis on <a href="https://scan.coverity.com/projects/388?tab=overview">Coverity</a></li>

--- a/docs/website/tds/tutorial/workshop2015.adoc
+++ b/docs/website/tds/tutorial/workshop2015.adoc
@@ -85,7 +85,7 @@ Form] (Repeated submissions encouraged)
  * Source code on https://github.com/Unidata/thredds[GitHub]
  ** Exercise: link:../../netcdf-java/tutorial/SourceCodeBuild.html[Build THREDDS from source code]
  ** Exercise: link:../../netcdf-java/tutorial/Contributing.html[Submit a pull request]
- * Maven artifacts on https://artifacts.unidata.ucar.edu/index.html#view-repositories[Nexus]
+ * Maven artifacts on https://artifacts.unidata.ucar.edu[Nexus]
  ** link:../../netcdf-java/reference/BuildDependencies.html[How to use them in your project]
  * CDM/TDS Nightly Build/Test System (link:images/jenkins.png[Jenkins])
  * Continuous Integration on https://travis-ci.org/Unidata/thredds[Travis]

--- a/docs/website/tds/tutorial/workshop2015.html
+++ b/docs/website/tds/tutorial/workshop2015.html
@@ -304,7 +304,7 @@ edit threddsConfig.xml to add local information</p>
 </div>
 </li>
 <li>
-<p>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu/index.html#view-repositories">Nexus</a></p>
+<p>Maven artifacts on <a href="https://artifacts.unidata.ucar.edu">Nexus</a></p>
 <div class="ulist">
 <ul>
 <li>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,17 +11,46 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
         // https://blog.bintray.com/2015/02/09/android-studio-migration-from-maven-central-to-jcenter/
         jcenter()
         mavenCentral()  // JCenter isn't quite a superset of Maven Central.
+        
+        // All of the repositories below could be replaced with:
+        //     url "https://artifacts.unidata.ucar.edu/repository/unidata-all/"
+        // which is a group repository that contains all other repositories. However, I prefer to list all source
+        // repos explicitly so that we know where all artifacts ultimately come from.
+        
+        // Hosted repositories.
         maven {
-            url "https://artifacts.unidata.ucar.edu/content/repositories/unidata"
+            // For "threddsIso", "ncwms", "visad" and "jj2000".
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-releases/"
         }
         maven {
-            url "https://artifacts.unidata.ucar.edu/content/repositories/unidata-3rdparty/"
+            // For "threddsIso" and "ncwms" snapshots.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/"
         }
         maven {
-            url "https://dl.bintray.com/cwardgar/maven/"  // For 'com.cwardgar.gretty:gretty-fork'.
+            // For "bounce" and several dependencies needed by "ncwms".
+            // Contains artifacts that are not available in any other Maven repository on the net.
+            // We should be concerned that we're relying on any such artifacts. TODO: Remove our dependence on these.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/"
+        }
+    
+        // Proxied repositories. In the event that the remote repos go away, we still have copies of the artifacts.
+        maven {
+            // For "geotk-referencing", which is needed by "ncwms". Repositories are not inherited from a dependency,
+            // so we must duplicate ncwms's needed repos here. See https://stackoverflow.com/a/19908009/3874643.
+            // Proxies 'http://maven.geotoolkit.org/'.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-geotoolkit/"
         }
         maven {
-            url "http://maven.asascience.com/maven/ncsos-releases"
+            // For "gretty". Proxies 'https://dl.bintray.com/cwardgar/maven/'.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-cwardgar/"
+        }
+        maven {
+            // For "ncsos". Proxies 'http://maven.asascience.com/maven/ncsos-releases/'.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-ncsos/"
+        }
+        maven {
+            // For "52n-oxf-xmlbeans". Proxies 'http://52north.org/maven/repo/releases/'.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-52north/"
         }
     }
 }
@@ -196,8 +225,6 @@ libraries["ncwms"] = dependencies.create("uk.ac.rdg.resc:ncwms:1.2.tds.4.6.11-SN
     // This needs to be a local exclusion; globally excluding "edu.ucar:cdm" would be very bad.
     exclude group: 'edu.ucar', module: 'cdm'  // version "4.6.1"
 }
-
-libraries["geoapi-pending"] = "org.opengis:geoapi-pending:3.1-M04"
 
 libraries["javax.servlet-api"] = "javax.servlet:javax.servlet-api:3.1.0"
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -12,13 +12,13 @@ configure(publishedProjects) { Project project ->
             if (version.endsWith('SNAPSHOT')) {
                 maven {
                     name = 'snapshots'
-                    url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots/'
+                    url = 'https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/'
                     // Set credentials in taskGraph.whenReady {}
                 }
             } else {
                 maven {
                     name = 'releases'
-                    url = 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/'
+                    url = 'https://artifacts.unidata.ucar.edu/repository/unidata-releases/'
                     // Set credentials in taskGraph.whenReady {}
                 }
             }

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     runtime libraries["threddsIso"]
     runtime libraries["ncsos"]
     compile libraries["ncwms"]
-    compile libraries["geoapi-pending"]
     compile libraries["oro"]
 
     providedCompile libraries["javax.servlet-api"]


### PR DESCRIPTION
* Explicitly list each and every repository from which we download dependencies. This means eschewing the "unidata-all" group repo!
* Drop "geoapi-pending" dependency from tds. It's actually just a dep that "ncwms" needs.
* Update docs and all other files to use the new endpoints.