### PR TITLE
Only configure Nexus credentials when we run a "publish" task.

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -4,19 +4,14 @@ import edu.ucar.build.publishing.PublishToRawRepoTask
 apply from: "$rootDir/gradle/any/properties.gradle"  // For Nexus credential properties.
 
 task publish(type: PublishToRawRepoTask) {
-    // TODO: Move these properties to any/publishing.gradle.
     host = "https://artifacts.unidata.ucar.edu/"
     repoName = "thredds-doc"
 
     srcFile = file('website/')
     destPath = version
     
-    // These statements can potentially fail the build. We only want that to happen if we're actually running the
-    // task, not merely configuring it.
-    doFirst {
-        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
-        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
-    }
+    // Disable this task until new thredds docs are ready to go.
+    enabled = false
 }
 
 // By default, this will perform a dry run, which simply prints the components that the query matched.
@@ -24,11 +19,20 @@ task publish(type: PublishToRawRepoTask) {
 task deleteFromNexus(type: DeleteFromNexusTask) {
     host = "https://artifacts.unidata.ucar.edu/"
     searchQueryParameters.repository = 'thredds-doc'
-    searchQueryParameters.q = version
+    searchQueryParameters.q = '*'  // Nuke everything in the repo.
+}
+
+// The above tasks require credentials for our Nexus server, which they look for in Gradle properties.
+// If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build will fail.
+// Therefore, we only want to configure the credentials when one of the above tasks is part of the execution plan.
+// Otherwise, unavailable credentials could cause a build to fail even if we aren't doing anything that interacts
+// with Nexus. The TaskExecutionGraph allows us to do that.
+gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
+    Collection<Task> nexusTasks = taskGraph.allTasks.findAll {
+        it instanceof PublishToRawRepoTask || it instanceof DeleteFromNexusTask }
     
-    // Ditto.
-    doFirst {
-        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
-        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+    nexusTasks.each {
+        it.username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+        it.password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
     }
 }

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -39,23 +39,19 @@ publishing {
     }
 }
 
-// Use taskGraph.whenReady() to delay the evaluation of the Nexus credentials for as long as possible.
-// It appears that it can't be deferred until the evaluation phase using Groovy GStrings: it's always done in the
-// execution phase.
+// The "publish" tasks require credentials for our Nexus server, which they look for in Gradle properties.
+// If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build will fail.
+// Therefore, we only want to configure credentials when a "publish" task is part of the execution plan. Otherwise,
+// unavailable credentials could cause a build to fail even if we aren't doing any publishing. The TaskExecutionGraph
+// allows us to do that.
 gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
     // This won't find any publishToMavenLocal tasks. Those are of type PublishToMavenLocal
     Collection<Task> mavenPublishTasks = taskGraph.allTasks.findAll { it instanceof PublishToMavenRepository }
     
-    if (!mavenPublishTasks) {
-        return  // We're not running any tasks that publish to a (remote) Maven repo.
-    }
-    
-    Closure nexusCredentials = {
-        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
-        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
-    }
-    
     mavenPublishTasks.each {
-        it.repository.credentials nexusCredentials
+        it.repository.credentials.with {
+            username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+            password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+        }
     }
 }


### PR DESCRIPTION
* We were already doing this for Maven publish; now we're doing it for thredds-doc publish and delete.
* Refactor the credentials-setting code to be a bit simpler.
* Disable :docs:publish for now.

I've already done a test publish on Jenkins: https://jenkins-aws.unidata.ucar.edu/job/cwardgar/65/