### PR TITLE
In tests, log all NCdumpW output to SLF4J

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestCoordinates.java
@@ -35,7 +35,7 @@
 package ucar.nc2.dataset;
 
 
-import junit.framework.*;
+import junit.framework.TestCase;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +50,8 @@ import ucar.nc2.constants.AxisType;
 import ucar.nc2.dt.grid.GeoGrid;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.ncml.NcMLReader;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -94,7 +94,7 @@ public class TestCoordinates extends TestCase {
 
     // if offset is applied twice, the result is not in +-180 range
     Array data = v.read();
-    NCdumpW.printArray(data);
+    logger.debug(NCdumpW.toString(data));
     IndexIterator ii = data.getIndexIterator();
     while (ii.hasNext()) {
       assert Math.abs(ii.getDoubleNext()) < 180 : ii.getDoubleCurrent();

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
@@ -57,8 +57,6 @@ import ucar.unidata.geoloc.vertical.VerticalTransform;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -225,9 +223,7 @@ public class TestGridSubset {
       assert data.getShape()[2] == 32 : data.getShape()[2];
       assert data.getShape()[3] == 64 : data.getShape()[3];
 
-      StringWriter sw = new StringWriter();
-      NCdumpW.printArray(data, "grid_section", new PrintWriter(sw), null);
-      logger.debug(sw.toString());
+      logger.debug(NCdumpW.toString(data, "grid_section", null));
 
       LatLonPoint p0 = new LatLonPointImpl(29.0, -90.0);
       LatLonRect bbox = new LatLonRect(p0, 1.0, 2.0);
@@ -684,11 +680,8 @@ public class TestGridSubset {
       Array data = grid.readDataSlice(1, 0, 10, 20);
       Array data2 = grid2.readDataSlice(0, 0, 10, 20);
 
-      StringWriter sw = new StringWriter();
-      PrintWriter pw = new PrintWriter(sw);
-      NCdumpW.printArray(data, "org", pw, null);
-      NCdumpW.printArray(data2, "subset", pw, null);
-      logger.debug(sw.toString());
+      logger.debug(NCdumpW.toString(data, "org", null));
+      logger.debug(NCdumpW.toString(data2, "subset", null));
 
       ucar.unidata.util.test.CompareNetcdf.compareData(data, data2);
     }

--- a/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrc.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrc.java
@@ -49,8 +49,8 @@ import ucar.nc2.dataset.CoordinateAxis1DTime;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dt.GridCoordSystem;
 import ucar.nc2.dt.GridDatatype;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
@@ -176,7 +176,7 @@ public class TestFmrc {
           if (axis.getShortName().startsWith("layer_between")) {
             CoordinateAxis1D axis1 = (CoordinateAxis1D) axis;
             Array data = axis.read();
-            NCdumpW.printArray(data);
+            logger.debug(NCdumpW.toString(data));
             Formatter f = new Formatter();
             f.format("%n bounds1=");
             showArray(f, axis1.getBound1());

--- a/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrcMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrcMisc.java
@@ -47,8 +47,8 @@ import ucar.nc2.dt.GridCoordSystem;
 import ucar.nc2.dt.GridDatatype;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarPeriod;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Formatter;
@@ -95,13 +95,11 @@ public class TestFmrcMisc {
       Assert.assertEquals("hours since 2015-03-08 12:51:00.000 UTC", time.getUnitsString());
       Assert.assertEquals(74, time.getSize());
       Array data = time.read();
-      System.out.printf("%s%n", NCdumpW.toString(data));
+      logger.debug("{}", NCdumpW.toString(data));
 
       for (CalendarDate cd : time.getCalendarDates()) {
         assert cd.getFieldValue(CalendarPeriod.Field.Minute) == 0 : System.out.printf("%s%n", cd);
       }
     }
   }
-
-
 }

--- a/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrcOffsetsGreaterEqual.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/fmrc/TestFmrcOffsetsGreaterEqual.java
@@ -45,8 +45,8 @@ import ucar.nc2.dt.GridCoordSystem;
 import ucar.nc2.dt.GridDatatype;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateUnit;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -126,9 +126,9 @@ original data:
       GridDatatype grid = gridDs.findGridByShortName("salt");
       GridCoordSystem gcs = grid.getCoordinateSystem();
       CoordinateAxis1D timeAxis = gcs.getTimeAxis1D();
-      System.out.printf("timeAxis = %s %s%n", NCdumpW.toString(timeAxis.read()), timeAxis.getUnitsString());
+      logger.debug("timeAxis = {} {}", NCdumpW.toString(timeAxis.read()), timeAxis.getUnitsString());
       CoordinateAxis1D runAxis = gcs.getRunTimeAxis();
-      System.out.printf("runAxis = %s %s%n", NCdumpW.toString( runAxis.read()), runAxis.getUnitsString());
+      logger.debug("runAxis = {} {}", NCdumpW.toString( runAxis.read()), runAxis.getUnitsString());
 
       CalendarDate expected = CalendarDate.parseISOformat(null, "2013-05-05T00:00:00");
       CalendarDateUnit cdu = CalendarDateUnit.of(null, timeAxis.getUnitsString());

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestPointDatasets.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestPointDatasets.java
@@ -641,7 +641,7 @@ public class TestPointDatasets {
         for (ucar.nc2.ft.PointFeature pointFeature : pfc) {
           System.out.printf("   3.hashcode=%d %n", pointFeature.hashCode());
           StructureData sdata = pointFeature.getDataAll();
-          NCdumpW.printStructureData(pw, sdata);
+          logger.debug(NCdumpW.toString(sdata));
         }
       }
     }

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
@@ -45,8 +45,8 @@ import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -117,7 +117,7 @@ public class TestGribCollectionReadingIosp {
       assert data.getRank() == 4;
       assert data.getDataType() == DataType.FLOAT;
       assert data.getSize() == 2;
-      System.out.printf("%s%n", NCdumpW.toString(data));
+      logger.debug("{}", NCdumpW.toString(data));
       while (data.hasNext()) {
         float val = data.nextFloat();
         assert !Float.isNaN(val);
@@ -139,7 +139,7 @@ public class TestGribCollectionReadingIosp {
       assert data.getRank() == 4;
       assert data.getDataType() == DataType.FLOAT;
       assert data.getSize() == 12;
-      System.out.printf("%s%n", NCdumpW.toString(data));
+      logger.debug("{}", NCdumpW.toString(data));
       while (data.hasNext()) {
         float val = data.nextFloat();
         assert !Float.isNaN(val);

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestScanMode.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestScanMode.java
@@ -11,8 +11,8 @@ import ucar.nc2.dt.GridCoordSystem;
 import ucar.nc2.dt.grid.GeoGrid;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -43,7 +43,7 @@ public class TestScanMode {
 
     // should be non NAN
     Array data = grid.readDataSlice(0, 0, 714, 1779);
-    NCdumpW.printArray(data);
+    logger.debug("{}", NCdumpW.toString(data));
 
     Index ima = data.getIndex();
     float val = data.getFloat(ima);
@@ -67,7 +67,7 @@ public class TestScanMode {
 
     // should be non NAN
     Array data = grid.readDataSlice(0, 0, result[1], result[0]);
-    NCdumpW.printArray(data);
+    logger.debug("{}", NCdumpW.toString(data));
 
     Index ima = data.getIndex();
     float val = data.getFloat(ima);

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5.java
@@ -41,8 +41,8 @@ import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -123,7 +123,7 @@ public class TestH5 {
       System.out.printf("%s%n", v);
 
       Array data = v.read();
-      System.out.printf("%s%n", NCdumpW.toString(data, "offset data", null));
+      logger.debug("{}", NCdumpW.toString(data, "offset data", null));
       Index ii = data.getIndex();
       assert (data.getLong(ii.set(11, 93)) == 1718796166693743L);
 
@@ -139,7 +139,7 @@ public class TestH5 {
       System.out.printf("%s%n", v);
 
       Array data = v.read();
-      System.out.printf("%s%n", NCdumpW.toString(data, "offset data", null));
+      logger.debug("{}", NCdumpW.toString(data, "offset data", null));
       Index ii = data.getIndex();
       assert (data.getDouble(ii.set(3, 2)) == 12.0);
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5OddTypes.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5OddTypes.java
@@ -35,18 +35,19 @@ package ucar.nc2.iosp.hdf5;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
-import ucar.nc2.*;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.DebugFlagsImpl;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -77,7 +78,7 @@ public class TestH5OddTypes {
       Array data = v2.read();
       assert data.getElementType() == ByteBuffer.class : data.getElementType();
       System.out.println("data size= " + new Section(data.getShape()));
-      System.out.printf("Opaque data = %s%n", NCdumpW.toString(data));
+      logger.debug("Opaque data = {}", NCdumpW.toString(data));
 
       Array odata = v2.read(new Section("1:20"));
       assert odata.getElementType() == ByteBuffer.class;
@@ -166,7 +167,7 @@ public class TestH5OddTypes {
     try (NetcdfFile ncfile = TestH5.openH5("support/cenum.h5")) {
       Variable v = ncfile.findVariable("enum");
       Array data = v.read();
-      System.out.printf("enum data = %s%n", NCdumpW.toString(data));
+      logger.debug("enum data = {}", NCdumpW.toString(data));
       System.out.println("\n**** testReadNetcdf4 done\n\n" + ncfile);
     }
     H5header.setDebugFlags(new DebugFlagsImpl(""));

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadStructure.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadStructure.java
@@ -32,18 +32,19 @@
  */
 package ucar.nc2.iosp.hdf5;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
-import ucar.nc2.*;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Structure;
+import ucar.nc2.Variable;
 import ucar.unidata.util.test.CompareNetcdf;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
-import java.io.*;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 /**
@@ -52,22 +53,6 @@ import java.lang.invoke.MethodHandles;
 @Category(NeedsCdmUnitTest.class)
 public class TestH5ReadStructure {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  File tempFile;
-  PrintWriter out;
-
-  @Before
-  public void setUp() throws Exception {
-    tempFile = File.createTempFile("TestLongOffset", "out");
-    out = new PrintWriter(new FileOutputStream(tempFile));
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    out.close();
-    if (!tempFile.delete())
-      System.out.printf("Delete failed on %s%n", tempFile);
-  }
 
   /*Structure {
      char a_string(10);
@@ -101,7 +86,7 @@ public class TestH5ReadStructure {
         assert (arr.getElementType() == char.class);
         assert (arr instanceof ArrayChar);
         ArrayChar arrc = (ArrayChar) arr;
-        out.println(arrc.getString());
+        logger.debug(arrc.getString());
         assert arrc.getString().equals("Astronomy") : arrc.getString();
 
         arr = d.getArray("b_string");
@@ -109,7 +94,7 @@ public class TestH5ReadStructure {
         assert (arr.getElementType() == char.class);
         assert (arr instanceof ArrayChar);
         arrc = (ArrayChar) arr;
-        out.println(arrc.getString());
+        logger.debug(arrc.getString());
         assert arrc.getString().equals("Biochemistry") : arrc.getString();
       }
 
@@ -156,19 +141,19 @@ public class TestH5ReadStructure {
         assert (arr != null);
         assert (arr.getElementType() == int.class);
         assert (arr instanceof ArrayInt);
-        NCdumpW.printArray(arr, "a_name", out, null);
+        logger.debug(NCdumpW.toString(arr, "a_name", null));
 
         arr = d.getArray("b_name");
         assert (arr != null);
         assert (arr.getElementType() == float.class);
         assert (arr instanceof ArrayFloat);
-        NCdumpW.printArray(arr, "b_name", out, null);
+        logger.debug(NCdumpW.toString(arr, "b_name", null));
 
         arr = d.getArray("c_name");
         assert (arr != null);
         assert (arr.getElementType() == double.class);
         assert (arr instanceof ArrayDouble);
-        NCdumpW.printArray(arr, "c_name", out, null);
+        logger.debug(NCdumpW.toString(arr, "c_name", null));
       }
 
       // this tests that we are using the btree ok
@@ -217,7 +202,7 @@ public class TestH5ReadStructure {
           assert (arr.getElementType() == int.class);
           assert (arr instanceof ArrayInt);
           assert (arr.getInt(arr.getIndex()) == 4 + count);
-          NCdumpW.printArray(arr, "a_name", out, null);
+          logger.debug(NCdumpW.toString(arr, "a_name", null));
 
           arr = d.getArray("b_name");
           assert (arr != null);
@@ -225,7 +210,7 @@ public class TestH5ReadStructure {
           assert (arr instanceof ArrayFloat);
           assert (arr.getSize() == 3);
           assert (arr.getFloat(arr.getIndex()) == (float) 4.0 + count);
-          NCdumpW.printArray(arr, "b_name", out, null);
+          logger.debug(NCdumpW.toString(arr, "b_name", null));
 
           count++;
         }
@@ -253,7 +238,7 @@ public class TestH5ReadStructure {
           assert (arr.getElementType() == int.class);
           assert (arr instanceof ArrayInt);
           assert (arr.getInt(arr.getIndex()) == count);
-          NCdumpW.printArray(arr, "a_name", out, null);
+          logger.debug(NCdumpW.toString(arr, "a_name", null));
 
           arr = d.getArray("b_name");
           assert (arr != null);
@@ -261,7 +246,7 @@ public class TestH5ReadStructure {
           assert (arr instanceof ArrayFloat);
           assert (arr.getSize() == 3);
           assert (arr.getFloat(arr.getIndex()) == (float) count);
-          NCdumpW.printArray(arr, "b_name", out, null);
+          logger.debug(NCdumpW.toString(arr, "b_name", null));
 
           count++;
         }

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadStructure2.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadStructure2.java
@@ -32,8 +32,6 @@
  */
 package ucar.nc2.iosp.hdf5;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -43,7 +41,6 @@ import ucar.nc2.*;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
-import java.io.*;
 import java.lang.invoke.MethodHandles;
 
 /**
@@ -52,22 +49,6 @@ import java.lang.invoke.MethodHandles;
 @Category(NeedsCdmUnitTest.class)
 public class TestH5ReadStructure2 {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  File tempFile;
-  PrintWriter out;
-
-  @Before
-  public void setUp() throws Exception {
-    tempFile = File.createTempFile("TestLongOffset", "out");
-    out = new PrintWriter(new FileOutputStream(tempFile));
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    out.close();
-    if (!tempFile.delete())
-      System.out.printf("Delete failed on %s%n", tempFile);
-  }
 
   /*
      Structure {
@@ -119,7 +100,7 @@ public class TestH5ReadStructure2 {
 
         for (StructureMembers.Member m : sd.getMembers()) {
           Array data = sd.getArray(m);
-          NCdumpW.printArray(data, m.getName(), out, null);
+          logger.debug(NCdumpW.toString(data, m.getName(), null));
         }
       }
 
@@ -165,7 +146,7 @@ public class TestH5ReadStructure2 {
 
         for (StructureMembers.Member m : sd.getMembers()) {
           Array data = sd.getArray(m);
-          NCdumpW.printArray(data, m.getName(), out, null);
+          logger.debug(NCdumpW.toString(data, m.getName(), null));
         }
       }
 
@@ -213,7 +194,7 @@ public class TestH5ReadStructure2 {
 
         for (StructureMembers.Member m : sd.getMembers()) {
           Array data = sd.getArray(m);
-          NCdumpW.printArray(data, m.getName(), out, null);
+          logger.debug(NCdumpW.toString(data, m.getName(), null));
         }
       }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5npoess.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5npoess.java
@@ -43,8 +43,8 @@ import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.util.DebugFlagsImpl;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -76,7 +76,7 @@ public class TestH5npoess {
     try (NetcdfFile ncfile = TestH5.openH5("npoess/ExampleFiles/AVAFO_NPP_d2003125_t10109_e101038_b9_c2005829155458_devl_Tst.h5")) {
       Variable dset = ncfile.findVariable("Data_Products/VIIRS-AF-EDR/VIIRS-AF-EDR_Gran_0");
       Array data = dset.read();
-      NCdumpW.printArray(data, "data", System.out, null);
+      logger.debug(NCdumpW.toString(data, "data", null));
     }
   }
 
@@ -95,7 +95,7 @@ public class TestH5npoess {
       Variable dset = ncfile.findVariable("Data_Products/ATMS-SCIENCE-RDR/ATMS-SCIENCE-RDR_Aggr");
       assert (null != dset);
       Array data = dset.read();
-      NCdumpW.printArray(data, dset.getFullName(), System.out, null);
+      logger.debug(NCdumpW.toString(data, dset.getFullName(), null));
     }
     H5header.setDebugFlags( new ucar.nc2.util.DebugFlagsImpl());
   }

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4problems.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4problems.java
@@ -52,7 +52,6 @@ import ucar.nc2.util.DebugFlagsImpl;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
 
 /**
@@ -105,7 +104,7 @@ public class TestN4problems {
     Variable v = ncfile.findVariable("primary_cloud");
     Array data = v.read();
     System.out.println("\n**** testReadNetcdf4 done\n\n" + ncfile);
-    NCdumpW.printArray(data, "primary_cloud", new PrintWriter(System.out), null);
+    logger.debug(NCdumpW.toString(data, "primary_cloud", null));
     ncfile.close();
     H5header.setDebugFlags( new ucar.nc2.util.DebugFlagsImpl());
   }

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
@@ -41,10 +41,10 @@ import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.iosp.netcdf3.N3iosp;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
-import java.io.*;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
@@ -152,7 +152,7 @@ public class TestN4reading {
       System.out.println("\n**** testReadNetcdf4 done\n\n" + ncfile);
       Variable v = ncfile.findVariable("measure_for_measure_var");
       Array data = v.read();
-      NCdumpW.printArray(data, "measure_for_measure_var", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "measure_for_measure_var", null));
     }
   }
 
@@ -165,21 +165,21 @@ public class TestN4reading {
       System.out.println("\n**** testVlen open\n\n" + ncfile);
       Variable v = ncfile.findVariable("levels");
       Array data = v.read();
-      NCdumpW.printArray(data, "read()", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "read()", null));
 
       int count = 0;
       while (data.hasNext()) {
         Array as = (Array) data.next();
-        NCdumpW.printArray(as, " " + count, new PrintWriter(System.out), null);
+        logger.debug(NCdumpW.toString(as, " " + count, null));
         count++;
       }
 
       // try subset
       data = v.read("0:9:2, :");
-      NCdumpW.printArray(data, "read(0:9:2,:)", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "read(0:9:2,:)", null));
 
       data = v.read(new Section().appendRange(0, 9, 2).appendRange(null));
-      NCdumpW.printArray(data, "read(Section)", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "read(Section)", null));
 
       // fail
       //int[] origin = new int[] {0, 0};
@@ -212,7 +212,7 @@ public class TestN4reading {
       System.out.println("\n**** testVlen2 open\n\n" + ncfile);
       Variable v = ncfile.findVariable("ragged_array");
       Array data = v.read();
-      NCdumpW.printArray(data, "read()", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "read()", null));
 
       assert data instanceof ArrayObject;
       int row = 0;
@@ -226,7 +226,7 @@ public class TestN4reading {
 
       // try subset
       data = v.read("0:4:2,:");
-      NCdumpW.printArray(data, "read(0:4:2,:)", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "read(0:4:2,:)", null));
       assert data instanceof ArrayObject;
       row = 0;
       while (data.hasNext()) {
@@ -280,7 +280,7 @@ public class TestN4reading {
       assert m != null;
       assert (m.getDataType() == DataType.STRUCTURE);
 
-      System.out.println(NCdumpW.toString(data, "", null));
+      logger.debug("{}", NCdumpW.toString(data, "", null));
 
     }
     System.out.println("*** testNestedStructure ok");
@@ -362,7 +362,7 @@ public class TestN4reading {
       System.out.println("\n**** testReadNetcdf4 done\n\n" + ncfile);
       Variable v = ncfile.findVariable("fun_soundings");
       Array data = v.read();
-      NCdumpW.printArray(data, "fun_soundings", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, "fun_soundings", null));
 
       assert data instanceof ArrayStructure;
       ArrayStructure as = (ArrayStructure) data;
@@ -414,14 +414,14 @@ public class TestN4reading {
       Variable v = ncfile.findVariable("tim_records");
       int[] vshape = v.getShape();
       Array data = v.read();
-      NCdumpW.printArray(data, v.getFullName(), new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(data, v.getFullName(), null));
 
       assert data instanceof ArrayStructure;
       ArrayStructure as = (ArrayStructure) data;
       assert as.getSize() == vshape[0];  //   int loopDataA(1, *, *);
       StructureData sdata = as.getStructureData(0);
       Array vdata = sdata.getArray("loopDataA");
-      NCdumpW.printArray(vdata, "loopDataA", new PrintWriter(System.out), null);
+      logger.debug(NCdumpW.toString(vdata, "loopDataA", null));
 
       assert vdata instanceof ArrayObject;
       Object o1 = vdata.getObject(0);

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestCDF5Reading.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestCDF5Reading.java
@@ -1,7 +1,6 @@
 package ucar.nc2.jni.netcdf;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -12,18 +11,12 @@ import ucar.ma2.ArrayFloat;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.MAMath;
 import ucar.nc2.*;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.iosp.NCheader;
 import ucar.unidata.io.RandomAccessFile;
-import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.UnitTestCommon;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.category.NeedsContentRoot;
 
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 
 /**
@@ -69,12 +62,9 @@ public class TestCDF5Reading extends UnitTestCommon
             jni.setLocation(location + " (jni)");
             Array data = read(jni, "f4", "0:2");
             if(prop_visual) {
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                NCdumpW.printArray(data, pw);
-                pw.close();
-                sw.close();
-                String testresult = sw.toString().replace('r', ' ').replace('\n', ' ').trim();
+                String dump = NCdumpW.toString(data);
+                logger.debug(dump);
+                String testresult = dump.replace('r', ' ').replace('\n', ' ').trim();
                 visual("CDF Read", testresult);
             }
             Assert.assertTrue(String.format("***Fail: data mismatch"),

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospWriting.java
@@ -210,15 +210,15 @@ public class TestNc4IospWriting {
             try (NetcdfFile ncFileOut = writer.write()) {
                 ncFileOut.setLocation("writeEnumType");
 
-                Writer out = new StringWriter();
-                NCdumpW.print(ncFile, out, WantValues.all, false, false, null, null);
-                out.close();
-                mem = out.toString();
+                Writer sw = new StringWriter();
+                NCdumpW.print(ncFile, sw, WantValues.all, false, false, null, null);
+                sw.close();
+                mem = sw.toString();
 
-                out = new StringWriter();
-                NCdumpW.print(ncFileOut, out, WantValues.all, false, false, null, null);
-                out.close();
-                disk = out.toString();
+                sw = new StringWriter();
+                NCdumpW.print(ncFileOut, sw, WantValues.all, false, false, null, null);
+                sw.close();
+                disk = sw.toString();
             }
             String diffs = UnitTestCommon.compare("TestNc4IospWriting.writeEnumType", mem, disk);
             Assert.assertTrue("Differences", diffs == null);

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestNcMLStrides.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestNcMLStrides.java
@@ -35,10 +35,15 @@ import junit.framework.TestCase;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
-import ucar.nc2.*;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+import ucar.ma2.ArrayInt;
+import ucar.ma2.Index;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Section;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -90,9 +95,9 @@ public class TestNcMLStrides extends TestCase {
     ArrayInt all = (ArrayInt) time.read();
 
     ArrayInt correct = (ArrayInt) all.section(new Section(stride).getRanges());
-    System.out.printf("correct(%s) %s", stride, NCdumpW.toString(correct));
+    logger.debug("correct({}) {}", stride, NCdumpW.toString(correct));
     ArrayInt data = (ArrayInt) time.read(stride);
-    System.out.printf("data(%s) %s%n", stride, NCdumpW.toString(data));
+    logger.debug("data({}) {}", stride, NCdumpW.toString(data));
     Index ci = correct.getIndex();
     Index di = data.getIndex();
     for (int i=0; i<data.getSize(); i++)

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
@@ -45,11 +45,10 @@ import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 
@@ -83,7 +82,8 @@ public class TestOffAggExistingTimeUnitsChange extends TestCase {
 
     int count = 0;
     Array data = v.read();
-    NCdumpW.printArray(data, "time", new PrintWriter(System.out), null);
+    logger.debug(NCdumpW.toString(data, "time", null));
+
     while (data.hasNext()) {
       assert Misc.closeEnough(data.nextInt(), (count + 1) * 3);
       count++;
@@ -117,7 +117,8 @@ public class TestOffAggExistingTimeUnitsChange extends TestCase {
 
     int count = 0;
     Array data = v.read();
-    NCdumpW.printArray(data, "time", new PrintWriter(System.out), null);
+    logger.debug(NCdumpW.toString(data, "time", null));
+
     while (data.hasNext()) {
       assert data.nextInt() == count * 3;
       count++;

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
@@ -45,11 +45,8 @@ import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
-import java.util.Date;
 
 @Category(NeedsCdmUnitTest.class)
 public class TestOffAggFmrcGrib {
@@ -223,7 +220,7 @@ public class TestOffAggFmrcGrib {
             assert data.getShape()[0] == nagg;
             assert data.getElementType() == double.class;
 
-            NCdumpW.printArray(data);
+            logger.debug(NCdumpW.toString(data));
 
             int count = 0;
             IndexIterator dataI = data.getIndexIterator();
@@ -258,9 +255,7 @@ public class TestOffAggFmrcGrib {
         DateUnit du = new DateUnit(units);
 
         Array data = time.read();
-        StringWriter sw = new StringWriter();
-        NCdumpW.printArray(data, "timeCoords", new PrintWriter(sw), null);
-        logger.debug(sw.toString());
+        logger.debug(NCdumpW.toString(data, "timeCoords", null));
 
         assert data.getSize() == nagg * ntimes;
         assert data.getShape()[0] == nagg;
@@ -270,8 +265,7 @@ public class TestOffAggFmrcGrib {
         DateFormatter formatter = new DateFormatter();
         while (data.hasNext()) {
             double val = data.nextDouble();
-            Date date = du.makeDate(val);
-            logger.debug("date = {}", formatter.toDateTimeStringISO(date));
+            logger.debug("date = {}", Double.isNaN(val) ? val : formatter.toDateTimeStringISO(du.makeDate(val)));
         }
 
         Index ima = data.getIndex();

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNetcdf.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNetcdf.java
@@ -40,8 +40,8 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.units.DateFormatter;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -144,7 +144,7 @@ public class TestOffAggFmrcNetcdf extends TestCase {
       assert data.getShape()[0] == nagg;
       assert data.getElementType() == double.class;
 
-      NCdumpW.printArray(data);
+      logger.debug(NCdumpW.toString(data));
 
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNonuniform.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNonuniform.java
@@ -42,8 +42,8 @@ import ucar.ma2.IndexIterator;
 import ucar.nc2.*;
 import ucar.nc2.units.DateFormatter;
 import ucar.nc2.units.DateUnit;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -142,7 +142,7 @@ public class TestOffAggFmrcNonuniform extends TestCase {
       assert data.getShape()[0] == nagg;
       assert data.getElementType() == double.class;
 
-      NCdumpW.printArray(data);
+      logger.debug(NCdumpW.toString(data));
 
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggForecastModel.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggForecastModel.java
@@ -42,8 +42,8 @@ import ucar.ma2.IndexIterator;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.*;
 import ucar.nc2.util.Misc;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -202,7 +202,7 @@ public class TestOffAggForecastModel {
       assert data.getShape()[0] == nagg;
       assert data.getElementType() == double.class;
 
-      NCdumpW.printArray(data);
+      logger.debug(NCdumpW.toString(data));
 
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();

--- a/cdm/src/main/java/ucar/nc2/dataset/conv/WRFConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/WRFConvention.java
@@ -731,55 +731,6 @@ map_proj =  1: Lambert Conformal
     WRFEtaTransformBuilder builder = new WRFEtaTransformBuilder(cs);
     return builder.makeCoordinateTransform(ds, null);
   }
-
-  public static void main(String args[]) throws IOException, InvalidRangeException {
-    try (NetcdfFile ncd = NetcdfDataset.openFile("R:/testdata/wrf/WRFOU~C@", null)) {
-
-      Variable glat = ncd.findVariable("GLAT");
-      Array glatData = glat.read();
-      IndexIterator ii = glatData.getIndexIterator();
-      while (ii.hasNext()) {
-        ii.setDoubleCurrent(Math.toDegrees(ii.getDoubleNext()));
-      }
-      PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, CDM.utf8Charset));
-      NCdumpW.printArray(glatData, "GLAT", pw, null);
-
-      Variable glon = ncd.findVariable("GLON");
-      Array glonData = glon.read();
-      ii = glonData.getIndexIterator();
-      while (ii.hasNext()) {
-        ii.setDoubleCurrent(Math.toDegrees(ii.getDoubleNext()));
-      }
-      NCdumpW.printArray(glonData, "GLON", pw, null);
-
-
-      Index index = glatData.getIndex();
-      Index index2 = glatData.getIndex();
-
-      int[] vshape = glatData.getShape();
-      int ny = vshape[1];
-      int nx = vshape[2];
-
-      ArrayDouble.D1 diff_y = (ArrayDouble.D1) Array.factory(DataType.DOUBLE, new int[]{ny});
-      ArrayDouble.D1 diff_x = (ArrayDouble.D1) Array.factory(DataType.DOUBLE, new int[]{nx});
-
-      for (int y = 0; y < ny - 1; y++) {
-        double val = glatData.getDouble(index.set(0, y, 0)) - glatData.getDouble(index2.set(0, y + 1, 0));
-        diff_y.set(y, val);
-      }
-
-      for (int x = 0; x < nx - 1; x++) {
-        double val = glatData.getDouble(index.set(0, 0, x)) - glatData.getDouble(index2.set(0, 0, x + 1));
-        diff_x.set(x, val);
-      }
-
-      NCdumpW.printArray(diff_y, "diff_y", pw, null);
-      NCdumpW.printArray(diff_x, "diff_x", pw, null);
-    }
-
-  }
-
-
 }
 
 /*

--- a/cdm/src/test/java/ucar/ma2/TestSection.java
+++ b/cdm/src/test/java/ucar/ma2/TestSection.java
@@ -450,14 +450,14 @@ public class TestSection extends TestCase {
     Array a = Array.makeArray(DataType.DOUBLE, 1000, 0.0, 1.0);
     Array a3 = a.reshape(new int[] {10,10,10});
 
-    System.out.printf("%n%s%n", NCdumpW.toString(a3, "test a3", null));
+    logger.debug("{}", NCdumpW.toString(a3, "test a3", null));
     Array a2 = a3.slice(0,1);
 
-    System.out.printf("%n%s%n", NCdumpW.toString(a2, "a3.slice(0,1)", null));
+    logger.debug("{}", NCdumpW.toString(a2, "a3.slice(0,1)", null));
 
     Array a1 = a2.slice(0,1);
 
-    System.out.printf("%n%s%n%n", NCdumpW.toString(a1, "a2.slice(0,1)", null));
+    logger.debug("{}", NCdumpW.toString(a1, "a2.slice(0,1)", null));
 
     ArrayDouble.D2 twoD = (ArrayDouble.D2) a2;
     System.out.printf("wrong= %f%n", a2.getDouble(0));

--- a/cdm/src/test/java/ucar/nc2/TestLongOffset.java
+++ b/cdm/src/test/java/ucar/nc2/TestLongOffset.java
@@ -32,19 +32,20 @@
  */
 package ucar.nc2;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.nc2.constants.CDM;
 import ucar.unidata.util.test.TestDir;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 
 /**
  * test reading a ncfile with long offsets "large format".
  */
-
 public class TestLongOffset extends TestCase  {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -61,24 +62,24 @@ public class TestLongOffset extends TestCase  {
   protected void tearDown() throws Exception {
     out.close();
     if (!tempFile.delete())
-      System.out.printf("delete failed on %s%n",tempFile);
+      logger.debug("delete failed on {}",tempFile);
   }
 
   public void testReadLongOffset() throws IOException {
-    NetcdfFile ncfile = TestDir.openFileLocal("longOffset.nc");
-    ncfile.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
-    PrintWriter pw = new PrintWriter( new OutputStreamWriter(out, CDM.utf8Charset));
+    try (NetcdfFile ncfile = TestDir.openFileLocal("longOffset.nc")) {
+      ncfile.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
 
-    NCdumpW.print(ncfile, "-vall", pw, null);
-    ncfile.close();
+      StringWriter sw = new StringWriter();
+      NCdumpW.print(ncfile, "-vall", sw, null);
+      logger.debug(sw.toString());
+    }
   }
 
   public void testReadLongOffsetV3mode() throws IOException {
-    NetcdfFile ncfile = TestDir.openFileLocal( "longOffset.nc");
-    PrintWriter pw = new PrintWriter( new OutputStreamWriter(out, CDM.utf8Charset));
-
-    NCdumpW.print(ncfile, "-vall", pw, null);
-    ncfile.close();
+    try (NetcdfFile ncfile = TestDir.openFileLocal( "longOffset.nc")) {
+      StringWriter sw = new StringWriter();
+      NCdumpW.print(ncfile, "-vall", sw, null);
+      logger.debug(sw.toString());
+    }
   }
-
 }

--- a/cdm/src/test/java/ucar/nc2/TestNcDump.java
+++ b/cdm/src/test/java/ucar/nc2/TestNcDump.java
@@ -56,28 +56,28 @@ public class TestNcDump {
   // Asserts that GitHub issue #929 has been fixed. See https://github.com/Unidata/thredds/issues/929
   @Test
   public void testUnsignedFillValue() throws IOException {
-    try (StringWriter writer = new StringWriter()) {
+    try (StringWriter sw = new StringWriter()) {
       NCdumpW.print(TestDir.cdmLocalTestDataDir + "testUnsignedFillValue.ncml",
-              writer, true, true, false, false, null, null);
+              sw, true, true, false, false, null, null);
 
       File expectedOutputFile = new File(TestDir.cdmLocalTestDataDir, "testUnsignedFillValue.dump");
       String expectedOutput = Files.toString(expectedOutputFile, Charsets.UTF_8);
 
-      Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(writer.toString()));
+      Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(sw.toString()));
     }
   }
 
   // Make sure the indentation is correct with a complex, nested structure.
   @Test
   public void testNestedGroups() throws IOException {
-    try (StringWriter writer = new StringWriter()) {
+    try (StringWriter sw = new StringWriter()) {
       NCdumpW.print(TestDir.cdmLocalTestDataDir + "testNestedGroups.ncml",
-              writer, true, true, false, false, null, null);
+              sw, true, true, false, false, null, null);
 
       File expectedOutputFile = new File(TestDir.cdmLocalTestDataDir, "testNestedGroups.dump");
       String expectedOutput = Files.toString(expectedOutputFile, Charsets.UTF_8);
 
-      Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(writer.toString()));
+      Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(sw.toString()));
     }
   }
 

--- a/cdm/src/test/java/ucar/nc2/TestUtils.java
+++ b/cdm/src/test/java/ucar/nc2/TestUtils.java
@@ -38,29 +38,15 @@ import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
-import ucar.nc2.constants.CDM;
 
 /**
- * Static utililities for testing
+ * Static utilities for testing
  *
  * @author Russ Rew
  */
 
 public class TestUtils  {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  static public void NCdump( String filename) {
-    try {
-      PrintWriter pw = new PrintWriter( new OutputStreamWriter(System.out, CDM.utf8Charset));
-      NCdumpW.print(filename, pw, false, true, false, false, null, null);
-      NCdumpW.printNcML(filename, pw);
-    } catch (IOException ioe) {
-      ioe.printStackTrace();
-      assert (false);
-    }
-
-    System.out.println( "**** NCdump done");
-  }
 
   /** read all data, make sure variable metadata matches the array */
   static public void testReadData( NetcdfFile ncfile, boolean showStatus) {

--- a/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffset.java
+++ b/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffset.java
@@ -37,9 +37,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
-import ucar.ma2.*;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -146,11 +146,11 @@ public class TestScaleOffset {
 
       Section s            = new Section().appendRange(1, 1).appendRange(1, 1);
       Array   readEnhanced = vs.read(s);
-      NCdumpW.printArray(readEnhanced);
+      logger.debug(NCdumpW.toString(readEnhanced));
 
       Variable sec         = vs.section(s);
       Array    readSection = sec.read();
-      NCdumpW.printArray(readSection);
+      logger.debug(NCdumpW.toString(readSection));
 
       ucar.unidata.util.test.CompareNetcdf.compareData(readEnhanced, readSection);
     }

--- a/cdm/src/test/java/ucar/nc2/dataset/TestStandardVar.java
+++ b/cdm/src/test/java/ucar/nc2/dataset/TestStandardVar.java
@@ -32,7 +32,7 @@
  */
 package ucar.nc2.dataset;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
@@ -44,7 +44,9 @@ import ucar.unidata.util.test.TestDir;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Formatter;
 
 /** Test TestStandardVar in JUnit framework. */
 
@@ -439,9 +441,9 @@ public class TestStandardVar extends TestCase {
     Array dataDefer =  deferVar.read();
 
     System.out.printf("Enhanced=");
-    NCdumpW.printArray(data);
+    logger.debug(NCdumpW.toString(data));
     System.out.printf("%nDeferred=");
-    NCdumpW.printArray(dataDefer);
+    logger.debug(NCdumpW.toString(dataDefer));
     System.out.printf("%nProcessed=");
 
     CompareNetcdf2 nc = new CompareNetcdf2(new Formatter(System.out), false, false, true);
@@ -452,7 +454,7 @@ public class TestStandardVar extends TestCase {
       double val = deferVar.convertScaleOffsetMissing(ii.getDoubleNext());
       ii.setDoubleCurrent(val);
     }
-    NCdumpW.printArray(dataDefer);
+    logger.debug(NCdumpW.toString(dataDefer));
 
     assert nc.compareData(enhancedVar.getShortName(), data, dataDefer, false);
 

--- a/cdm/src/test/java/ucar/nc2/dt/grid/TestGeoGrid.java
+++ b/cdm/src/test/java/ucar/nc2/dt/grid/TestGeoGrid.java
@@ -32,16 +32,19 @@
  */
 package ucar.nc2.dt.grid;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
-import ucar.nc2.*;
-import ucar.nc2.dataset.*;
+import ucar.ma2.Array;
+import ucar.ma2.Index;
+import ucar.ma2.Range;
+import ucar.nc2.Dimension;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dt.GridCoordSystem;
 import ucar.unidata.util.test.TestDir;
 
-import java.io.*;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 /** Test grids with 1 dimensional z and/or t dimension */
@@ -70,7 +73,7 @@ public class TestGeoGrid extends TestCase {
     assert gcs_section.getTimeAxis().equals( gcs.getTimeAxis());
 
     Array data = grid_section.readDataSlice(-1, -1, -1, -1);
-    NCdumpW.printArray( data, "grid_section", System.out,  null);
+    logger.debug(NCdumpW.toString( data, "grid_section", null));
 
     dataset.close();
   }

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
@@ -32,14 +32,18 @@
  */
 package ucar.nc2.ncml;
 
-import junit.framework.*;
-
+import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
-import ucar.nc2.*;
-import ucar.nc2.units.DateUnit;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
 import ucar.nc2.units.DateFormatter;
+import ucar.nc2.units.DateUnit;
 import ucar.nc2.util.Misc;
 
 import java.io.IOException;
@@ -257,7 +261,7 @@ public class TestAggExistingCoordVars extends TestCase {
       assert data.getShape()[0] == 3;
       assert data.getElementType() == String.class;
 
-      NCdumpW.printArray(data, "time coord", System.out, null);
+      logger.debug(NCdumpW.toString(data, "time coord", null));
 
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();
@@ -303,7 +307,7 @@ public class TestAggExistingCoordVars extends TestCase {
       assert data.getShape()[0] == 3;
       assert data.getElementType() == double.class;
 
-      NCdumpW.printArray(data, "time coord", System.out, null);
+      logger.debug(NCdumpW.toString(data, "time coord", null));
 
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingPromote.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingPromote.java
@@ -32,12 +32,17 @@
  */
 package ucar.nc2.ncml;
 
-import junit.framework.*;
-
+import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
-import ucar.nc2.*;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Dimension;
+import ucar.nc2.NCdumpW;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -83,7 +88,7 @@ public class TestAggExistingPromote extends TestCase {
     assert datap.getShape()[0] == 3;
     assert datap.getElementType() == String.class;
 
-    NCdumpW.printArray(datap, "time_coverage_end", System.out, null);
+    logger.debug(NCdumpW.toString(datap, "time_coverage_end", null));
 
     String[] resultp = new String[]{"2006-06-07T12:00:00Z", "2006-06-07T13:00:00Z", "2006-06-07T14:00:00Z"};
     int count = 0;
@@ -118,7 +123,7 @@ public class TestAggExistingPromote extends TestCase {
       assert data.getShape()[0] == 3;
       assert data.getElementType() == String.class;
 
-      NCdumpW.printArray(data, "time coord", System.out, null);
+      logger.debug(NCdumpW.toString(data, "time coord", null));
 
       count = 0;
       dataI = data.getIndexIterator();
@@ -207,7 +212,7 @@ public class TestAggExistingPromote extends TestCase {
     assert datap.getSize() == dim.getLength();
     assert datap.getElementType() == String.class;
 
-    NCdumpW.printArray(datap, "title", System.out, null);
+    logger.debug(NCdumpW.toString(datap, "title", null));
 
     while (datap.hasNext())
       assert datap.next().equals("Example Data");
@@ -228,7 +233,7 @@ public class TestAggExistingPromote extends TestCase {
     assert datap.getSize() == dim.getLength();
     assert datap.getElementType() == String.class;
 
-    NCdumpW.printArray(datap, "title", System.out, null);
+    logger.debug(NCdumpW.toString(datap, "title", null));
 
     int count = 0;
     while (datap.hasNext()) {

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggMisc.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggMisc.java
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.InvalidRangeException;
-import ucar.ma2.Section;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
@@ -85,7 +84,7 @@ public class TestAggMisc {
             Variable v = ncfile.findVariable("time");
             Array data = v.read();
             assert data.getSize() == 20;
-            NCdumpW.printArray(data);
+            logger.debug(NCdumpW.toString(data));
         }
     }
 
@@ -99,7 +98,7 @@ public class TestAggMisc {
             Variable v = ncfile.findVariable("time");
             Array data = v.read();
             assert data.getSize() == 59;
-            NCdumpW.printArray(data);
+            logger.debug(NCdumpW.toString(data));
         }
     }
 
@@ -113,7 +112,7 @@ public class TestAggMisc {
             Variable v = ncfile.findVariable("time");
             Array data = v.read();
             assert data.getSize() == 3;
-            NCdumpW.printArray(data);
+            logger.debug(NCdumpW.toString(data));
         }
     }
 }

--- a/grib/src/test/java/ucar/nc2/grib/grib1/TestGrib1Unpack.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib1/TestGrib1Unpack.java
@@ -5,14 +5,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import thredds.featurecollection.FeatureCollectionConfig;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.grib.GribData;
-import ucar.nc2.grib.grib1.tables.Grib1Customizer;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -119,7 +117,7 @@ public class TestGrib1Unpack {
       int[] shape = new int[]{gds.getNy(), gds.getNx()};
       Array dataA = Array.factory(DataType.FLOAT, shape, data);
       Array lineA = dataA.slice(0, lineno);
-      System.out.printf("%s%n", NCdumpW.toString(lineA));
+      logger.debug("{}", NCdumpW.toString(lineA));
     }
     System.out.printf("%n", method);
 

--- a/it/src/test/java/thredds/tds/TestTdsNcml.java
+++ b/it/src/test/java/thredds/tds/TestTdsNcml.java
@@ -55,7 +55,6 @@ import ucar.nc2.util.Misc;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.Formatter;
 
@@ -156,7 +155,8 @@ public class TestTdsNcml {
 
     int count = 0;
     Array data = v.read();
-    NCdumpW.printArray(data, "time", new PrintWriter(System.out), null);
+    logger.debug(NCdumpW.toString(data, "time", null));
+
     while (data.hasNext()) {
       assert Misc.closeEnough(data.nextInt(), (count + 1) * 3);
       count++;

--- a/it/src/test/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
+++ b/it/src/test/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
@@ -52,8 +52,6 @@ import ucar.unidata.geoloc.ProjectionRect;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.category.NeedsExternalResource;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 
 public class TestGridSubsetThredds {
@@ -92,9 +90,7 @@ public class TestGridSubsetThredds {
       assert data.getShape()[2] == 65 : data.getShape()[2];
       assert data.getShape()[3] == 106 : data.getShape()[3];
 
-      StringWriter sw = new StringWriter();
-      NCdumpW.printArray(data, "grid_section", new PrintWriter(sw), null);
-      logger.debug(sw.toString());
+      logger.debug(NCdumpW.toString(data, "grid_section", null));
     } finally {
       if (dataset != null) dataset.close();
     }
@@ -212,9 +208,7 @@ public class TestGridSubsetThredds {
       GeoGrid subset = grid.subset(timeRange, new Range(bestZIndex, bestZIndex), null, null);
       Array yxData = subset.readYXData(0, 0);
 
-      StringWriter sw = new StringWriter();
-      NCdumpW.printArray(yxData, "xyData", new PrintWriter(sw), null);
-      logger.debug(sw.toString());
+      logger.debug(NCdumpW.toString(yxData, "xyData", null));
     }
   }
 
@@ -268,11 +262,8 @@ public class TestGridSubsetThredds {
       Array data = grid.readDataSlice(0, 0, 159, 0);
       Array data2 = grid2.readDataSlice(0, 0, 0, 0);
 
-      StringWriter sw = new StringWriter();
-      PrintWriter pw = new PrintWriter(sw);
-      NCdumpW.printArray(data, "org", pw, null);
-      NCdumpW.printArray(data2, "subset", pw, null);
-      logger.debug(sw.toString());
+      logger.debug(NCdumpW.toString(data, "org", null));
+      logger.debug(NCdumpW.toString(data2, "subset", null));
 
       ucar.unidata.util.test.CompareNetcdf.compareData(data, data2);
     }

--- a/opendap/src/test/java/ucar/nc2/dods/TestConvertD2N.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestConvertD2N.java
@@ -34,23 +34,25 @@ package ucar.nc2.dods;
 
 import opendap.dap.*;
 import opendap.dap.parsers.ParseException;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.PrintStream;
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.Enumeration;
-import java.util.Vector;
-
 import opendap.test.TestSources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayStructure;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.StructureMembers;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.Variable;
 import ucar.nc2.util.IO;
 import ucar.unidata.util.test.UtilsMa2Test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Vector;
 
 /**
  *
@@ -165,7 +167,7 @@ public class TestConvertD2N {
         Variable v = (Variable) vars.get(i);
         Array data = v.read();
         if (showData)
-          NCdumpW.printArray(data, v.getFullName() + data.shapeToString(), System.out, null);
+          logger.debug(NCdumpW.toString(data, v.getFullName() + data.shapeToString(), null));
       }
     }
 
@@ -183,7 +185,7 @@ public class TestConvertD2N {
       }
 
       if (showData)
-        NCdumpW.printArray(data, v.getFullName()+data.shapeToString(), System.out, null);
+        logger.debug(NCdumpW.toString(data, v.getFullName()+data.shapeToString(), null));
     }
 
   }

--- a/opendap/src/test/java/ucar/nc2/dods/TestDODSnestedSequence.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestDODSnestedSequence.java
@@ -162,7 +162,7 @@ public class TestDODSnestedSequence {
     assert a.getRank() == 1;
     assert a.getSize() == 25 : a.getSize();
 
-    NCdumpW.printArray(a, "stuff", System.out, null);
+    logger.debug(NCdumpW.toString(a, "stuff", null));
 
     int count = 0;
     IndexIterator iter = a.getIndexIterator();

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridCoverageSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridCoverageSubsettingTest.java
@@ -31,18 +31,6 @@
  */
 package thredds.server.ncss.controller.grid;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,10 +48,9 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import thredds.mock.web.MockTdsContextLoader;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner.Parameters;
+import thredds.mock.web.MockTdsContextLoader;
 import ucar.ma2.Array;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
@@ -72,7 +59,16 @@ import ucar.nc2.util.IO;
 import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.ProjectionRect;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
-import ucar.unidata.util.test.TestDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ParameterizedClassRunner.class)
 @WebAppConfiguration
@@ -184,12 +180,12 @@ public class GridCoverageSubsettingTest {
     Variable v = nf.findVariable(null, "x");
     assert v != null;
     Array x = v.read();
-    NCdumpW.printArray(x);
+    logger.debug(NCdumpW.toString(x));
     System.out.printf("%n");
     v = nf.findVariable(null, "y");
     assert v != null;
     Array y = v.read();
-    NCdumpW.printArray(y);
+    logger.debug(NCdumpW.toString(y));
     System.out.printf("%n");
 
     int nx = (int) x.getSize();

--- a/ui/src/main/java/ucar/nc2/ui/ToolsUI.java
+++ b/ui/src/main/java/ucar/nc2/ui/ToolsUI.java
@@ -1734,9 +1734,9 @@ public class ToolsUI extends JPanel {
         else
           ncfile = NetcdfDataset.openFile(filename, null);
 
-        StringWriter writer = new StringWriter(50000);
-        NCdumpW.print(ncfile, command, writer, task);
-        result = writer.toString();
+        StringWriter sw = new StringWriter(50000);
+        NCdumpW.print(ncfile, command, sw, task);
+        result = sw.toString();
 
       } finally {
         try {
@@ -1755,9 +1755,9 @@ public class ToolsUI extends JPanel {
 
       GetDataRunnable runner = new GetDataRunnable() {
         public void run(Object o) throws IOException {
-          StringWriter writer = new StringWriter(50000);
-          NCdumpW.print(ncfile, command, writer, task);
-          result = writer.toString();
+          StringWriter sw = new StringWriter(50000);
+          NCdumpW.print(ncfile, command, sw, task);
+          result = sw.toString();
         }
       };
       task = new GetDataTask(runner, filename, null);


### PR DESCRIPTION
* Previously, most of it was logged to STDOUT. It was a huge contributor to the STDOUT spam we get when running tests.
* Most of the changes involved switching from the `NCdumpW.print*` methods to the `NCdumpW.toString()` methods. The latter produces a string that we just pass on to SLF4J.
* Nuked some methods in `NCdumpW` that were no longer being used. One of the `printArray()` methods was only being used by a (useless) `main()` method in `WRFConvention`, so I went ahead and nuked the `main()` too.
* I only converted `NCdumpW` output to SLF4J in this commit; many of the edited classes still have loads of other crap being printed to STDOUT. We'll get to that stuff in time.