### PR TITLE
Remove cruft from TestDir

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestConventionFeatureTypes.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestConventionFeatureTypes.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
 
@@ -66,7 +67,7 @@ public class TestConventionFeatureTypes {
 
   @Test
   public void testFeatureDatasets() throws IOException {
-    for (File f :  TestDir.getAllFilesInDirectoryStandardFilter(dir)) {
+    for (File f : getAllFilesInDirectoryStandardFilter(dir)) {
       logger.debug("Open FeatureDataset {}", f.getPath());
       try (FeatureDataset fd = FeatureDatasetFactoryManager.open(type, f.getPath(), null, new Formatter())) {
         Assert.assertNotNull(f.getPath(), fd);
@@ -79,14 +80,93 @@ public class TestConventionFeatureTypes {
   }
 
   @Test
-   public void testCoverageDatasets() throws IOException {
-    if (type != FeatureType.GRID) return;
-     for (File f :  TestDir.getAllFilesInDirectoryStandardFilter(dir)) {
-       logger.debug("Open CoverageDataset {}", f.getPath());
-       try (NetcdfDataset ds = NetcdfDataset.openDataset(f.getPath())) {
-         DtCoverageCSBuilder builder = DtCoverageCSBuilder.classify(ds, new Formatter());
-         Assert.assertNotNull(builder);
-       }
-     }
-   }
- }
+  public void testCoverageDatasets() throws IOException {
+    if (type != FeatureType.GRID) {
+      return;
+    }
+    for (File f : getAllFilesInDirectoryStandardFilter(dir)) {
+      logger.debug("Open CoverageDataset {}", f.getPath());
+      try (NetcdfDataset ds = NetcdfDataset.openDataset(f.getPath())) {
+        DtCoverageCSBuilder builder = DtCoverageCSBuilder.classify(ds, new Formatter());
+        Assert.assertNotNull(builder);
+      }
+    }
+  }
+
+  private static List<File> getAllFilesInDirectoryStandardFilter(File topDir) {
+    if (topDir == null || !topDir.exists()) {
+      return Collections.emptyList();
+    }
+
+    if ((topDir.getName().equals("exclude")) || (topDir.getName().equals("problem"))) {
+      return Collections.emptyList();
+    }
+
+    // get list of files
+    File[] fila = topDir.listFiles();
+    if (fila == null) {
+      return Collections.emptyList();
+    }
+
+    List<File> files = new ArrayList<>();
+    for (File f : fila) {
+      if (!f.isDirectory()) {
+        files.add(f);
+      }
+    }
+
+    // eliminate redundant files
+    // ".Z", ".zip", ".gzip", ".gz", or ".bz2"
+    if (files.size() > 0) {
+      Collections.sort(files);
+      ArrayList<File> files2 = new ArrayList<>(files);
+
+      File prev = null;
+      for (File f : files) {
+        String name = f.getName();
+        String stem = stem(name);
+        if (name.contains(".gbx") || name.contains(".ncx") || name.endsWith(".xml") || name.endsWith(".pdf") ||
+                name.endsWith(".txt") || name.endsWith(".tar")) {
+          files2.remove(f);
+
+        } else if (prev != null) {
+          if (name.endsWith(".ncml")) {
+            if (prev.getName().equals(stem) || prev.getName().equals(stem + ".nc")) {
+              files2.remove(prev);
+            }
+          } else if (name.endsWith(".bz2")) {
+            if (prev.getName().equals(stem)) {
+              files2.remove(f);
+            }
+          } else if (name.endsWith(".gz")) {
+            if (prev.getName().equals(stem)) {
+              files2.remove(f);
+            }
+          } else if (name.endsWith(".gzip")) {
+            if (prev.getName().equals(stem)) {
+              files2.remove(f);
+            }
+          } else if (name.endsWith(".zip")) {
+            if (prev.getName().equals(stem)) {
+              files2.remove(f);
+            }
+          } else if (name.endsWith(".Z")) {
+            if (prev.getName().equals(stem)) {
+              files2.remove(f);
+            }
+          }
+        }
+        prev = f;
+      }
+
+      return files2;
+    }
+
+    return files;
+  }
+
+  private static String stem(String name) {
+    int pos = name.lastIndexOf('.');
+    return (pos > 0) ? name.substring(0, pos) : name;
+  }
+}

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
@@ -32,7 +32,7 @@
  */
 package ucar.nc2.ncml;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,298 +41,311 @@ import ucar.nc2.*;
 import ucar.nc2.units.DateFormatter;
 import ucar.nc2.units.DateUnit;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.Date;
 
 @Category(NeedsCdmUnitTest.class)
-public class TestOffAggFmrcGrib extends TestCase {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+public class TestOffAggFmrcGrib {
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private boolean showValues = false;
+    @Test
+    public void testSimple() throws Exception {
+        String location = TestDir.cdmUnitTestDir + "ncml/nc/nam_c20s/fmrcAgg.ncml";
+        logger.debug("{}", location);
 
-  public void testSimple() throws Exception {
-    // no fmrcDefinition
-    String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
-      "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" +
-      "  <aggregation dimName='run' type='forecastModelRunCollection' timeUnitsChange='true'>\n" +
-      "    <scan location='" + TestDir.cdmUnitTestDir + "ncml/nc/nam_c20s/' suffix='.grib1' " +
-            "dateFormatMark='NAM_CONUS_20km_surface_#yyyyMMdd_HHmm'/>\n" +
-      "  </aggregation>\n" +
-      "</netcdf>";
+        // no fmrcDefinition
+        String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" +
+                "  <aggregation dimName='run' type='forecastModelRunCollection' timeUnitsChange='true'>\n" +
+                "    <scan location='" + TestDir.cdmUnitTestDir + "ncml/nc/nam_c20s/' suffix='.grib1' " +
+                "dateFormatMark='NAM_CONUS_20km_surface_#yyyyMMdd_HHmm'/>\n" + "  </aggregation>\n" + "</netcdf>";
+        logger.debug("{}", xml);
 
-    String location = TestDir.cdmUnitTestDir + "ncml/nc/nam_c20s/fmrcAgg.ncml";
-    System.out.printf("%s%n%s%n", location, xml);
-    NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), location, null);
-    TestDir.showMem("TestAggFmrcGrib start ");
+        int naggs = 8;
+        int[] runhours = new int[] { 0, 12, 18, 24, 30, 4194, 4200, 4206 };
+        double[][] timevals = new double[][] {
+                { 0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0,
+                        51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0 },
+                { 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0,
+                        63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0 },
+                { 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0,
+                        69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0 },
+                { 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0,
+                        78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0, 105.0, 108.0, Double.NaN },
+                { 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0,
+                        81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0, 105.0, 108.0, 111.0, 114.0 },
+                { 4194.0, 4197.0, 4200.0, 4203.0, 4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0,
+                        4230.0, 4233.0, 4236.0, 4239.0, 4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0,
+                        4266.0, 4269.0, 4272.0, 4275.0, 4278.0 },
+                { 4200.0, 4203.0, 4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0, 4230.0, 4233.0,
+                        4236.0, 4239.0, 4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0, 4266.0, 4269.0,
+                        4272.0, 4275.0, 4278.0, 4281.0, 4284.0 },
+                { 4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0, 4230.0, 4233.0, 4236.0, 4239.0,
+                        4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0, 4266.0, 4269.0, 4272.0, 4275.0,
+                        4278.0, 4281.0, 4284.0, 4287.0, 4290.0 } };
 
-    int naggs = 8;
+        try (NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), location, null)) {
+            logger.debug(showMem("Start "));
 
-    testDimensions(ncfile, naggs, "time");
-    testCoordVar(ncfile, 257);
-    int[] runhours = new int[] {0,12,18,24,30, 4194, 4200, 4206};
-    double[][] timevals = new double[][]  {
-    {0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0},
-    {12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0},
-    {18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0},
-    {24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0, 105.0, 108.0, Double.NaN},
-    {30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0, 105.0, 108.0, 111.0, 114.0},
-    {4194.0, 4197.0, 4200.0, 4203.0, 4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0, 4230.0, 4233.0, 4236.0, 4239.0, 4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0, 4266.0, 4269.0, 4272.0, 4275.0, 4278.0},
-    {4200.0, 4203.0, 4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0, 4230.0, 4233.0, 4236.0, 4239.0, 4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0, 4266.0, 4269.0, 4272.0, 4275.0, 4278.0, 4281.0, 4284.0},
-    {4206.0, 4209.0, 4212.0, 4215.0, 4218.0, 4221.0, 4224.0, 4227.0, 4230.0, 4233.0, 4236.0, 4239.0, 4242.0, 4245.0, 4248.0, 4251.0, 4254.0, 4257.0, 4260.0, 4263.0, 4266.0, 4269.0, 4272.0, 4275.0, 4278.0, 4281.0, 4284.0, 4287.0, 4290.0}
-  };
+            testDimensions(ncfile, naggs, "time");
+            testCoordVar(ncfile, 257);
 
-    testAggCoordVar(ncfile, naggs, new DateUnit("hours since 2006-03-15T18:00:00Z"), runhours);
-    testTimeCoordVar(ncfile, naggs, 29, "Pressure_surface", timevals);
+            testAggCoordVar(ncfile, naggs, new DateUnit("hours since 2006-03-15T18:00:00Z"), runhours);
+            testTimeCoordVar(ncfile, naggs, 29, "Pressure_surface", timevals);
 
-    System.out.println("TestAggForecastModel.testReadData ");    
-    testReadData(ncfile, naggs);
- //   testReadSlice(ncfile);
+            testReadData(ncfile, naggs);
+            //   testReadSlice(ncfile);
 
-    TestDir.showMem("TestAggFmrcGrib end ");
-    ncfile.close();    
-  }
-
-  // this has fmrcDefinition, and ragged time coords - some are set to NaNs
-  public void testRagged() throws Exception {
-    String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
-      "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" +
-      "  <aggregation dimName='run' type='forecastModelRunCollection' timeUnitsChange='true' " +
-            "fmrcDefinition='" + TestDir.cdmUnitTestDir + "ncml/nc/c20ss/fmrcDefinition.xml'>\n" +
-      "    <scan location='" + TestDir.cdmUnitTestDir + "ncml/nc/c20ss/' suffix='.grib1' enhance='true' " +
-            "dateFormatMark='NAM_CONUS_20km_selectsurface_#yyyyMMdd_HHmm'/>\n" +
-      "  </aggregation>\n" +
-      "</netcdf>";
-
-        double[][] evals = new double[][]   {
-    {0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN},
-    {6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0},
-    {12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN},
-    {18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0}
-  };
-
-    NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), "AggFmrcGribRunseq.ncml", null);
-    int naggs = 4;
-    String timeVarName = "time";
-    String timeDimName = "time";
-    testDimensions(ncfile, naggs, timeDimName);
-    testCoordVar(ncfile, 257);
-    int[] runtimes = new int[] {0,6,12,18};
-    testAggCoordVar(ncfile, naggs, new DateUnit("hours since 2006-07-29T18:00:00Z"), runtimes);
-    testTimeCoordVar(ncfile, naggs, 29, timeVarName, evals);
-
-    ncfile.close();
-  }
-
-  private void testDimensions(NetcdfFile ncfile, int nagg, String timeDimName) {
-    Dimension latDim = ncfile.findDimension("x");
-    assert null != latDim;
-    assert latDim.getShortName().equals("x");
-    assert latDim.getLength() == 369;
-    assert !latDim.isUnlimited();
-
-    Dimension lonDim = ncfile.findDimension("y");
-    assert null != lonDim;
-    assert lonDim.getShortName().equals("y");
-    assert lonDim.getLength() == 257;
-    assert !lonDim.isUnlimited();
-
-    Dimension timeDim = ncfile.findDimension(timeDimName);
-    assert null != timeDim;
-    assert timeDim.getShortName().equals(timeDimName);
-    assert timeDim.getLength() == 29;
-
-    Dimension runDim = ncfile.findDimension("run");
-    assert null != runDim;
-    assert runDim.getShortName().equals("run");
-    assert runDim.getLength() == nagg : nagg +" != "+ runDim.getLength();
-  }
-
- private void testCoordVar(NetcdfFile ncfile, int n) throws IOException {
-
-    Variable lat = ncfile.findVariable("y");
-    assert null != lat;
-    assert lat.getShortName().equals("y");
-    assert lat.getRank() == 1;
-    assert lat.getSize() == n;
-    assert lat.getShape()[0] == n;
-    assert lat.getDataType().isFloatingPoint();
-
-    assert !lat.isUnlimited();
-    assert lat.getDimension(0).equals(ncfile.findDimension("y"));
-
-    Attribute att = lat.findAttribute("units");
-    assert null != att;
-    assert !att.isArray();
-    assert att.isString();
-    assert att.getDataType() == DataType.STRING;
-    assert att.getStringValue().equals("km");
-    assert att.getNumericValue() == null;
-    assert att.getNumericValue(3) == null;
-
-   Array data = lat.read();
-   assert data.getRank() == 1;
-   assert data.getSize() == n;
-   assert data.getShape()[0] == n;
-   assert data.getElementType() == double.class || data.getElementType() == float.class;
-
-   int last =(int)  data.getSize() - 1;
-   assert Misc.closeEnough(data.getDouble(0), -832.2073364257812) : data.getDouble(0);
-   assert Misc.closeEnough(data.getDouble(last), 4369.20068359375) : data.getDouble(last);
-  }
-
-  private void testAggCoordVar(NetcdfFile ncfile, int nagg, DateUnit du, int[] runhours) {
-    Variable time = ncfile.findVariable("run");
-    assert null != time;
-    assert time.getShortName().equals("run");
-    assert time.getRank() == 1;
-    assert time.getSize() == nagg;
-    assert time.getShape()[0] == nagg;
-    assert time.getDataType() == DataType.DOUBLE;
-
-    DateFormatter formatter = new DateFormatter();
-    try {
-      Array data = time.read();
-      assert data.getRank() == 1;
-      assert data.getSize() == nagg;
-      assert data.getShape()[0] == nagg;
-      assert data.getElementType() == double.class;
-
-      NCdumpW.printArray(data);
-
-      int count = 0;
-      IndexIterator dataI = data.getIndexIterator();
-      while (dataI.hasNext()) {
-        double val = dataI.getDoubleNext();
-        assert val == runhours[count];
-        count++;
-      }
-
-    } catch (IOException io) {
-      io.printStackTrace();
-      assert false;
+            logger.debug(showMem("End "));
+        }
     }
 
-  }
-
-  private void testTimeCoordVar(NetcdfFile ncfile, int nagg, int ntimes, String varName, double[][] timevals) throws Exception {
-    Variable v = ncfile.findVariable(varName);
-    assert v != null : ncfile.getLocation();
-    Dimension d = v.getDimension(1); // time dim
-    Variable time = ncfile.findVariable(d.getShortName());
-    assert null != time;
-    System.out.printf("%ntime dimension for %s = %s%n", varName, time.getFullName());
-
-    assert time.getRank() == 2;
-    assert time.getSize() == nagg * ntimes;
-    assert time.getShape()[0] == nagg;
-    assert time.getShape()[1] == ntimes;
-    assert time.getDataType() == DataType.DOUBLE || time.getDataType() == DataType.INT;
-
-    String units = time.getUnitsString();
-    DateUnit du = new DateUnit( units);
-
-    DateFormatter formatter = new DateFormatter();
-    Array data = time.read();
-    if (true) {
-      PrintWriter pw = new PrintWriter(System.out);
-      NCdumpW.printArray(data, "timeCoords", pw, null);
-      pw.flush();
+    private static String showMem(String where) {
+        Runtime runtime = Runtime.getRuntime();
+        StringBuilder sb = new StringBuilder();
+        sb.append(where).append(" memory free = ").append(runtime.freeMemory() * .001 * .001);
+        sb.append(" total= ").append(runtime.totalMemory() * .001 * .001);
+        sb.append(" max= ").append(runtime.maxMemory() * .001 * .001).append(" MB");
+        return sb.toString();
     }
 
-    assert data.getSize() == nagg * ntimes;
-    assert data.getShape()[0] == nagg;
-    assert data.getShape()[1] == ntimes;
-    assert data.getElementType() == double.class || data.getElementType() == int.class;
+    // this has fmrcDefinition, and ragged time coords - some are set to NaNs
+    @Test
+    public void testRagged() throws Exception {
+        String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" +
+                "  <aggregation dimName='run' type='forecastModelRunCollection' timeUnitsChange='true' " +
+                "fmrcDefinition='" + TestDir.cdmUnitTestDir + "ncml/nc/c20ss/fmrcDefinition.xml'>\n" +
+                "    <scan location='" + TestDir.cdmUnitTestDir + "ncml/nc/c20ss/' suffix='.grib1' enhance='true' " +
+                "dateFormatMark='NAM_CONUS_20km_selectsurface_#yyyyMMdd_HHmm'/>\n" + "  </aggregation>\n" + "</netcdf>";
 
-    while (data.hasNext()) {
-      double val = data.nextDouble();
-      Date date = du.makeDate(val);
-      // if (showValues) System.out.println(" date= "+ formatter.toDateTimeStringISO(date));
+        double[][] evals = new double[][] {
+                { 0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0,
+                        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+                        Double.NaN, Double.NaN, Double.NaN, Double.NaN },
+                { 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0,
+                        57.0, 60.0, 63.0, 66.0, 69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0 },
+                { 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0,
+                        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+                        Double.NaN, Double.NaN, Double.NaN, Double.NaN },
+                { 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0, 42.0, 45.0, 48.0, 51.0, 54.0, 57.0, 60.0, 63.0, 66.0,
+                        69.0, 72.0, 75.0, 78.0, 81.0, 84.0, 87.0, 90.0, 93.0, 96.0, 99.0, 102.0 } };
+
+        try (NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), "AggFmrcGribRunseq.ncml", null)) {
+            int naggs = 4;
+            String timeVarName = "time";
+            String timeDimName = "time";
+            testDimensions(ncfile, naggs, timeDimName);
+            testCoordVar(ncfile, 257);
+            int[] runtimes = new int[] { 0, 6, 12, 18 };
+            testAggCoordVar(ncfile, naggs, new DateUnit("hours since 2006-07-29T18:00:00Z"), runtimes);
+            testTimeCoordVar(ncfile, naggs, 29, timeVarName, evals);
+        }
     }
 
-    Index ima = data.getIndex();
-    for (int run=0; run<nagg; run++)
-      for (int tidx=0; tidx<ntimes; tidx++) {
-        double val = data.getDouble(ima.set(run, tidx));
-        if (showValues) System.out.println(" run= "+ run + " tidx= "+ tidx +  " val= "+ val );
-        if (!Double.isNaN(val))
-          assert Misc.closeEnough(val, timevals[run][tidx]) : "run,time=("+run+","+tidx+"): "+val+" != "+ timevals[run][tidx];
-      }
+    private void testDimensions(NetcdfFile ncfile, int nagg, String timeDimName) {
+        Dimension latDim = ncfile.findDimension("x");
+        assert null != latDim;
+        assert latDim.getShortName().equals("x");
+        assert latDim.getLength() == 369;
+        assert !latDim.isUnlimited();
 
-  }
+        Dimension lonDim = ncfile.findDimension("y");
+        assert null != lonDim;
+        assert lonDim.getShortName().equals("y");
+        assert lonDim.getLength() == 257;
+        assert !lonDim.isUnlimited();
 
-  private void testReadData(NetcdfFile ncfile, int nagg) throws IOException {
-    Variable v = ncfile.findVariable("Pressure_surface");
-    assert null != v;
-    assert v.getShortName().equals("Pressure_surface");  // float Pressure_surface(run=8, time=29, y=257, x=369);
-    assert v.getRank() == 4;
-    int[] shape = v.getShape();
-    assert shape[0] == nagg;
-    assert shape[1] == 29 : new Section(shape).toString();
-    assert shape[2] == 257 : new Section(shape).toString();
-    assert shape[3] == 369 : new Section(shape).toString();
-    assert v.getDataType() == DataType.FLOAT;
+        Dimension timeDim = ncfile.findDimension(timeDimName);
+        assert null != timeDim;
+        assert timeDim.getShortName().equals(timeDimName);
+        assert timeDim.getLength() == 29;
 
-    assert !v.isCoordinateVariable();
+        Dimension runDim = ncfile.findDimension("run");
+        assert null != runDim;
+        assert runDim.getShortName().equals("run");
+        assert runDim.getLength() == nagg : nagg + " != " + runDim.getLength();
+    }
 
-    assert v.getDimension(0) == ncfile.findDimension("run");
-    assert v.getDimension(1) == ncfile.findDimension("time");
-    assert v.getDimension(2) == ncfile.findDimension("y");
-    assert v.getDimension(3) == ncfile.findDimension("x");
+    private void testCoordVar(NetcdfFile ncfile, int n) throws IOException {
+        Variable lat = ncfile.findVariable("y");
+        assert null != lat;
+        assert lat.getShortName().equals("y");
+        assert lat.getRank() == 1;
+        assert lat.getSize() == n;
+        assert lat.getShape()[0] == n;
+        assert lat.getDataType().isFloatingPoint();
 
-    Array data = v.read();
-    assert data.getRank() == 4;
-    assert data.getShape()[0] == nagg;
-    assert data.getShape()[1] == 29;
-    assert data.getShape()[2] == 257;
-    assert data.getShape()[3] == 369;
+        assert !lat.isUnlimited();
+        assert lat.getDimension(0).equals(ncfile.findDimension("y"));
 
-    double sum = MAMath.sumDoubleSkipMissingData(data, 0.0);
+        Attribute att = lat.findAttribute("units");
+        assert null != att;
+        assert !att.isArray();
+        assert att.isString();
+        assert att.getDataType() == DataType.STRING;
+        assert att.getStringValue().equals("km");
+        assert att.getNumericValue() == null;
+        assert att.getNumericValue(3) == null;
 
-    /* float sum = 0.0f;
-    IndexIterator ii = data.getIndexIterator();
-    while (ii.hasNext()) {
-      sum += ii.getFloatNext();
-    } */
-    System.out.println(" sum= "+sum);
+        Array data = lat.read();
+        assert data.getRank() == 1;
+        assert data.getSize() == n;
+        assert data.getShape()[0] == n;
+        assert data.getElementType() == double.class || data.getElementType() == float.class;
 
-  }
+        int last = (int) data.getSize() - 1;
+        assert Misc.closeEnough(data.getDouble(0), -832.2073364257812) : data.getDouble(0);
+        assert Misc.closeEnough(data.getDouble(last), 4369.20068359375) : data.getDouble(last);
+    }
 
-  private void testReadSlice(NetcdfFile ncfile, int[] origin, int[] shape) throws IOException, InvalidRangeException {
+    private void testAggCoordVar(NetcdfFile ncfile, int nagg, DateUnit du, int[] runhours) {
+        Variable time = ncfile.findVariable("run");
+        assert null != time;
+        assert time.getShortName().equals("run");
+        assert time.getRank() == 1;
+        assert time.getSize() == nagg;
+        assert time.getShape()[0] == nagg;
+        assert time.getDataType() == DataType.DOUBLE;
 
-    Variable v = ncfile.findVariable("P_sfc");
+        DateFormatter formatter = new DateFormatter();
+        try {
+            Array data = time.read();
+            assert data.getRank() == 1;
+            assert data.getSize() == nagg;
+            assert data.getShape()[0] == nagg;
+            assert data.getElementType() == double.class;
 
-      Array data = v.read(origin, shape);
-      assert data.getRank() == 4;
-      assert data.getSize() == shape[0] * shape[1] * shape[2] * shape[3];
-      assert data.getShape()[0] == shape[0] : data.getShape()[0] +" "+shape[0];
-      assert data.getShape()[1] == shape[1];
-      assert data.getShape()[2] == shape[2];
-      assert data.getShape()[3] == shape[3];
-      assert data.getElementType() == float.class;
+            NCdumpW.printArray(data);
 
-      /* Index tIndex = data.getIndex();
-      for (int i=0; i<shape[0]; i++)
-       for (int j=0; j<shape[1]; j++)
-        for (int k=0; k<shape[2]; k++) {
-          double val = data.getDouble( tIndex.set(i, j, k));
-          //System.out.println(" "+val);
-          assert TestUtils.close(val, 100*(i+origin[0]) + 10*j + k) : val;
-        } */
+            int count = 0;
+            IndexIterator dataI = data.getIndexIterator();
+            while (dataI.hasNext()) {
+                double val = dataI.getDoubleNext();
+                assert val == runhours[count];
+                count++;
+            }
 
-  }
+        } catch (IOException io) {
+            io.printStackTrace();
+            assert false;
+        }
+    }
 
-  private void testReadSlice(NetcdfFile ncfile) throws IOException, InvalidRangeException {
-    testReadSlice( ncfile, new int[] {0, 0, 0, 0}, new int[] {1, 11, 3, 4} );
-    testReadSlice( ncfile, new int[] {0, 0, 0, 0}, new int[] {3, 2, 3, 2} );
-    testReadSlice( ncfile, new int[] {3, 5, 0, 0}, new int[] {1, 5, 3, 4} );
-    testReadSlice( ncfile, new int[] {3, 9, 0, 0}, new int[] {5, 2, 2, 3} );
-   }
+    private void testTimeCoordVar(NetcdfFile ncfile, int nagg, int ntimes, String varName, double[][] timevals)
+            throws Exception {
+        Variable v = ncfile.findVariable(varName);
+        assert v != null : ncfile.getLocation();
+        Dimension d = v.getDimension(1); // time dim
+        Variable time = ncfile.findVariable(d.getShortName());
+        assert null != time;
+        logger.debug("time dimension for {} = {}", varName, time.getFullName());
+
+        assert time.getRank() == 2;
+        assert time.getSize() == nagg * ntimes;
+        assert time.getShape()[0] == nagg;
+        assert time.getShape()[1] == ntimes;
+        assert time.getDataType() == DataType.DOUBLE || time.getDataType() == DataType.INT;
+
+        String units = time.getUnitsString();
+        DateUnit du = new DateUnit(units);
+
+        Array data = time.read();
+        StringWriter sw = new StringWriter();
+        NCdumpW.printArray(data, "timeCoords", new PrintWriter(sw), null);
+        logger.debug(sw.toString());
+
+        assert data.getSize() == nagg * ntimes;
+        assert data.getShape()[0] == nagg;
+        assert data.getShape()[1] == ntimes;
+        assert data.getElementType() == double.class || data.getElementType() == int.class;
+
+        DateFormatter formatter = new DateFormatter();
+        while (data.hasNext()) {
+            double val = data.nextDouble();
+            Date date = du.makeDate(val);
+            logger.debug("date = {}", formatter.toDateTimeStringISO(date));
+        }
+
+        Index ima = data.getIndex();
+        for (int run = 0; run < nagg; run++) {
+            for (int tidx = 0; tidx < ntimes; tidx++) {
+                double val = data.getDouble(ima.set(run, tidx));
+                logger.debug("run={} tidx={} val={}", run, tidx, val);
+
+                if (!Double.isNaN(val)) {
+                    assert Misc.closeEnough(val, timevals[run][tidx]) :
+                            "run,time=(" + run + "," + tidx + "): " + val + " != " + timevals[run][tidx];
+                }
+            }
+        }
+    }
+
+    private void testReadData(NetcdfFile ncfile, int nagg) throws IOException {
+        Variable v = ncfile.findVariable("Pressure_surface");
+        assert null != v;
+        assert v.getShortName().equals("Pressure_surface");  // float Pressure_surface(run=8, time=29, y=257, x=369);
+        assert v.getRank() == 4;
+        int[] shape = v.getShape();
+        assert shape[0] == nagg;
+        assert shape[1] == 29 : new Section(shape).toString();
+        assert shape[2] == 257 : new Section(shape).toString();
+        assert shape[3] == 369 : new Section(shape).toString();
+        assert v.getDataType() == DataType.FLOAT;
+
+        assert !v.isCoordinateVariable();
+
+        assert v.getDimension(0) == ncfile.findDimension("run");
+        assert v.getDimension(1) == ncfile.findDimension("time");
+        assert v.getDimension(2) == ncfile.findDimension("y");
+        assert v.getDimension(3) == ncfile.findDimension("x");
+
+        Array data = v.read();
+        assert data.getRank() == 4;
+        assert data.getShape()[0] == nagg;
+        assert data.getShape()[1] == 29;
+        assert data.getShape()[2] == 257;
+        assert data.getShape()[3] == 369;
+
+        double sum = MAMath.sumDoubleSkipMissingData(data, 0.0);
+        logger.debug("sum={}", sum);
+    }
+
+    private void testReadSlice(NetcdfFile ncfile, int[] origin, int[] shape) throws IOException, InvalidRangeException {
+        Variable v = ncfile.findVariable("P_sfc");
+
+        Array data = v.read(origin, shape);
+        assert data.getRank() == 4;
+        assert data.getSize() == shape[0] * shape[1] * shape[2] * shape[3];
+        assert data.getShape()[0] == shape[0] : data.getShape()[0] + " " + shape[0];
+        assert data.getShape()[1] == shape[1];
+        assert data.getShape()[2] == shape[2];
+        assert data.getShape()[3] == shape[3];
+        assert data.getElementType() == float.class;
+
+        //Index tIndex = data.getIndex();
+        //for (int i = 0; i < shape[0]; i++) {
+        //    for (int j = 0; j < shape[1]; j++) {
+        //        for (int k = 0; k < shape[2]; k++) {
+        //            double val = data.getDouble(tIndex.set(i, j, k));
+        //            //logger.debug("{}", val);
+        //            assert TestUtils.close(val, 100 * (i + origin[0]) + 10 * j + k) : val;
+        //        }
+        //    }
+        //}
+    }
+
+    private void testReadSlice(NetcdfFile ncfile) throws IOException, InvalidRangeException {
+        testReadSlice(ncfile, new int[] { 0, 0, 0, 0 }, new int[] { 1, 11, 3, 4 });
+        testReadSlice(ncfile, new int[] { 0, 0, 0, 0 }, new int[] { 3, 2, 3, 2 });
+        testReadSlice(ncfile, new int[] { 3, 5, 0, 0 }, new int[] { 1, 5, 3, 4 });
+        testReadSlice(ncfile, new int[] { 3, 9, 0, 0 }, new int[] { 5, 2, 2, 3 });
+    }
 }
-

--- a/cdm/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/src/main/java/ucar/nc2/util/Misc.java
@@ -33,10 +33,10 @@
 
 package ucar.nc2.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Formatter;
+import java.util.List;
 
 /**
  * Miscellaneous static routines.
@@ -194,38 +194,6 @@ public class Misc {
   }
 
   //////////////////////////////////////////////////////////////////////
-
-  /**
-   * Filename of the user property file read from the "user.home" directory
-   * if the "unidata.testdata2.path" and "unidata.upc.share.path" are not
-   * available as system properties.
-   */
-  private static final String threddsPropFileName = "thredds.properties";
-  private static final String testdataDirPropName = "unidata.testdata.path";
-  private static String testdataDirPath = null;
-
-  public static String getTestdataDirPath() {
-    if (testdataDirPath == null)
-      testdataDirPath = System.getProperty(testdataDirPropName);  // Check for system property
-
-    if (testdataDirPath == null) {
-      File userHomeDirFile = new File(System.getProperty("user.home"));
-      File userThreddsPropsFile = new File(userHomeDirFile, threddsPropFileName);
-      if (userThreddsPropsFile.exists() && userThreddsPropsFile.canRead()) {
-        Properties userThreddsProps = new Properties();
-        try (FileInputStream fin = new FileInputStream(userThreddsPropsFile)) {
-          userThreddsProps.load(fin);
-        } catch (IOException e) {
-          System.out.println("**Failed loading user THREDDS property file: " + e.getMessage());
-        }
-        if (!userThreddsProps.isEmpty()) {
-          testdataDirPath = userThreddsProps.getProperty(testdataDirPropName);
-        }
-      }
-    }
-
-    return testdataDirPath;
-  }
 
   static public boolean compare(byte[] raw1, byte[] raw2, Formatter f) {
     if (raw1 == null || raw2 == null) return false;

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggMisc.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggMisc.java
@@ -80,10 +80,10 @@ public class TestAggMisc {
         String location = "testNestedValues.ncml";
 
         try (NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(ncml), location, null)) {
-            readAllData(ncfile);
+            TestDir.readAllData(ncfile);
 
-            Variable v    = ncfile.findVariable("time");
-            Array    data = v.read();
+            Variable v = ncfile.findVariable("time");
+            Array data = v.read();
             assert data.getSize() == 20;
             NCdumpW.printArray(data);
         }
@@ -94,10 +94,10 @@ public class TestAggMisc {
         String filename = "file:./" + TestDir.cdmLocalTestDataDir + "testNested.ncml";
 
         try (NetcdfFile ncfile = NetcdfDataset.openFile(filename, null)) {
-            readAllData(ncfile);
+            TestDir.readAllData(ncfile);
 
-            Variable v    = ncfile.findVariable("time");
-            Array    data = v.read();
+            Variable v = ncfile.findVariable("time");
+            Array data = v.read();
             assert data.getSize() == 59;
             NCdumpW.printArray(data);
         }
@@ -108,49 +108,12 @@ public class TestAggMisc {
         String filename = "file:./" + TestNcML.topDir + "nested/TestNestedDirs.ncml";
 
         try (NetcdfFile ncfile = NetcdfDataset.openFile(filename, null)) {
-            readAllData(ncfile);
+            TestDir.readAllData(ncfile);
 
-            Variable v    = ncfile.findVariable("time");
-            Array    data = v.read();
+            Variable v = ncfile.findVariable("time");
+            Array data = v.read();
             assert data.getSize() == 3;
             NCdumpW.printArray(data);
         }
-    }
-
-    // The methods below originally belonged to ucar.nc2.TestAll.
-    // They were only being used in this class, however, so I moved them and nuked TestAll.
-
-    static public int readAllData( NetcdfFile ncfile) {
-        System.out.println("\n------Reading ncfile "+ncfile.getLocation());
-        try {
-
-            for (Variable v : ncfile.getVariables()) {
-                if (v.getSize() > max_size) {
-                    Section s = makeSubset(v);
-                    System.out.println("  Try to read variable " + v.getNameAndDimensions() +
-                                       " size= " + v.getSize() + " section= " + s);
-                    v.read(s);
-                } else {
-                    System.out.println("  Try to read variable " + v.getNameAndDimensions() +
-                                       " size= " + v.getSize());
-                    v.read();
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            assert false;
-        }
-
-        return 1;
-    }
-
-    static int max_size = 1000 * 1000 * 10;
-    static Section makeSubset(Variable v) throws InvalidRangeException {
-        int[] shape = v.getShape();
-        shape[0] = 1;
-        Section s = new Section(shape);
-        long size = s.computeSize();
-        shape[0] = (int) Math.max(1, max_size / size);
-        return new Section(shape);
     }
 }

--- a/ui/src/main/java/ucar/nc2/ui/BufrTableBViewer.java
+++ b/ui/src/main/java/ucar/nc2/ui/BufrTableBViewer.java
@@ -168,18 +168,6 @@ public class BufrTableBViewer extends JPanel {
     BAMutil.setActionProperties(usedAction, "dd", "checkUsed", false, 'C', -1);
     BAMutil.addActionToContainer(buttPanel, usedAction);
 
-    AbstractAction usedAllAction = new AbstractAction() {
-      public void actionPerformed(ActionEvent e) {
-        try {
-          showUsed();
-        } catch (IOException e1) {
-          e1.printStackTrace();
-        }
-      }
-    };
-    BAMutil.setActionProperties(usedAllAction, "dd", "showUsedAll", false, 'U', -1);
-    BAMutil.addActionToContainer(buttPanel, usedAllAction);
-
     AbstractAction diffAction = new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
         try {
@@ -441,17 +429,6 @@ Class,FXY,enElementName,BUFR_Unit,BUFR_Scale,BUFR_ReferenceValue,BUFR_DataWidth_
   ///////////////////////
 
   private HashMap<Short, List<Message>> usedDds = null;
-
-  private void showUsed() throws IOException {
-    String rootDir = Misc.getTestdataDirPath();
-    String dataDir = "cdmUnitTest/formats/bufr/";
-    usedDds = new HashMap<>(3000);
-
-    scanFileForDds(rootDir + dataDir + "uniqueIDD.bufr");
-    scanFileForDds(rootDir + dataDir + "uniqueExamples.bufr");
-    scanFileForDds(rootDir + dataDir + "uniqueBrasil.bufr");
-    scanFileForDds(rootDir + dataDir + "uniqueFnmoc.bufr");
-  }
 
   private void showUsed(String filename) throws IOException {
     usedDds = new HashMap<>(3000);


### PR DESCRIPTION
* `TestDir` is a crucial utility for our test suite; almost every class in `:cdm-test` uses it in some way. So, I figured that cleaning it up could be a significant win.
* Removed "thredds.properties" and everything related to it from `TestDir`. Apparently it was an alternate way to specify "unidata.testdata.path", but I don't think we're making use of it at all.
* `Misc` also had a method that processed thredds.properties called `getTestdataDirPath()`. However, that method was only used by features in the BUFR section of ToolsUI, and even when a valid thredds.properties was available, those features no longer worked. So, I nuked `Misc.getTestdataDirPath()`, as well as the relevant ToolsUI buttons.
* I identified that `getAllFilesInDirectoryStandardFilter()`, `getAllFilesInDirectory()`, and `showMem()` were each only used by one class. So, I moved those methods to the appropriate classes.
* Completely refactored `TestOffAggFmrcGrib`. It was pretty damn crufty before.
* Removed `TestAggMisc.readAllData()` and `TestAggMisc.makeSubset()` as we already have those methods in `TestDir`.
* Log to SLF4J, not STDOUT.