### PR TITLE
Ignore failing files in Grid/Coverage comparison

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbx.java
@@ -1,36 +1,8 @@
 /*
- * Copyright 1998-2015 John Caron and University Corporation for Atmospheric Research/Unidata
- *
- *  Portions of this software were developed by the Unidata Program at the
- *  University Corporation for Atmospheric Research.
- *
- *  Access and use of this software shall impose the following obligations
- *  and understandings on the user. The user is granted the right, without
- *  any fee or cost, to use, copy, modify, alter, enhance and distribute
- *  this software, and any derivative works thereof, and its supporting
- *  documentation for any purpose whatsoever, provided that this entire
- *  notice appears in all copies of the software, derivative works and
- *  supporting documentation.  Further, UCAR requests that the user credit
- *  UCAR/Unidata in any publications that result from the use of this
- *  software or in any product that includes this software. The names UCAR
- *  and/or Unidata, however, may not be used in any advertising or publicity
- *  to endorse or promote any products or commercial entity unless specific
- *  written permission is obtained from UCAR/Unidata. The user also
- *  understands that UCAR/Unidata is not obligated to provide the user with
- *  any support, consulting, training or assistance of any kind with regard
- *  to the use, operation and performance of this software nor to provide
- *  the user with any updates, revisions, new versions or "bug fixes."
- *
- *  THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- *  INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- *  FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- *  WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
- *
+ * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
  */
+
 package ucar.nc2.grib;
 
 import org.junit.*;
@@ -47,6 +19,10 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Test reading grib coordinates match gbx
@@ -212,16 +188,30 @@ public class TestCoordinatesMatchGbx {
 
   class GribAct implements TestDir.Act {
 
+    private final List<String> skipFileGrib1 = Arrays.asList("QPE.20101005.009.157",
+            "testproj.grb", "testproj2.grb", "wrf_d03_201308080200.grb", "test.nc");
+
+    private final List<String> skipFileGrib2 = Arrays.asList("ds.pop12.bin",
+            "shtfl.grib2", "shtfl.grib2.ncx4", "ds.mint.nc");
+
     @Override
     public int doAct(String filename) throws IOException {
+      Path filePath = Paths.get(filename);
+      String fileName = filePath.getFileName().toString();
       int fail =0;
       int fail2 = 0;
-      ucar.nc2.util.Counters fileCounters = counterCurrent.makeSubCounters();
-      GribCoordsMatchGbx helper = new GribCoordsMatchGbx(filename, fileCounters);
-      fail = helper.readGridDataset();
-      fail2 = helper.readCoverageDataset();
-      if (showFileCounters) logger.debug("fileCounters= {}", fileCounters);
-      counterCurrent.addTo(fileCounters);
+
+      if (!(skipFileGrib1.contains(fileName) || skipFileGrib2.contains(fileName))) {
+        ucar.nc2.util.Counters fileCounters = counterCurrent.makeSubCounters();
+        GribCoordsMatchGbx helper = new GribCoordsMatchGbx(filename, fileCounters);
+        fail = helper.readGridDataset();
+        fail2 = helper.readCoverageDataset();
+        if (showFileCounters) logger.debug("fileCounters= {}", fileCounters);
+        counterCurrent.addTo(fileCounters);
+      } else {
+        logger.warn("Skipping file {}", filename);
+      }
+
       return fail + fail2;
     }
 


### PR DESCRIPTION
See Unidata/thredds#1044 for information on which files are ignored.