### PR TITLE
Don't include servlet-api JARs in WARs that we build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ buildscript {
         classpath libraries["gretty"]
         classpath libraries["shadow"]
         classpath libraries["coveralls-gradle-plugin"]
-        classpath libraries["gradle-extra-configurations-plugin"]
     
         classpath libraries["guava"]  // For various utility methods used in the build scripts.
     }

--- a/buildSrc/src/main/groovy/edu/ucar/build/PublishingUtil.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/PublishingUtil.groovy
@@ -129,9 +129,7 @@ abstract class PublishingUtil {
                         }
                         
                         assert pomDependencyNodes*.name()*.localPart.toUnique() == ['dependency']
-
-                        // The compile-scoped dependencies of the project. The provided-scoped dependencies are
-                        // already being handled by gradle-extra-configurations-plugin: https://goo.gl/xzRuLu
+                        
                         DependencySet projCompileDeps = projCompileConfig.dependencies
 
                         List<Node> depNodesToFix = pomDependencyNodes.findAll { Node pomDependencyNode ->

--- a/dap4/d4servletshared/build.gradle
+++ b/dap4/d4servletshared/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':netcdf4')
     compile project(':cdm')
 
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["slf4j-api"]
     compile libraries["spring-web"]
     compile libraries["spring-context"]

--- a/dap4/d4ts/build.gradle
+++ b/dap4/d4ts/build.gradle
@@ -3,5 +3,5 @@ apply plugin: 'war'
 dependencies {
     compile project(':dap4:d4core')
     compile project(':dap4:d4servletshared')
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
 }

--- a/dap4/d4tswar/build.gradle
+++ b/dap4/d4tswar/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     compile project(':dap4:d4ts')
     compile project(':cdm')
     compile project(':netcdf4')
-
-    provided libraries["javax.servlet-api"]
+    
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["slf4j-api"]
     runtime libraries["log4j-slf4j-impl"]
     runtime libraries["log4j-core"]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,14 +17,10 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
         // which is a group repository that contains all other repositories. However, I prefer to list all source
         // repos explicitly so that we know where all artifacts ultimately come from.
         
-        // Hosted repositories.
+        // Hosted releases repositories.
         maven {
             // For "threddsIso", "ncwms", "visad" and "jj2000".
             url "https://artifacts.unidata.ucar.edu/repository/unidata-releases/"
-        }
-        maven {
-            // For "threddsIso" and "ncwms" snapshots.
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/"
         }
         maven {
             // For "bounce" and several dependencies needed by "ncwms".
@@ -33,24 +29,31 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
             url "https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/"
         }
     
-        // Proxied repositories. In the event that the remote repos go away, we still have copies of the artifacts.
+        // Third-party repositories.
         maven {
             // For "geotk-referencing", which is needed by "ncwms". Repositories are not inherited from a dependency,
             // so we must duplicate ncwms's needed repos here. See https://stackoverflow.com/a/19908009/3874643.
-            // Proxies 'http://maven.geotoolkit.org/'.
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-geotoolkit/"
+            url "http://maven.geotoolkit.org/"
         }
         maven {
-            // For "gretty". Proxies 'https://dl.bintray.com/cwardgar/maven/'.
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-cwardgar/"
+            url "https://dl.bintray.com/cwardgar/maven/"  // For 'com.cwardgar.gretty-fork:gretty'.
         }
         maven {
-            // For "ncsos". Proxies 'http://maven.asascience.com/maven/ncsos-releases/'.
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-ncsos/"
+            url "http://maven.asascience.com/maven/ncsos-releases/"  // For "ncsos".
         }
         maven {
-            // For "52n-oxf-xmlbeans". Proxies 'http://52north.org/maven/repo/releases/'.
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-52north/"
+            url "http://52north.org/maven/repo/releases/"  // For "52n-oxf-xmlbeans".
+        }
+        
+        // Hosted snapshots repository. We want this to be last so that we can minimize warnings such as:
+        //   Failed to get resource: HEAD. [HTTP HTTP/1.1 400 Repository version policy:
+        //   SNAPSHOT does not allow version: 1.4:
+        //   https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/org/khelekore/prtree/1.4/prtree-1.4.pom]
+        // The warning is harmless, and is even an expected part of artifact resolution, but it's spammy as hell,
+        // especially when you're running something like "./gradlew dependencies".
+        maven {
+            // For "threddsIso" and "ncwms" snapshots.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/"
         }
     }
 }
@@ -66,13 +69,11 @@ ext {
 
 ////////////////////////////////////////// Plugins //////////////////////////////////////////
 
-libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:1.0.3"
+libraries["gretty"] = "com.cwardgar.gretty-fork:gretty:2.0.1"
 
 libraries["shadow"] = "com.github.jengelman.gradle.plugins:shadow:1.2.3"
 
 libraries["coveralls-gradle-plugin"] = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1"
-
-libraries["gradle-extra-configurations-plugin"] = "com.netflix.nebula:gradle-extra-configurations-plugin:2.2.1"
 
 ////////////////////////////////////////// Spring //////////////////////////////////////////
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -3,7 +3,6 @@ import org.gradle.api.internal.java.JavaLibrary
 
 configure(javaProjects) {
     apply plugin: 'java'
-    apply plugin: 'provided-base'  // Gives us the "provided" configuration.
 
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7

--- a/opendap/build.gradle
+++ b/opendap/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':cdm')
     compile project(':httpservices')
 
-    provided libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     compile libraries["jdom2"]
     compile libraries["httpclient"]
     compile libraries["httpcore"]

--- a/opendap/dtswar/build.gradle
+++ b/opendap/dtswar/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'war'
 dependencies {
     compile project(':cdm')
     compile project(':opendap')
-
-    provided libraries["javax.servlet-api"]
+    
+    compileOnly libraries["javax.servlet-api"]
     runtime libraries["taglibs-standard-impl"]
 
     compile libraries["slf4j-api"]

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -48,7 +48,8 @@ dependencies {
     compile libraries["validation-api"]
     runtime libraries["hibernate-validator"]
     runtime libraries["jaxen"]
-
+    
+    testCompile libraries["javax.servlet-api"]  // Needed during test runtime as well, so testCompileOnly is no good.
     testCompile libraries["spring-test"]
     testCompile libraries["hamcrest-core"]
     testCompile libraries["httpunit"]

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile libraries["ncwms"]
     compile libraries["oro"]
 
-    providedCompile libraries["javax.servlet-api"]
+    compileOnly libraries["javax.servlet-api"]
     runtime libraries["taglibs-standard-impl"]
     compile libraries["validation-api"]
     runtime libraries["hibernate-validator"]
@@ -93,6 +93,15 @@ processTestResources {
 }
 
 war {
+    // Assert that no servlet-api JAR is slated for inclusion in the WAR.
+    doFirst {
+        File servletApiJar = classpath.find { it.name.contains("servlet-api") }
+        if (servletApiJar) {
+            // This will fail the build.
+            throw new GradleException("Found a servlet-api JAR in the WAR classpath: ${servletApiJar.name}")
+        }
+    }
+    
     // Replace '$projectVersion' and '$buildTimestamp' placeholders with the correct values.
     // Currently, we only use those placeholders in tds.properties and README.txt.
     def properties = [:]


### PR DESCRIPTION
* The culprit here was Gretty. I've updated to "com.cwardgar.gretty-fork:gretty:2.0.1", which fixes the bug.
* In :tds:war, fail the build if we find that a "servlet-api" JAR is slated for inclusion in the WAR.
* Use the "compileOnly" configuration that was introduced in Gradle 2.12, instead of "provided" or "providedCompile". As a result, we no longer need the "gradle-extra-configurations-plugin" plugin.
* Maven proxy repositories are proving to be a pain. Simply use the associated source repos instead. If those repos go away, we can host the needed artifacts in "unidata-3rdparty".