### PR TITLE
Allow setting of buffersize for java.util.zip.InflateSteam 

### DIFF
--- a/cdm/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/src/main/java/ucar/nc2/Attribute.java
@@ -37,6 +37,7 @@ import ucar.ma2.Array;
 import ucar.ma2.ArrayChar;
 import ucar.ma2.DataType;
 import ucar.ma2.Index;
+import ucar.nc2.constants.CDM;
 import ucar.nc2.util.Indent;
 
 import java.nio.ByteBuffer;
@@ -59,8 +60,8 @@ public class Attribute extends CDMNode {
 
   static final String SPECIALPREFIX = "_";
   static final String[] SPECIALS = new String[]{
-          "_NCProperties", "_IsNetcdf4", "_SuperblockVersion",
-          "_DAP4_Little_Endian", "_edu.ucar"
+          CDM.NCPROPERTIES, CDM.ISNETCDF4, CDM.SUPERBLOCKVERSION,
+          CDM.DAP4_LITTLE_ENDIAN, CDM.EDU_UCAR_PREFIX
   };
 
   /**

--- a/cdm/src/main/java/ucar/nc2/Group.java
+++ b/cdm/src/main/java/ucar/nc2/Group.java
@@ -515,7 +515,7 @@ public class Group extends CDMNode implements AttributeContainer {
     List<Attribute> container = this.attributes;
     if(Attribute.isspecial(att))
 	container = this.specials;
-    for (int i = 0; i < attributes.size(); i++) {
+    for (int i = 0; i < container.size(); i++) {
       Attribute a = container.get(i);
       if (att.getShortName().equals(a.getShortName())) {
         container.set(i, att); // replace

--- a/cdm/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm/src/main/java/ucar/nc2/constants/CDM.java
@@ -78,4 +78,10 @@ public interface CDM {
   public static final String RLATLON_UNITS = "degrees";
   public static final String TIME_INTERVAL = "time_interval";
 
+  // Special Attribute Names
+  public static final String NCPROPERTIES = "_NCProperties";
+  public static final String ISNETCDF4 = "_IsNetcdf4";
+  public static final String SUPERBLOCKVERSION = "_SuperblockVersion";
+  public static final String DAP4_LITTLE_ENDIAN = "_DAP4_Little_Endian";
+  public static final String EDU_UCAR_PREFIX = "_edu.ucar";
 }

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
@@ -63,7 +63,7 @@ public class H5iosp extends AbstractIOServiceProvider {
   static boolean debugPos = false;
   static boolean debugHeap = false;
   static boolean debugHeapStrings = false;
-  static boolean debugFilter = false;
+  static boolean debugFilter = true;
   static boolean debugRead = false;
   static boolean debugFilterIndexer = false;
   static boolean debugChunkIndexer = false;
@@ -71,7 +71,7 @@ public class H5iosp extends AbstractIOServiceProvider {
   static boolean debugStructure = false;
   static boolean skipEos = false;
 
-  static private org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(H5iosp.class);
+  static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(H5iosp.class);
 
   static public void setDebugFlags(ucar.nc2.util.DebugFlags debugFlag) {
     debug = debugFlag.isSet("H5iosp/read");
@@ -85,6 +85,8 @@ public class H5iosp extends AbstractIOServiceProvider {
 
     H5header.setDebugFlags(debugFlag);
     H4header.setDebugFlags(debugFlag);
+    H5tiledLayoutBB.debugFilter = debugFilter;
+
   }
 
   public boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) throws IOException {

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
@@ -63,7 +63,7 @@ public class H5iosp extends AbstractIOServiceProvider {
   static boolean debugPos = false;
   static boolean debugHeap = false;
   static boolean debugHeapStrings = false;
-  static boolean debugFilter = true;
+  static boolean debugFilter = false;
   static boolean debugRead = false;
   static boolean debugFilterIndexer = false;
   static boolean debugChunkIndexer = false;
@@ -85,7 +85,8 @@ public class H5iosp extends AbstractIOServiceProvider {
 
     H5header.setDebugFlags(debugFlag);
     H4header.setDebugFlags(debugFlag);
-    H5tiledLayoutBB.debugFilter = debugFilter;
+    if(debugFilter)
+      H5tiledLayoutBB.debugFilter = debugFilter;
 
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
@@ -63,7 +63,7 @@ class H5tiledLayoutBB implements LayoutBB {
   // System property name for -D flag
   static final String INFLATEBUFFERSIZE = "unidata.h5iosp.inflate.buffersize";
 
-  static public boolean debugFilter = true;
+  static public boolean debugFilter = false;
 
   private LayoutBBTiled delegate;
 

--- a/cdm/src/main/java/ucar/nc2/iosp/netcdf4/Nc4.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/netcdf4/Nc4.java
@@ -18,9 +18,7 @@ public class Nc4 {
   static public final String NETCDF4_STRICT  = "_nc3_strict";  // global - when using classic model
   static public final String NETCDF4_NON_COORD  = "_nc4_non_coord_";  // appended to variable when it conflicts with dimension scale
 
-  // This is a persistent attribute added in netcdf-c-4.4.1-RC2. It'll look something like:
-  //     _NCProperties = "version=1|netcdflibversion=4.4.1|hdf5libversion=1.8.17"
-  static public final String NETCDF4_NC_PROPERTIES = "_NCProperties";
+
 }
 
 /*

--- a/cdm/src/test/java/ucar/nc2/TestSpecialAttributes.java
+++ b/cdm/src/test/java/ucar/nc2/TestSpecialAttributes.java
@@ -8,6 +8,7 @@ package ucar.nc2;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Test;
+import ucar.nc2.constants.CDM;
 import ucar.unidata.util.test.TestDir;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class TestSpecialAttributes extends TestCase
     {
         NetcdfFile ncfile = TestDir.openFileLocal("testSpecialAttributes.nc4");
         // Attempt to read special attributes by name
-        for(String name : new String[]{"_NCProperties"}) {
+        for(String name : new String[]{CDM.NCPROPERTIES}) {
             Attribute special = ncfile.getRootGroup().findAttribute(name);
             Assert.assertTrue("Could not access special attribute: " + name,
                     special != null && Attribute.isspecial(special));

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -2737,6 +2737,8 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     if (att.getShortName().equals(H5header.HDF5_DIMENSION_LABELS)) return;
     if (att.getShortName().equals(CDM.CHUNK_SIZES)) return;
     if (att.getShortName().equals(CDM.COMPRESS)) return;
+    if (att.getShortName().equals(CDM.NCPROPERTIES)) return;
+    if (att.getShortName().equals(CDM.ISNETCDF4)) return;
 
     int ret = 0;
     Array values = att.getValues();

--- a/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
+++ b/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
@@ -219,7 +219,7 @@ public class DsgSubsetWriterTest {
         @Override
         public boolean attCheckOk(Variable v, Attribute att) {
             return !att.getShortName().equals(CDM.TITLE) &&  // Ignore the "title" attribute.
-                   !att.getShortName().equals(Nc4.NETCDF4_NC_PROPERTIES);
+                   !att.getShortName().equals(CDM.NCPROPERTIES);
         }
 
         @Override

--- a/ui/src/main/java/ucar/util/prefs/ui/BeanTable.java
+++ b/ui/src/main/java/ucar/util/prefs/ui/BeanTable.java
@@ -293,6 +293,8 @@ public class BeanTable extends JPanel {
    */
   public Object getSelectedBean() {
     int viewRowIndex = jtable.getSelectedRow();
+    if(viewRowIndex < 0)
+      return null;
     int modelRowIndex = jtable.convertRowIndexToModel(viewRowIndex);
     return (modelRowIndex < 0) || (modelRowIndex >= beans.size()) ? null : beans.get(modelRowIndex);
   }


### PR DESCRIPTION
re: e-support ZIZ-818863

Changes:

1. Modified H5tiledLayoutBB.java to allow the jvm
   -Dthredds.h5iosp.inflate.buffersize flag to set
   the buffer size used by java.util.zip.InflateStream.
   Defaults to the current 512 bytes.

2. Cleaned up the handling of special Attributes
   by centralizing their names into CDM.java.
   Affects NC4.java, NC4Iosp.java,
   DsgSubsetWriterTest.java
   TestSpecialAttributes.java

3. For H5iosp.java, if debugFilter is set, then propagate to
   H5tiledLayoutBB.debugFilter.

4. Fixed minor bug in BeanTable to avoid NPE.

Cannot figure out a test for this, other than debug statement.







