### PR TITLE
Fix FeatureDatasetCapabilitiesXML.doOne()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tds/src/test/data/thredds/logs/
 opendap/src/test/data/test.*.*
 tds/src/test/content/thredds/logs
 tds/src/test/content/thredds/cache
+tds/src/test/content/thredds/state
 
 # OS generated files 
 .DS_Store*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip


### PR DESCRIPTION
* We must call FeatureDatasetPoint.calcBounds(), or else the capabilities document will lack the "TimeSpan" and "LatLonBox" elements.
* Do proper resource release with try/finally.
* Convert System.out.print calls to slf4j.
* User JUnit's TempoaryFolder @rule, not TestDir.getTempFile().

Other stuff:
* Update Gradle from 3.4.1 to 3.5.1.
* Add "tds/src/test/content/thredds/state" to .gitignore.