### PR TITLE
Change Maven repository for geotoolkit JARs

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,9 +31,9 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
     
         // Third-party repositories.
         maven {
-            // For "geotk-referencing", which is needed by "ncwms". Repositories are not inherited from a dependency,
+            // For geotoolkit JARs, which are needed by "ncwms". Repositories are not inherited from a dependency,
             // so we must duplicate ncwms's needed repos here. See https://stackoverflow.com/a/19908009/3874643.
-            url "http://maven.geotoolkit.org/"
+            url "https://nexus.geomatys.com/repository/geotoolkit/"
         }
         maven {
             url "https://dl.bintray.com/cwardgar/maven/"  // For 'com.cwardgar.gretty-fork:gretty'.


### PR DESCRIPTION
This seems to fix the threddsMaster failures we've been seeing on Jenkins, such as [Job 357](https://jenkins-aws.unidata.ucar.edu/job/threddsMaster/357/console). I noticed that all of the corrupt JARs were coming from http://maven.geotoolkit.org. That's not a valid Maven repository URL; the correct URL is https://nexus.geomatys.com/repository/geotoolkit/. Obviously they are doing some Apache magic to make the first URL work.

On a lark, I decided to try the second URL, and lo and behold, [the issue vanished](https://jenkins-aws.unidata.ucar.edu/job/cwardgar/1/console). I can't tell you why. Maybe the redirect/rewrite operation is corrupting the bytes, either on the client or the server. Who knows?

In any event, I'm not very confident that this commit really fixes the problem. Once this is merged into master, I want to run Jenkins again.