### PR TITLE
Fixes #445: GRIB1 data length overflow

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionIndicator.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1SectionIndicator.java
@@ -49,6 +49,8 @@ public class Grib1SectionIndicator {
 
   private final long messageLength;
   private final long startPos;
+  private final int messageLengthNotFixed;
+  boolean isMessageLengthFixed=false;
 
   /**
    * Read Grib2SectionIndicator from raf.
@@ -65,15 +67,21 @@ public class Grib1SectionIndicator {
       if (b[i] != MAGIC[i])
         throw new IllegalArgumentException("Not a GRIB record");
 
-    messageLength = GribNumbers.uint3(raf);
+    messageLengthNotFixed = GribNumbers.uint3(raf);
     int edition = raf.read();
     if (edition != 1)
       throw new IllegalArgumentException("Not a GRIB-1 record");
+    messageLength = Grib1RecordScanner.getFixedTotalLengthEcmwfLargeGrib(raf, messageLengthNotFixed);
+    if(messageLength!=messageLengthNotFixed) {
+    	isMessageLengthFixed = true;
+    }
   }
 
   public Grib1SectionIndicator(long startPos, long messageLength) {
     this.startPos = startPos;
     this.messageLength = messageLength;
+    this.messageLengthNotFixed = (int)messageLength;
+    this.isMessageLengthFixed = false;
   }
 
   /**


### PR DESCRIPTION
Due to a trick done by ECMWF's GRIBEX to support large GRIBs, we need a special treatment to fix the length of the GRIB message. See: 
https://software.ecmwf.int/wiki/display/EMOS/Changes+in+cycle+000281
https://github.com/Unidata/thredds/issues/445
