### PR TITLE
Use new sonarqube plugin, url

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -52,7 +52,7 @@ libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
 libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3"
 
-libraries["sonarqube-gradle-plugin"] = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.1"
+libraries["sonarqube-gradle-plugin"] = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
 
 libraries["license-gradle-plugin"] = "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
 

--- a/gradle/any/properties.gradle
+++ b/gradle/any/properties.gradle
@@ -6,7 +6,7 @@ ext {
     // Used to publish code coverage report to https://coveralls.io/github/Unidata/thredds
     COVERALLS_REPO_TOKEN_KEY = 'coveralls.repo.token'
     
-    // Used to publish static analysis report to https://sonarqube.com/dashboard/index/thredds
+    // Used to publish static analysis report to https://sonarcloud.io/dashboard?id=thredds
     SONARQUBE_USER_TOKEN_KEY = 'sonarqube.user.token'
     
     // Do not propagate these system properties to the Gretty web-apps or Gradle test executors.

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -15,7 +15,7 @@ gradle.projectsEvaluated {
             // Global properties. See http://docs.sonarqube.org/display/SONAR/Analysis+Parameters
             properties["sonar.verbose"] = "false"
             properties["sonar.projectKey"] = "thredds"
-            properties["sonar.host.url"] = "https://sonarqube.com"
+            properties["sonar.host.url"] = "https://sonarcloud.io"
             // Defer invocation of getPropertyOrFailBuild() until the execution phase, using lazy GStrings.
             properties["sonar.login"] = "${-> getPropertyOrFailBuild SONARQUBE_USER_TOKEN_KEY}"
             


### PR DESCRIPTION
sonarqube.com is now sonarcloud.io. This PR bumps the sonarqube plugin version as well as points to the new URL. See [here](https://about.sonarcloud.io/news/2017/06/09/sonarcloud-is-live.html) for the announcement.