### PR TITLE
Add suppression file for Jenkins

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+   <suppress>
+      <notes><![CDATA[
+      file name: tdmFat-5.0.0-SNAPSHOT.jar
+      file name: tdm-5.0.0-SNAPSHOT.jar
+      ]]></notes>
+      <filePath regex="true">.*\/tdm.*\.jar</filePath>
+      <cpe>cpe:/a:tdm_project:tdm</cpe>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
Add a suppression file to ignore false positives reported by dependency-check plugin on Jenkins. The entery in this file suppresses false positives for CVE-2017-7871, which deals with https://github.com/trollepierre/tdm/issues/50, which is not related to our TDM module (totally different project).