### PR TITLE
Correct lat/lon for latlon coordinate files

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/conv/M3IOConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/M3IOConvention.java
@@ -168,7 +168,9 @@ public class M3IOConvention extends CoordSysBuilder {
     // Makes coordinate axes for Lat/Lon
     double start = findAttributeDouble(ds, startName); // degrees
     double incr = findAttributeDouble(ds, incrName); // degrees
-
+    // The coordinate value should be the cell center.
+    // I recommend also adding a bounds coordinate variable for clarity in the future.
+    start = start + incr / 2.; // shiftin lon and lat to central
     CoordinateAxis v = new CoordinateAxis1D(ds, null, name, DataType.DOUBLE, dimName, unitName,
             "synthesized coordinate from " + startName + " " + incrName + " global attributes");
     v.setValues(n, start, incr);


### PR DESCRIPTION
The IO/API format is not clear about whether data is cell-center (e.g., CRO files) or point (e.g., DOT). However, all files' meta-data describes a grid lattice where the XORIG/YORIG represent a half cell shift southwest from the location of the stored quantity (CRO or DOT). Thus, the coordinate variables should represent cell centers.

This is correctly handled in makeCoordAxis, but not in makeCoordLLAxis. This update applies the half step shift to the coordinate variable, which will correct the location during plotting in Panoply (tested).