### PR TITLE
Add calendar attribute to timeCoverage in client catalog

### DIFF
--- a/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -651,7 +651,7 @@ public class CatalogBuilder {
     // look for dates
     list = parent.getChildren("date", Catalog.defNS);
     for (Element e : list) {
-      DatasetBuilder.addToList(flds, Dataset.Dates, readDate(e,null));
+      DatasetBuilder.addToList(flds, Dataset.Dates, readDate(e, null));
     }
 
     // look for documentation
@@ -981,14 +981,13 @@ public class CatalogBuilder {
   /*
     <xsd:complexType name="timeCoverageType">
     <xsd:sequence>
+      <xsd:attribute name="calendar" type="xsd:string"/>
       <xsd:choice minOccurs="2" maxOccurs="3">
         <xsd:element name="start" type="dateTypeFormatted"/>
         <xsd:element name="end" type="dateTypeFormatted"/>
         <xsd:element name="duration" type="duration"/>
       </xsd:choice>
-
       <xsd:element name="resolution" type="duration" minOccurs="0"/>
-      <xsd:element name="calendar" type="xsd:string" minOccurs="0"/>
     </xsd:sequence>
   </xsd:complexType>
 
@@ -1037,7 +1036,7 @@ public class CatalogBuilder {
   protected DateRange readTimeCoverage(Element tElem) {
     if (tElem == null) return null;
     
-    Calendar calendar = readCalendar(tElem.getChild("calendar", Catalog.defNS));
+    Calendar calendar = readCalendar(tElem.getAttributeValue("calendar"));
     DateType start = readDate(tElem.getChild("start", Catalog.defNS), calendar);
     DateType end = readDate(tElem.getChild("end", Catalog.defNS), calendar);
 
@@ -1050,6 +1049,20 @@ public class CatalogBuilder {
       errlog.format(" ** warning: TimeCoverage error ='%s'%n", e.getMessage());
       return null;
     }
+  }
+
+  protected Calendar readCalendar(String calendarAttribValue) {
+    if (calendarAttribValue == null) {
+      return Calendar.getDefault();
+    }
+
+    Calendar calendar = Calendar.get(calendarAttribValue);
+    if (calendar == null) {
+      errlog.format(" ** Parse error: Bad calendar name = '%s'%n", calendarAttribValue);
+      return Calendar.getDefault();
+    }
+
+    return calendar;
   }
 
   protected DateType readDate(Element elem, Calendar calendar) {
@@ -1079,20 +1092,6 @@ public class CatalogBuilder {
       errlog.format(" ** Parse error: Bad duration format = '%s'%n", text);
       return null;
     }
-  }
-
-  protected Calendar readCalendar(Element elem) {
-    if (elem == null) {
-      return Calendar.getDefault();
-    }
-
-    Calendar calendar = Calendar.get(elem.getText());
-    if (calendar == null) {
-      errlog.format(" ** Parse error: Bad calendar name = '%s'%n", elem.getText());
-      return Calendar.getDefault();
-    }
-
-    return calendar;
   }
 
   /*

--- a/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -654,7 +654,7 @@ public class CatalogBuilder {
     // look for dates
     list = parent.getChildren("date", Catalog.defNS);
     for (Element e : list) {
-      DatasetBuilder.addToList(flds, Dataset.Dates, readDate(e));
+      DatasetBuilder.addToList(flds, Dataset.Dates, readDate(e,null));
     }
 
     // look for documentation
@@ -991,6 +991,7 @@ public class CatalogBuilder {
       </xsd:choice>
 
       <xsd:element name="resolution" type="duration" minOccurs="0"/>
+      <xsd:attribute name="calendar" type="xsd:string"/>
     </xsd:sequence>
   </xsd:complexType>
 
@@ -1038,9 +1039,11 @@ public class CatalogBuilder {
    */
   protected DateRange readTimeCoverage(Element tElem) {
     if (tElem == null) return null;
-
-    DateType start = readDate(tElem.getChild("start", Catalog.defNS));
-    DateType end = readDate(tElem.getChild("end", Catalog.defNS));
+    
+    String cal = tElem.getAttributeValue("calendar");
+    
+    DateType start = readDate(tElem.getChild("start", Catalog.defNS),cal);
+    DateType end = readDate(tElem.getChild("end", Catalog.defNS),cal);
     TimeDuration duration = readDuration(tElem.getChild("duration", Catalog.defNS));
     TimeDuration resolution = readDuration(tElem.getChild("resolution", Catalog.defNS));
 
@@ -1052,17 +1055,17 @@ public class CatalogBuilder {
     }
   }
 
-  protected DateType readDate(Element elem) {
+  protected DateType readDate(Element elem, String cal) {
     if (elem == null) return null;
     String format = elem.getAttributeValue("format");
     String type = elem.getAttributeValue("type");
-    return makeDateType(elem.getText(), format, type);
+    return makeDateType(elem.getText(), format, type, cal);
   }
 
-  protected DateType makeDateType(String text, String format, String type) {
+  protected DateType makeDateType(String text, String format, String type, String cal) {
     if (text == null) return null;
     try {
-      return new DateType(text, format, type);
+      return new DateType(text, format, type, ucar.nc2.time.Calendar.get(cal));
     } catch (java.text.ParseException e) {
       errlog.format(" ** Parse error: Bad date format = '%s'%n", text);
       return null;

--- a/cdm/src/main/java/ucar/nc2/units/DateRange.java
+++ b/cdm/src/main/java/ucar/nc2/units/DateRange.java
@@ -96,7 +96,7 @@ public class DateRange {
   }
 
   /**
-   * Encapsolates a range of dates, using DateType start/end, and/or a TimeDuration.
+   * Encapsulates a range of dates, using DateType start/end, and/or a TimeDuration.
    * A DateRange can be specified in any of the following ways:
    * <ol>
    * <li> a start date and end date
@@ -106,8 +106,8 @@ public class DateRange {
    *
    * @param start      starting date
    * @param end        ending date
-   * @param duration   time duration
-   * @param resolution time resolution; optional
+   * @param duration   time duration; may be null
+   * @param resolution time resolution; may be null
    */
   public DateRange(DateType start, DateType end, TimeDuration duration, TimeDuration resolution) {
     this.start = start;

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
@@ -281,14 +281,13 @@
   <!-- date and time-->
   <xsd:complexType name="timeCoverageType">
     <xsd:sequence>
+      <xsd:attribute name="calendar" type="xsd:string"/>
       <xsd:choice minOccurs="2" maxOccurs="3">
         <xsd:element name="start" type="dateTypeFormatted"/>
         <xsd:element name="end" type="dateTypeFormatted"/>
         <xsd:element name="duration" type="duration"/>
       </xsd:choice>
-
       <xsd:element name="resolution" type="duration" minOccurs="0"/>
-      <xsd:element name="calendar" type="xsd:string" minOccurs="0"/>
     </xsd:sequence>
   </xsd:complexType>
 

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
@@ -288,6 +288,7 @@
       </xsd:choice>
 
       <xsd:element name="resolution" type="duration" minOccurs="0"/>
+      <xsd:element name="calendar" type="xsd:string" minOccurs="0"/>
     </xsd:sequence>
   </xsd:complexType>
 

--- a/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
+++ b/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
@@ -1,48 +1,39 @@
 <?xml version="1.0"?>
-<catalog
-    xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
-    >
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
+    http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd">
 
   <service base="http://acd.ucar.edu/models/MOZART/DATA_COMP/datasets_nc/solve1/" serviceType="HTTP" name="disk"/>
 
   <dataset name="test1" ID="test1">
-
     <metadata inherited="true">
       <timeCoverage>
         <end>present</end>
         <duration>14 days</duration>
       </timeCoverage>
     </metadata>
-
   </dataset>
 
   <dataset name="test2" ID="test2">
-
     <metadata inherited="true">
       <timeCoverage>
         <start>1999-11-16T12:00:00</start>
         <duration>P3M</duration>
       </timeCoverage>
     </metadata>
-
   </dataset>
 
   <dataset name="test3" ID="test3">
-
     <metadata inherited="true">
       <timeCoverage>
         <start>2005-05-12 00:52:56</start>
         <end>2005-05-14 00:52:56</end>
       </timeCoverage>
     </metadata>
-
   </dataset>
 
   <dataset name="test4" ID="test4">
-
     <metadata inherited="true">
       <timeCoverage>
         <start>2005-05-12 00:52:56</start>
@@ -50,8 +41,15 @@
         <resolution>3 hour</resolution>
       </timeCoverage>
     </metadata>
-
   </dataset>
-
-
+  
+  <dataset name="test5" ID="test5">
+    <metadata inherited="true">
+      <timeCoverage>
+        <start>2017-02-12</start>
+        <end>2017-03-12</end>
+        <calendar>uniform30day</calendar>
+      </timeCoverage>
+    </metadata>
+  </dataset>
 </catalog>

--- a/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
+++ b/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
@@ -45,10 +45,9 @@
   
   <dataset name="test5" ID="test5">
     <metadata inherited="true">
-      <timeCoverage>
-        <start>2017-02-12</start>
-        <end>2017-03-12</end>
-        <calendar>uniform30day</calendar>
+      <timeCoverage calendar="uniform30day">
+        <start>2017-02-30</start>
+        <end>2017-04-01</end>
       </timeCoverage>
     </metadata>
   </dataset>

--- a/cdm/src/test/java/thredds/client/catalog/TestClientCatalog.java
+++ b/cdm/src/test/java/thredds/client/catalog/TestClientCatalog.java
@@ -199,14 +199,17 @@ public class TestClientCatalog {
     logger.debug("tc = {}", tc);
 
     CalendarDate start = tc.getStart().getCalendarDate();
-    assert CalendarDateFormatter.toDateString(start).equals("2017-02-12");
-    CalendarDate end = tc.getEnd().getCalendarDate();
-    assert CalendarDateFormatter.toDateString(end).equals("2017-03-12");
-
     assert start.getCalendar() == Calendar.uniform30day;  // Using non-default calendar.
-    // In the Gregorian calendar, the difference between 2017-02-12 and 2017-03-12 would be 28 days.
-    // But in the uniform30day calendar, it's 30.
-    assert end.getDifference(start, CalendarPeriod.Field.Day) == 30;
+
+    // This date is valid in the uniform30day calendar. If we tried it with the standard calendar, we'd get an error:
+    //     Illegal base time specification: '2017-02-30' Value 30 for dayOfMonth must be in the range [1,28]
+    assert CalendarDateFormatter.toDateString(start).equals("2017-02-30");
+
+    CalendarDate end = tc.getEnd().getCalendarDate();
+    assert CalendarDateFormatter.toDateString(end).equals("2017-04-01");
+
+    // In the uniform30day calendar, the difference between 2017-02-30 and 2017-04-01 is 31 days.
+    assert end.getDifference(start, CalendarPeriod.Field.Day) == 31;
   }
 
   /////////////

--- a/cdm/src/test/java/thredds/client/catalog/TestClientCatalog.java
+++ b/cdm/src/test/java/thredds/client/catalog/TestClientCatalog.java
@@ -38,8 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.client.catalog.tools.CatalogXmlWriter;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateFormatter;
+import ucar.nc2.time.CalendarPeriod;
 import ucar.nc2.units.DateRange;
 import ucar.nc2.units.TimeDuration;
 import ucar.nc2.units.TimeUnit;
@@ -148,7 +150,7 @@ public class TestClientCatalog {
   }
 
   @Test
-  public void testTC() throws Exception {
+  public void testTimeCoverage() throws Exception {
     Catalog cat = ClientCatalogUtil.open("TestTimeCoverage.xml");
     assert cat != null;
 
@@ -190,6 +192,21 @@ public class TestClientCatalog {
     TimeDuration d = tc.getDuration();
     TimeUnit tu = d.getTimeUnit();
     assert tu.getUnitString().equals("days") : tu.getUnitString(); // LOOK should be 3 hours, or hours or ??
+
+    ds = cat.findDatasetByID("test5");
+    tc = ds.getTimeCoverage();
+    assert null != tc;
+    logger.debug("tc = {}", tc);
+
+    CalendarDate start = tc.getStart().getCalendarDate();
+    assert CalendarDateFormatter.toDateString(start).equals("2017-02-12");
+    CalendarDate end = tc.getEnd().getCalendarDate();
+    assert CalendarDateFormatter.toDateString(end).equals("2017-03-12");
+
+    assert start.getCalendar() == Calendar.uniform30day;  // Using non-default calendar.
+    // In the Gregorian calendar, the difference between 2017-02-12 and 2017-03-12 would be 28 days.
+    // But in the uniform30day calendar, it's 30.
+    assert end.getDifference(start, CalendarPeriod.Field.Day) == 30;
   }
 
   /////////////
@@ -241,14 +258,14 @@ public class TestClientCatalog {
   public void testSubset() throws IOException {
     Catalog cat = ClientCatalogUtil.open("InvCatalog-1.0.xml");
     CatalogXmlWriter writer = new CatalogXmlWriter();
-    logger.debug(writer.writeXML(cat));
+    logger.debug("{}", writer.writeXML(cat));
 
     Dataset ds = cat.findDatasetByID("testSubset");
     assert (ds != null) : "cant find dataset 'testSubset'";
     assert ds.getFeatureType() == FeatureType.GRID;
 
     Catalog subsetCat = cat.subsetCatalogOnDataset(ds);
-    logger.debug(writer.writeXML(subsetCat));
+    logger.debug("{}", writer.writeXML(subsetCat));
 
     List<Dataset> dss = subsetCat.getDatasets();
     assert dss.size() == 1;
@@ -263,51 +280,4 @@ public class TestClientCatalog {
     assert subsetDs.getFeatureTypeName() != null;
     assert subsetDs.getFeatureTypeName().equalsIgnoreCase("Grid");
   }
-
-  ////////////////////////////
-
-  @Test
-  public void testTimeCoverage() throws Exception {
-    Catalog cat = ClientCatalogUtil.open("TestTimeCoverage.xml");
-    assert cat != null;
-
-    Dataset ds = cat.findDatasetByID("test1");
-    DateRange tc = ds.getTimeCoverage();
-    assert null != tc;
-    logger.debug("tc = {}", tc);
-    assert tc.getEnd().isPresent();
-    assert tc.getResolution() == null;
-    assert tc.getDuration().equals( new TimeDuration("14 days") );
-
-    ds = cat.findDatasetByID("test2");
-    tc = ds.getTimeCoverage();
-    assert null != tc;
-    logger.debug("tc = {}", tc);
-    CalendarDate got = tc.getStart().getCalendarDate();
-    CalendarDate want = CalendarDateFormatter.isoStringToCalendarDate(null, "1999-11-16T12:00:00");
-    assert got.equals( want);
-    assert tc.getResolution() == null;
-    TimeDuration gott = tc.getDuration();
-    TimeDuration wantt = new TimeDuration("P3M");
-    assert gott.equals( wantt);
-
-    ds = cat.findDatasetByID("test3");
-    tc = ds.getTimeCoverage();
-    assert null != tc;
-    logger.debug("tc = {}", tc);
-    assert tc.getResolution() == null;
-    assert tc.getDuration().equals( new TimeDuration("2 days") );
-
-    ds = cat.findDatasetByID("test4");
-    tc = ds.getTimeCoverage();
-    assert null != tc;
-    logger.debug("tc = {}", tc);
-    TimeDuration r = tc.getResolution();
-    assert r != null;
-    TimeDuration r2 = new TimeDuration("3 hour");
-    assert r.equals( r2 );
-    TimeDuration d = tc.getDuration();
-    TimeUnit tu = d.getTimeUnit();
-    assert tu.getUnitString().equals("days") : tu.getUnitString(); // LOOK should be 3 hours, or hours or ??
- }
 }

--- a/docs/website/tds/catalog/InvCatalogSpec.adoc
+++ b/docs/website/tds/catalog/InvCatalogSpec.adoc
@@ -850,6 +850,7 @@ Example:
       <xsd:element name="duration" type="duration"/>
     </xsd:choice>
     <xsd:element name="resolution" type="duration" minOccurs="0"/>
+    <xsd:element name="calendar" type="xsd:string" minOccurs="0"/>
   </xsd:sequence>
 </xsd:complexType>
 ----
@@ -858,8 +859,12 @@ A timeCoverage element specifies a date range. The date range can be
 specified in three ways: 1) by giving both a _start_ and an _end_
 link:#dateType[date type] element; 2) by specifying a _start_ element
 and a link:#durationType[_duration_] element; or 3) by specifying an
-_end_ element and a _duration_ element. The optional resolution element
-should be used to indicate the data resolution for time series data.
+_end_ element and a _duration_ element.
+
+There are 2 optional elements:
+1. `resolution`: the temporal resolution of time series data.
+2. `calendar`: the <<../../netcdf-java/CDM/CalendarDateTime#_supported_calendars, calendar>>
+in which the dates should be interpreted. If none is specified, `proleptic_gregorian` will be used.
 
 Example:
 
@@ -879,6 +884,12 @@ Example:
   <end>present</end>
   <duration>10 days</duration>
   <resolution>15 minutes</resolution>
+</timeCoverage>
+
+<timeCoverage>
+  <start>2017-02-12</start>
+  <end>2017-03-12</end>
+  <calendar>uniform30day</calendar>  // Difference between start and end will be 30 days, not 28 as in Gregorian.
 </timeCoverage>
 ----
 

--- a/docs/website/tds/catalog/InvCatalogSpec.adoc
+++ b/docs/website/tds/catalog/InvCatalogSpec.adoc
@@ -844,12 +844,12 @@ Example:
 ----
 <xsd:complexType name="timeCoverageType">
   <xsd:sequence>
+    <xsd:attribute name="calendar" type="xsd:string"/>
     <xsd:choice minOccurs="2" maxOccurs="3" >
       <xsd:element name="start" type="dateTypeFormatted"/>
       <xsd:element name="end" type="dateTypeFormatted"/>
       <xsd:element name="duration" type="duration"/>
     </xsd:choice>
-    <xsd:element name="resolution" type="duration" minOccurs="0"/>
     <xsd:element name="calendar" type="xsd:string" minOccurs="0"/>
   </xsd:sequence>
 </xsd:complexType>
@@ -859,12 +859,12 @@ A timeCoverage element specifies a date range. The date range can be
 specified in three ways: 1) by giving both a _start_ and an _end_
 link:#dateType[date type] element; 2) by specifying a _start_ element
 and a link:#durationType[_duration_] element; or 3) by specifying an
-_end_ element and a _duration_ element.
+_end_ element and a _duration_ element. The optional resolution element
+should be used to indicate the data resolution for time series data.
 
-There are 2 optional elements:
-1. `resolution`: the temporal resolution of time series data.
-2. `calendar`: the <<../../netcdf-java/CDM/CalendarDateTime#_supported_calendars, calendar>>
-in which the dates should be interpreted. If none is specified, `proleptic_gregorian` will be used.
+The `calendar` attribute of timeCoverage controls the CDM
+<<../../netcdf-java/CDM/CalendarDateTime#_supported_calendars, calendar>>
+in which dates should be interpreted. If none is specified, `proleptic_gregorian` will be used.
 
 Example:
 
@@ -886,10 +886,9 @@ Example:
   <resolution>15 minutes</resolution>
 </timeCoverage>
 
-<timeCoverage>
-  <start>2017-02-12</start>
-  <end>2017-03-12</end>
-  <calendar>uniform30day</calendar>  // Difference between start and end will be 30 days, not 28 as in Gregorian.
+<timeCoverage calendar="uniform30day">
+  <start>2017-02-30</start>  // Valid date in uniform30day calendar but not in Gregorian.
+  <end>2017-04-01</end>      // Difference between start and end is 31 days.
 </timeCoverage>
 ----
 


### PR DESCRIPTION
* Updated InvCatalog.1.2.xsd.
* Added test to `TestClientCatalog.testTimeCoverage()` that asserts that the element is being processed and that it is having the expected effect on start and end times.
* Removed duplicate method from `TestClientCatalog` and converted its STDOUT prints to SLF4J.
* Added documentation to `InvCatalogSpec.adoc`.

This implements the additions we discussed in #985. I decided to change `calendar` from an attribute to an element because it is more in line with how the other `timeCoverage` data are specified.

@lesserwhirls This PR includes documentation changes that you may want to keep track of.