### PR TITLE
Change logger declarations in Groovy test classes.

### DIFF
--- a/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishToRawRepoTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishToRawRepoTaskSpec.groovy
@@ -4,8 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Test static methods of PublishToRawRepoTask.
  *
@@ -13,7 +11,7 @@ import java.lang.invoke.MethodHandles
  * @since 2017-09-30
  */
 class PublishToRawRepoTaskSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(PublishToRawRepoTaskSpec)
     
     def "stripLeadingAndTrailingSlashes"() {
         expect: 'empty string produces empty string'

--- a/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishingUtilTest.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishingUtilTest.groovy
@@ -14,8 +14,6 @@ import org.slf4j.LoggerFactory
 import spock.lang.Issue
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Test PublishingUtil with ProjectBuilder and GradleRunner.
  *
@@ -23,7 +21,7 @@ import java.lang.invoke.MethodHandles
  * @since 2016-01-16
  */
 class PublishingUtilTest extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(PublishingUtilTest)
     
     def "createDependencyManagement() on multi-module project"() {
         setup: "Build a test Project using ProjectBuilder"

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
@@ -13,8 +13,6 @@ import org.xmlunit.builder.Input
 import org.xmlunit.diff.Diff
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests ToolsUiJnlpBaseTask.
  *
@@ -22,7 +20,7 @@ import java.lang.invoke.MethodHandles
  * @since 2017-04-05
  */
 class ToolsUiJnlpBaseTaskSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(ToolsUiJnlpBaseTaskSpec)
     
     @Rule TemporaryFolder tempFolder
     

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
@@ -15,8 +15,6 @@ import org.xmlunit.builder.Input
 import org.xmlunit.diff.Diff
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests ToolsUiJnlpExtensionTask.
  *
@@ -24,7 +22,7 @@ import java.lang.invoke.MethodHandles
  * @since 2017-04-05
  */
 class ToolsUiJnlpExtensionTaskSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(ToolsUiJnlpExtensionTaskSpec)
     
     private static Project rootProject
     

--- a/cdm/src/test/groovy/ucar/nc2/ft/point/FlattenedDatasetPointCollectionSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft/point/FlattenedDatasetPointCollectionSpec.groovy
@@ -4,26 +4,19 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import ucar.nc2.constants.FeatureType
-import ucar.nc2.ft.DsgFeatureCollection
-import ucar.nc2.ft.FeatureDatasetPoint
-import ucar.nc2.ft.PointFeature
-import ucar.nc2.ft.PointFeatureCC
-import ucar.nc2.ft.PointFeatureCCC
-import ucar.nc2.ft.PointFeatureCollection
+import ucar.nc2.ft.*
 import ucar.nc2.time.CalendarDateRange
 import ucar.nc2.time.CalendarDateUnit
 import ucar.unidata.geoloc.EarthLocationImpl
 import ucar.unidata.geoloc.LatLonPointImpl
 import ucar.unidata.geoloc.LatLonRect
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015/06/26
  */
 class FlattenedDatasetPointCollectionSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(FlattenedDatasetPointCollectionSpec)
     
     // FDP used in all feature methods. Its getPointFeatureCollectionList() method will be stubbed to return
     // different collections per test.

--- a/cdm/src/test/groovy/ucar/nc2/ft/point/PointIteratorFilteredSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft/point/PointIteratorFilteredSpec.groovy
@@ -16,14 +16,12 @@ import ucar.nc2.time.CalendarDateUnit
 import ucar.unidata.geoloc.LatLonPointImpl
 import ucar.unidata.geoloc.LatLonRect
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015/09/21
  */
 class PointIteratorFilteredSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(PointIteratorFilteredSpec)
     
     def "space and time filter"() {
         setup: "feature dataset"

--- a/cdm/src/test/groovy/ucar/nc2/ft/point/remote/PointStreamSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft/point/remote/PointStreamSpec.groovy
@@ -13,14 +13,12 @@ import ucar.nc2.ft.point.FlattenedDatasetPointCollection
 import ucar.nc2.ft.point.PointTestUtil
 import ucar.unidata.util.test.TestDir
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015/09/21
  */
 class PointStreamSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(PointStreamSpec)
     
     public static final String cfDocDsgExamplesDir = TestDir.cdmLocalTestDataDir + "cfDocDsgExamples/";
     public static final String pointDir = TestDir.cdmLocalTestDataDir + "point/";

--- a/cdm/src/test/groovy/ucar/nc2/iosp/netcdf3/N3iospSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/iosp/netcdf3/N3iospSpec.groovy
@@ -4,14 +4,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015/09/16
  */
 class N3iospSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(N3iospSpec)
     
     def "test invalid NetCDF object names: null or empty"() {
         expect: "null names are invalid"

--- a/cdm/src/test/groovy/ucar/nc2/ncml/CacheAggregationsSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ncml/CacheAggregationsSpec.groovy
@@ -8,8 +8,6 @@ import ucar.nc2.Variable
 import ucar.nc2.dataset.DatasetUrl
 import ucar.nc2.dataset.NetcdfDataset
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests acquiring aggregated datasets from a file cache.
  *
@@ -17,7 +15,7 @@ import java.lang.invoke.MethodHandles
  * @since 2015-12-29
  */
 class CacheAggregationsSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(CacheAggregationsSpec)
     
     def setupSpec() {
         // All datasets, once opened, will be added to this cache.

--- a/cdm/src/test/groovy/ucar/nc2/ncml/NcMLWriterSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ncml/NcMLWriterSpec.groovy
@@ -14,14 +14,12 @@ import ucar.ma2.DataType
 import ucar.nc2.*
 import ucar.nc2.dataset.NetcdfDataset
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015/08/05
  */
 class NcMLWriterSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(NcMLWriterSpec)
     
     @Shared
     NetcdfFile ncFile

--- a/cdm/src/test/groovy/ucar/nc2/util/cache/ReacquireClosedDatasetSpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/util/cache/ReacquireClosedDatasetSpec.groovy
@@ -7,8 +7,6 @@ import ucar.nc2.dataset.DatasetUrl
 import ucar.nc2.dataset.NetcdfDataset
 import ucar.unidata.util.test.TestDir
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests caching behavior when datasets are closed and then reacquired.
  *
@@ -16,7 +14,7 @@ import java.lang.invoke.MethodHandles
  * @since 2016-01-02
  */
 class ReacquireClosedDatasetSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger logger = LoggerFactory.getLogger(ReacquireClosedDatasetSpec)
     
     def setupSpec() {
         // All datasets, once opened, will be added to this cache. Config values copied from CdmInit.

--- a/it/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
+++ b/it/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
@@ -9,7 +9,6 @@ import spock.lang.Specification
 import thredds.TestWithLocalServer
 import thredds.util.ContentType
 
-import java.lang.invoke.MethodHandles
 import java.nio.charset.Charset
 
 /**
@@ -21,7 +20,7 @@ import java.nio.charset.Charset
  * @since 2017-04-21
  */
 class FreshTdsInstallSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(FreshTdsInstallSpec)
     
     String propName = "tds.content.root.path"
     

--- a/it/src/test/groovy/thredds/client/catalog/ClientCatalogBasicSpec.groovy
+++ b/it/src/test/groovy/thredds/client/catalog/ClientCatalogBasicSpec.groovy
@@ -8,14 +8,12 @@ import spock.lang.Unroll
 import thredds.TestWithLocalServer
 import ucar.unidata.util.test.category.NeedsCdmUnitTest
 
-import java.lang.invoke.MethodHandles
-
 /**
  * @author cwardgar
  * @since 2015-10-12
  */
 class ClientCatalogBasicSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(ClientCatalogBasicSpec)
 
     @Unroll
     def "test local catalog [#catFrag]"() {

--- a/legacy/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
+++ b/legacy/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
@@ -8,8 +8,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
 import java.nio.file.Files
+
 /**
  * Tests the caching behavior of CachingThreddsS3Client.
  *
@@ -17,7 +17,7 @@ import java.nio.file.Files
  * @since 2015/08/27
  */
 class CachingThreddsS3ClientSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(CachingThreddsS3ClientSpec)
     
     // create a CachingThreddsS3Client that wraps our mock ThreddsS3Client
     ThreddsS3Client mockThreddsS3Client = Mock(ThreddsS3Client)

--- a/legacy/src/test/groovy/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3Spec.groovy
+++ b/legacy/src/test/groovy/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3Spec.groovy
@@ -9,8 +9,6 @@ import spock.lang.Shared
 import spock.lang.Specification
 import thredds.crawlabledataset.CrawlableDataset
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests CrawlableDatasetAmazonS3
  *
@@ -18,7 +16,7 @@ import java.lang.invoke.MethodHandles
  * @since 2015/08/14
  */
 class CrawlableDatasetAmazonS3Spec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(CrawlableDatasetAmazonS3Spec)
     
     // Shared resources are initialized in setupSpec()
     @Shared S3URI parentDirUri, childDir1Uri, childDir2Uri, dataset1Uri, dataset2Uri

--- a/legacy/src/test/groovy/thredds/crawlabledataset/s3/S3URISpec.groovy
+++ b/legacy/src/test/groovy/thredds/crawlabledataset/s3/S3URISpec.groovy
@@ -4,8 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests S3URI.
  *
@@ -13,7 +11,7 @@ import java.lang.invoke.MethodHandles
  * @since 2015/08/26
  */
 class S3URISpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(S3URISpec)
     
     def "constructor throws exception for invalid arguments"() {
         when: "no S3 prefix"

--- a/legacy/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
+++ b/legacy/src/test/groovy/thredds/crawlabledataset/s3/ThreddsS3ClientImplSpec.groovy
@@ -9,8 +9,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests that ThreddsS3ClientImpl implements the contract of ThreddsS3Client, particularly with respect to unhappy
  * code paths. Makes heavy use of mocking to avoid actually connecting to Amazon S3.
@@ -22,7 +20,7 @@ import java.lang.invoke.MethodHandles
  * @since 2015/08/26
  */
 class ThreddsS3ClientImplSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(ThreddsS3ClientImplSpec)
     
     ObjectListing emptyMockObjectListing
     ObjectListing nonEmptyMockObjectListing

--- a/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospMiscSpec.groovy
+++ b/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospMiscSpec.groovy
@@ -12,8 +12,6 @@ import ucar.nc2.NetcdfFile
 import ucar.nc2.NetcdfFileWriter
 import ucar.nc2.Variable
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Tests miscellaneous aspects of Nc4Iosp.
  *
@@ -21,7 +19,7 @@ import java.lang.invoke.MethodHandles
  * @since 2017-03-27
  */
 class Nc4IospMiscSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(Nc4IospMiscSpec)
     
     @Rule TemporaryFolder tempFolder = new TemporaryFolder()
     

--- a/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospSpec.groovy
+++ b/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospSpec.groovy
@@ -6,8 +6,6 @@ import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import ucar.nc2.Attribute
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Test various aspects of Nc4Iosp.
  *
@@ -15,7 +13,7 @@ import java.lang.invoke.MethodHandles
  * @since 2016-12-27
  */
 class Nc4IospSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(Nc4IospSpec)
     
     def setup() {
         // Ignore this class's tests if NetCDF-4 isn't present.

--- a/netcdf4/src/unloadedTest/groovy/ucar/nc2/jni/netcdf/UnloadedNc4IospSpec.groovy
+++ b/netcdf4/src/unloadedTest/groovy/ucar/nc2/jni/netcdf/UnloadedNc4IospSpec.groovy
@@ -5,8 +5,6 @@ import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import ucar.nc2.Attribute
 
-import java.lang.invoke.MethodHandles
-
 /**
  * Test various aspects of Nc4Iosp when the C lib is NOT loaded.
  *
@@ -14,7 +12,7 @@ import java.lang.invoke.MethodHandles
  * @since 2016-12-27
  */
 class UnloadedNc4IospSpec extends Specification {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+    private static final Logger logger = LoggerFactory.getLogger(UnloadedNc4IospSpec)
     
     def "flush in define mode, without C lib loaded"() {
         setup:


### PR DESCRIPTION
* The `MethodHandles.lookup().lookupClass()` trick doesn't work in Groovy, unfortunately.