### PR TITLE
Fix bug in config catalog initialization

### DIFF
--- a/tds/src/main/java/thredds/core/ConfigCatalogInitialization.java
+++ b/tds/src/main/java/thredds/core/ConfigCatalogInitialization.java
@@ -181,7 +181,17 @@ public class ConfigCatalogInitialization {
 
     switch (readMode) {
       case always:
-        if (databaseAlreadyExists) this.datasetTracker.reinit();
+        // if the database already exists, we need to close it
+        // before we reinit
+        if (databaseAlreadyExists) {
+          logCatalogInit.info("ConfigCatalogInitializion datasetTracker database already exists - closing it before reinitialization.");
+          try {
+            this.datasetTracker.close();
+          } catch (IOException e) {
+            logCatalogInit.error("There was an error closing the datasetTracker database.", e);
+          }
+          this.datasetTracker.reinit();
+        }
         this.catalogTracker = new CatalogTracker(trackerDir, true, numberCatalogs, nextCatId);
         this.dataRootTracker = new DataRootTracker(trackerDir, true, callback);
         this.dataRootPathMatcher = new DataRootPathMatcher(ccc, dataRootTracker);  // starting over


### PR DESCRIPTION
In the case where a dataset tracker database exists on disk and the server uses read mode = always on startup, there was a bug in that the dataset tracker database was not properly being removed because it was not closed first. This resulted in an empty dataset tracker after startup, which means the TDS was not aware that it had any datasets. For some services, this isn't a big deal, as they do not use the dataset tracker (for example, opendap), but for others, this was a major problem (wcs, wms, for example). This issue showed up with the [update to ChronicleMap](https://github.com/Unidata/thredds/pull/1007).