### PR TITLE
Downgrade jna shipped with chronicle-map

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -207,6 +207,13 @@ libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.14
     // We do not need XStream for our use of chronicle-map.
     // Nuke it.
     exclude group: 'com.thoughtworks.xstream', module: 'xstream'
+    // the version of jna shipped with chronicle-map requires GLIBC 2.14
+    // which prevents the use of the TDS on several versions of linux, such
+    // as CentOS and Hed Hat 6. We already include jna in netCDF-Java for
+    // netCDF-C support, so we will rely on that version instead.
+    // We should be able to get rid of this on the next release of chronicle-map,
+    // as their snapshot BOM pom shows that they pulled back on jna.
+    exclude group: 'net.java.dev.jna', module: 'jna'
 }
 
 libraries["javax.servlet-api"] = "javax.servlet:javax.servlet-api:3.1.0"


### PR DESCRIPTION
Allows the TDS to be run on systems using GLIBC 2.12. We should be able to get rid of this on the next release of chronicle-map, as their snapshot BOM shows that they pulled back on jna.