### PR TITLE
Use a proxy repository (on artifacts) for geotoolkit dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
         // which is a group repository that contains all other repositories. However, I prefer to list all source
         // repos explicitly so that we know where all artifacts ultimately come from.
         
-        // Hosted releases repositories.
+        // Hosted release repositories.
         maven {
             // For "threddsIso", "ncwms", "visad" and "jj2000".
             url "https://artifacts.unidata.ucar.edu/repository/unidata-releases/"
@@ -29,12 +29,22 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
             url "https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/"
         }
     
-        // Third-party repositories.
+        // Hosted proxy repositories. In the event that the remote repos go away, we still have copies of the artifacts.
         maven {
             // For geotoolkit JARs, which are needed by "ncwms". Repositories are not inherited from a dependency,
             // so we must duplicate ncwms's needed repos here. See https://stackoverflow.com/a/19908009/3874643.
-            url "https://nexus.geomatys.com/repository/geotoolkit/"
+            //
+            // This repo proxies "https://nexus.geomatys.com/repository/geotoolkit/", which Gradle seems to have
+            // difficulty interacting with. It complains about malformed class files in the JARs that it downloads
+            // from there, which lead to compilation failures in :tds:compileJava. I cannot pinpoint the exact cause,
+            // but I suspect it's because the host requires clients to support SNI, but Gradle currently does not
+            // (see https://github.com/gradle/gradle/issues/1868). A proxy repository circumvents the issue: it
+            // downloads the artifacts from the source repo on behalf of Gradle. That way, Gradle needn't interact
+            // with the source repo at all.
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-geotoolkit/"
         }
+    
+        // Third-party repositories.
         maven {
             url "https://dl.bintray.com/cwardgar/maven/"  // For 'com.cwardgar.gretty-fork:gretty'.
         }
@@ -45,7 +55,7 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
             url "http://52north.org/maven/repo/releases/"  // For "52n-oxf-xmlbeans".
         }
         
-        // Hosted snapshots repository. We want this to be last so that we can minimize warnings such as:
+        // Hosted snapshot repository. We want this to be last so that we can minimize warnings such as:
         //   Failed to get resource: HEAD. [HTTP HTTP/1.1 400 Repository version policy:
         //   SNAPSHOT does not allow version: 1.4:
         //   https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/org/khelekore/prtree/1.4/prtree-1.4.pom]


### PR DESCRIPTION
Second attempt to fix the threddsMaster failures on Jenkins. As before, I already have a [successful run of the "cwardgar" Jenkins job](https://jenkins-aws.unidata.ucar.edu/job/cwardgar/2/). Once this is merged into master, I want to run threddsMaster again.