### PR TITLE
Set the inflate output stream buffer size

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
@@ -272,9 +272,9 @@ class H5tiledLayoutBB implements LayoutBB {
       java.util.zip.Inflater inflater = new java.util.zip.Inflater();
       java.util.zip.InflaterInputStream inflatestream
         = new java.util.zip.InflaterInputStream(in, inflater, inflatebuffersize);
-      ByteArrayOutputStream out = new ByteArrayOutputStream(
-              Math.min(8 * compressed.length, MAX_ARRAY_LEN));  // Fixes KXL-349288
-      IO.copy(inflatestream, out);
+      int len = Math.min(8 * compressed.length, MAX_ARRAY_LEN);
+      ByteArrayOutputStream out = new ByteArrayOutputStream(len); // Fixes KXL-349288
+      IO.copyB(inflatestream, out, len);
 
       byte[] uncomp = out.toByteArray();
       if (debug || debugFilter)


### PR DESCRIPTION
re: e-support ZIZ-818863
re: gihub pr https://github.com/Unidata/thredds/pull/955

The user has asked for the ability to use a larger output buffer
size for the stream to which the inflated file is written.  This
is a follow-on to the previous request to allow the user to set
the inflate buffer size.

The solution we have arrived at is to set the output buffer size
to be the same size as 8*chunk size being inflated (which is as
large or larger than the deflated size).  This means that the
chunk size for the input file will also determine the output
buffer size.

This fix is in master, if it works out, then I will add it to 5.0.0.
The fix only changes code in H5tiledLayoutBB.java, method
Datachunk#inflate().