### PR TITLE
Enable NcML written in TDS config catalogs to be opened as a FeatureDatasetCoverage

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
@@ -1,16 +1,20 @@
 /*
- * (c) 1998-2017 John Caron and University Corporation for Atmospheric Research/Unidata
+ * (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  */
 package ucar.nc2.ft2.coverage;
 
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.DatasetUrl;
+import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.ft.FeatureDataset;
 import ucar.nc2.ft2.coverage.adapter.DtCoverageAdapter;
 import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset;
+import ucar.nc2.ncml.NcMLReader;
 import ucar.nc2.util.Optional;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -125,6 +129,18 @@ public class CoverageDatasetFactory {
       return Optional.empty(e.getCause().getMessage());
     }
 
+  }
+
+  static public Optional<FeatureDatasetCoverage> openNcmlString(String ncml) throws IOException, FileNotFoundException {
+    NetcdfDataset ncd = NcMLReader.readNcML(new StringReader(ncml), null);
+
+    DtCoverageDataset gds = new DtCoverageDataset(ncd);
+    if (gds.getGrids().size() > 0) {
+      Formatter errlog = new Formatter();
+      FeatureDatasetCoverage cc = DtCoverageAdapter.factory(gds, errlog);
+      return  ucar.nc2.util.Optional.of(cc);
+    }
+      return Optional.empty("Could not open NcML as Coverage");
   }
 
 }

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -168,8 +168,8 @@
     </dataset>
 
     <!-- test NcML aggregation in dataset -->
-    <dataset name="Example NcML Aggregation" ID="ExampleNcMLAgg" urlPath="ExampleNcML/Agg.nc">
-      <serviceName>odap</serviceName>
+    <dataset name="Example NcML Aggregation - GRID default services" ID="ExampleNcMLAgg" urlPath="ExampleNcML/Agg.nc">
+      <serviceName>all</serviceName>
       <dataType>Grid</dataType>
       <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
         <attribute name="ncmlAdded" value="stuff"/>

--- a/tds/src/test/content/thredds/threddsConfig.xml
+++ b/tds/src/test/content/thredds/threddsConfig.xml
@@ -87,7 +87,6 @@
   </GribIndex>
 
   <AggregationCache>
-    <dir>/tomcat_home/content/thredds/cache/agg/</dir>
     <scour>24 hours</scour>
     <maxAge>90 days</maxAge>
     <cachePathPolicy>OneDirectory</cachePathPolicy>


### PR DESCRIPTION
Fixes the issue where WCS service did not work for NcML, as reported on the THREDDS mailing list.