### PR TITLE
Improve and standardize floating-point comparisons

### DIFF
--- a/cdm-test/src/test/java/ucar/coord/TestCoordinateND.java
+++ b/cdm-test/src/test/java/ucar/coord/TestCoordinateND.java
@@ -42,8 +42,8 @@ public class TestCoordinateND {
     System.out.printf("%s%n", f);
     System.out.printf("reindexed %s%n====================%n", counter.show());
 
-    assert Misc.closeEnough(curr.getSparseArray().getDensity(), 1.0);
-    assert Misc.closeEnough(reindexed.getSparseArray().getDensity(), .826446);
+    assert Misc.nearlyEquals(curr.getSparseArray().getDensity(), 1.0f);
+    assert Misc.nearlyEquals(reindexed.getSparseArray().getDensity(), .826446f);
   }
 
   static public CoordinateND<Short> makeCoordinateND(int rank, int size) {

--- a/cdm-test/src/test/java/ucar/coord/TestSparseArray.java
+++ b/cdm-test/src/test/java/ucar/coord/TestSparseArray.java
@@ -34,7 +34,7 @@ public class TestSparseArray {
     Formatter info = new Formatter(System.out);
     sa.showInfo(info, null);
 
-    assert Misc.closeEnough(sa.getDensity(), 0.906667);
+    assert Misc.nearlyEquals(sa.getDensity(), 0.906667f);
 
   }
 }

--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestNestedStructuresEnhancement.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestNestedStructuresEnhancement.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.StructureDataIterator;
 import ucar.nc2.Sequence;
-import ucar.nc2.Structure;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.iosp.bufr.BufrIosp2;
 import ucar.ma2.StructureData;
@@ -102,7 +101,7 @@ public class TestNestedStructuresEnhancement {
 
         ArrayStructure as = data.getArrayStructure("Geopotential");
         assert as != null;
-        assert Misc.closeEnough(as.getScalarFloat(0, as.findMember("Wind_speed")), 6.1);
+        assert Misc.nearlyEquals(as.getScalarFloat(0, as.findMember("Wind_speed")), 6.1);
       }
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestProjectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestProjectionCoordinates.java
@@ -42,6 +42,7 @@ import ucar.nc2.dt.GridCoordSystem;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.ProjectionImpl;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
@@ -108,11 +109,8 @@ public class TestProjectionCoordinates {
     System.out.printf( "start = %f %f%n", start1.getLatitude(), start1.getLongitude());
     System.out.printf( "end = %f %f%n", start2.getLatitude(), start2.getLongitude());
 
-    assert Misc.closeEnough(start1.getLatitude(), startLat) : Misc.howClose(start1.getLatitude(), startLat);
-    assert Misc.closeEnough(start1.getLongitude(), startLon) : Misc.howClose(start1.getLongitude(), startLon);
-
-    assert Misc.closeEnough(start2.getLatitude(), endLat,  2.0E-4) :  Misc.howClose(start2.getLatitude(), endLat);
-    assert Misc.closeEnough(start2.getLongitude(),endLon, 2.0E-4) : Misc.howClose(start2.getLongitude(), endLon);
+    assert start1.nearlyEquals(new LatLonPointImpl(startLat, startLon));
+    assert start2.nearlyEquals(new LatLonPointImpl(endLat, endLon), 2.0E-4);
 
     ncd.close();
   }

--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestProjectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestProjectionCoordinates.java
@@ -109,7 +109,7 @@ public class TestProjectionCoordinates {
     System.out.printf( "start = %f %f%n", start1.getLatitude(), start1.getLongitude());
     System.out.printf( "end = %f %f%n", start2.getLatitude(), start2.getLongitude());
 
-    assert start1.nearlyEquals(new LatLonPointImpl(startLat, startLon));
+    assert start1.nearlyEquals(new LatLonPointImpl(startLat, startLon), 2.0E-4);
     assert start2.nearlyEquals(new LatLonPointImpl(endLat, endLon), 2.0E-4);
 
     ncd.close();

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
@@ -178,10 +178,10 @@ public class TestGridSubset {
       ProjectionImpl p = gcs.getProjection();
       ProjectionRect prect = p.latLonToProjBB(bbox); // must override default implementation
       logger.debug("{} -> {}", bbox, prect);
-      assert Misc.closeEnough(prect.getMinX(), -2129.5688);
-      assert Misc.closeEnough(prect.getWidth(), 4297.8453);
-      assert Misc.closeEnough(prect.getMinY(), -1793.0041);
-      assert Misc.closeEnough(prect.getHeight(), 3308.3885);
+      assert Misc.nearlyEquals(prect.getMinX(), -2129.5688);
+      assert Misc.nearlyEquals(prect.getWidth(), 4297.8453);
+      assert Misc.nearlyEquals(prect.getMinY(), -1793.0041);
+      assert Misc.nearlyEquals(prect.getHeight(), 3308.3885);
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
       logger.debug("{} -> {}", prect, bb2);
@@ -431,7 +431,7 @@ public class TestGridSubset {
 
       ProjectionRect pr = gcs2.getProjection().getDefaultMapArea();
       logger.debug("projection mapArea = {}", pr);
-      assert (pr.closeEnough(gcs2.getBoundingBox()));
+      assert (pr.nearlyEquals(gcs2.getBoundingBox()));
     }
   }
 
@@ -462,7 +462,7 @@ public class TestGridSubset {
 
       ProjectionRect pr = gcs2.getProjection().getDefaultMapArea();
       logger.debug("projection mapArea = {}", pr);
-      assert (pr.closeEnough(gcs2.getBoundingBox()));
+      assert (pr.nearlyEquals(gcs2.getBoundingBox()));
 
       CoordinateAxis xaxis = gcs.getXHorizAxis();
       CoordinateAxis yaxis = gcs.getYHorizAxis();
@@ -546,7 +546,7 @@ public class TestGridSubset {
 
       ProjectionRect pr = gcs2.getProjection().getDefaultMapArea();
       logger.debug("projection mapArea = {}", pr);
-      assert (pr.closeEnough(gcs2.getBoundingBox()));
+      assert (pr.nearlyEquals(gcs2.getBoundingBox()));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestGridSubset.java
@@ -178,10 +178,10 @@ public class TestGridSubset {
       ProjectionImpl p = gcs.getProjection();
       ProjectionRect prect = p.latLonToProjBB(bbox); // must override default implementation
       logger.debug("{} -> {}", bbox, prect);
-      assert Misc.nearlyEquals(prect.getMinX(), -2129.5688);
-      assert Misc.nearlyEquals(prect.getWidth(), 4297.8453);
-      assert Misc.nearlyEquals(prect.getMinY(), -1793.0041);
-      assert Misc.nearlyEquals(prect.getHeight(), 3308.3885);
+
+      ProjectionRect expected = new ProjectionRect(
+              new ProjectionPointImpl(-2129.5688, -1793.0041), 4297.8453, 3308.3885);
+      assert prect.nearlyEquals(expected);
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
       logger.debug("{} -> {}", prect, bb2);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
@@ -59,7 +59,7 @@ public class GribCoverageValidator implements GribDataValidator {
       Assert.assertTrue("time coord lower", tinv[1] >= timeOffset);          // upper >= time
 
     } else {
-      Assert.assertEquals("offset coord", timeOffset, ptime.getForecastTime(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(timeOffset, ptime.getForecastTime()));
     }
 
     // vert
@@ -75,14 +75,14 @@ public class GribCoverageValidator implements GribDataValidator {
         Assert.assertTrue("vert coord upper", upper >= wantVert);          // upper >= vert
 
       } else {
-        Assert.assertEquals("vert coord", lev1, wantVert, Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(lev1, wantVert));
       }
     }
 
     // ens
     Double wantEns = coords.getEnsCoord();
     if (wantEns != null) {
-      Assert.assertEquals("ens coord", pds.getPerturbationNumber(), wantEns, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(pds.getPerturbationNumber(), wantEns));
     }
 
   }
@@ -131,18 +131,18 @@ public class GribCoverageValidator implements GribDataValidator {
       //double upper = Math.max(level1val, level2val);
       //Assert.assertTrue("vert coord lower", lower <= wantVert);          // lower <= vert
       //Assert.assertTrue("vert coord upper", upper >= wantVert);          // upper >= vert
-      Assert.assertEquals("vert coord 1", vertCoordIntv[0], level1val, Misc.maxReletiveError);
-      Assert.assertEquals("vert coord 2", vertCoordIntv[1], level2val, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[0], level1val));
+      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[1], level2val));
 
     } else if (vertCoord != null) {
-      Assert.assertEquals("vert coord", vertCoord, level1val, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(vertCoord, level1val));
     }
 
     // ens
     Double wantEns = coords.getEnsCoord();
     if (wantEns != null) {
       Grib2Pds.PdsEnsemble pdse = (Grib2Pds.PdsEnsemble) pds;
-      Assert.assertEquals("ens coord", wantEns, pdse.getPerturbationNumber(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(wantEns, pdse.getPerturbationNumber()));
     }
 
   }

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
@@ -131,11 +131,11 @@ public class GribCoverageValidator implements GribDataValidator {
       //double upper = Math.max(level1val, level2val);
       //Assert.assertTrue("vert coord lower", lower <= wantVert);          // lower <= vert
       //Assert.assertTrue("vert coord upper", upper >= wantVert);          // upper >= vert
-      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[0], level1val));
-      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[1], level2val));
+      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[0], level1val, 1e-6));
+      Assert.assertTrue(Misc.nearlyEquals(vertCoordIntv[1], level2val, 1e-6));
 
     } else if (vertCoord != null) {
-      Assert.assertTrue(Misc.nearlyEquals(vertCoord, level1val));
+      Assert.assertTrue(Misc.nearlyEquals(vertCoord, level1val, 1e-6));
     }
 
     // ens

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
@@ -128,7 +128,7 @@ public class TestCoverageCurvilinear {
       System.out.printf("data shape=%s%n", Misc.showInts(data.getShape()));
       Assert.assertArrayEquals(geo.getCoordSysForData().getShape(), data.getShape());
 
-      int[] expectedShape = new int[] {1,166,160};
+      int[] expectedShape = new int[] {1, 165, 161};
       Assert.assertArrayEquals(expectedShape, data.getShape());
       //NCdumpW.printArray(data);
     }
@@ -159,8 +159,8 @@ public class TestCoverageCurvilinear {
       int[] expectedShape = new int[] {1,1,22,12};
       Assert.assertArrayEquals(expectedShape, data.getShape());
       // NCdumpW.printArray(data);
-      Assert.assertTrue(Misc.nearlyEquals(0.0036624447, data.getDouble(ima.set(0, 0, 0, 0))));
-      Assert.assertTrue(Misc.nearlyEquals(0.20564626, data.getDouble(ima.set(0, 0, 21, 11))));
+      Assert.assertTrue(Misc.nearlyEquals(0.0036624447, data.getDouble(ima.set(0, 0, 0, 0)), 1e-6));
+      Assert.assertTrue(Misc.nearlyEquals(0.20564626, data.getDouble(ima.set(0, 0, 21, 11)), 1e-6));
     }
   }
 
@@ -189,8 +189,8 @@ public class TestCoverageCurvilinear {
       int[] expectedShape = new int[] {1,151,171};
       Assert.assertArrayEquals(expectedShape, data.getShape());
       // NCdumpW.printArray(data);
-      Assert.assertTrue(Misc.nearlyEquals(1.782, data.getDouble(ima.set(0, 0, 0))));
-      Assert.assertTrue(Misc.nearlyEquals(1.769, data.getDouble(ima.set(0, 11, 0))));
+      Assert.assertTrue(Misc.nearlyEquals(1.782, data.getDouble(ima.set(0, 0, 0)), 1e-6));
+      Assert.assertTrue(Misc.nearlyEquals(1.769, data.getDouble(ima.set(0, 11, 0)), 1e-6));
     } catch (InvalidRangeException e) {
       e.printStackTrace();
     }

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.Index;
 import ucar.ma2.InvalidRangeException;
-import ucar.nc2.NCdumpW;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.ft2.coverage.Coverage;
 import ucar.nc2.ft2.coverage.CoverageCoordSys;
@@ -160,8 +159,8 @@ public class TestCoverageCurvilinear {
       int[] expectedShape = new int[] {1,1,22,12};
       Assert.assertArrayEquals(expectedShape, data.getShape());
       // NCdumpW.printArray(data);
-      Assert.assertEquals(0.0036624447, data.getDouble(ima.set(0, 0, 0, 0)), Misc.maxReletiveError);
-      Assert.assertEquals(0.20564626, data.getDouble(ima.set(0, 0, 21, 11)), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.0036624447, data.getDouble(ima.set(0, 0, 0, 0))));
+      Assert.assertTrue(Misc.nearlyEquals(0.20564626, data.getDouble(ima.set(0, 0, 21, 11))));
     }
   }
 
@@ -190,8 +189,8 @@ public class TestCoverageCurvilinear {
       int[] expectedShape = new int[] {1,151,171};
       Assert.assertArrayEquals(expectedShape, data.getShape());
       // NCdumpW.printArray(data);
-      Assert.assertEquals(1.782, data.getDouble(ima.set(0, 0, 0)), Misc.maxReletiveError);
-      Assert.assertEquals(1.769, data.getDouble(ima.set(0, 11, 0)), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(1.782, data.getDouble(ima.set(0, 0, 0))));
+      Assert.assertTrue(Misc.nearlyEquals(1.769, data.getDouble(ima.set(0, 11, 0))));
     } catch (InvalidRangeException e) {
       e.printStackTrace();
     }

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
@@ -47,10 +47,10 @@ public class TestCoverageHorizSubset {
       ProjectionImpl p = hcs.getTransform().getProjection();
       ProjectionRect prect = p.latLonToProjBB(bbox); // must override default implementation
       System.out.printf("%s -> %s %n", bbox, prect);
-      assert Misc.closeEnough(prect.getMinX(), -2129.5688);
-      assert Misc.closeEnough(prect.getWidth(), 4297.8453);
-      assert Misc.closeEnough(prect.getMinY(), -1793.0041);
-      assert Misc.closeEnough(prect.getHeight(), 3308.3885);
+      assert Misc.nearlyEquals(prect.getMinX(), -2129.5688);
+      assert Misc.nearlyEquals(prect.getWidth(), 4297.8453);
+      assert Misc.nearlyEquals(prect.getMinY(), -1793.0041);
+      assert Misc.nearlyEquals(prect.getHeight(), 3308.3885);
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
       System.out.printf("%s -> %s %n", prect, bb2);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
@@ -47,10 +47,10 @@ public class TestCoverageHorizSubset {
       ProjectionImpl p = hcs.getTransform().getProjection();
       ProjectionRect prect = p.latLonToProjBB(bbox); // must override default implementation
       System.out.printf("%s -> %s %n", bbox, prect);
-      assert Misc.nearlyEquals(prect.getMinX(), -2129.5688);
-      assert Misc.nearlyEquals(prect.getWidth(), 4297.8453);
-      assert Misc.nearlyEquals(prect.getMinY(), -1793.0041);
-      assert Misc.nearlyEquals(prect.getHeight(), 3308.3885);
+
+      ProjectionRect expected = new ProjectionRect(
+              new ProjectionPointImpl(-2129.5688, -1793.0041), 4297.8453, 3308.3885);
+      assert prect.nearlyEquals(expected);
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
       System.out.printf("%s -> %s %n", prect, bb2);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
@@ -134,7 +134,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 3, 0));
-      Assert.assertEquals(0.244, testValue, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.244, testValue));
     }
   }
 
@@ -167,7 +167,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0,0,2,2));
-      Assert.assertEquals(0.073, testValue, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.073, testValue));
     }
   }
 
@@ -199,7 +199,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0,0,1,0));
-      Assert.assertEquals(371.5, testValue, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(371.5, testValue));
     }
   }
 
@@ -236,8 +236,8 @@ public class TestCoverageSubsetTime {
       Assert.assertNotNull(timeAxis);
       Assert.assertEquals(92, timeAxis.getNcoords());
       Assert.assertEquals(CoverageCoordAxis.Spacing.discontiguousInterval, timeAxis.getSpacing());
-      Assert.assertEquals(0.0, timeAxis.getStartValue(), Misc.maxReletiveError);
-      Assert.assertEquals(384.0, timeAxis.getEndValue(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.0, timeAxis.getStartValue()));
+      Assert.assertTrue(Misc.nearlyEquals(384.0, timeAxis.getEndValue()));
 
       // LOOK need to test data
     }
@@ -270,8 +270,8 @@ public class TestCoverageSubsetTime {
       Assert.assertNotNull(runtimeAxis);
       Assert.assertEquals(4, runtimeAxis.getNcoords());
       Assert.assertEquals(CoverageCoordAxis.Spacing.regularPoint, runtimeAxis.getSpacing());
-      Assert.assertEquals(0.0, runtimeAxis.getCoordMidpoint(0), Misc.maxReletiveError);
-      Assert.assertEquals(6.0, runtimeAxis.getResolution(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.0, runtimeAxis.getCoordMidpoint(0)));
+      Assert.assertTrue(Misc.nearlyEquals(6.0, runtimeAxis.getResolution()));
 
       CoverageCoordAxis timeAxis = geoCs.getAxis(AxisType.TimeOffset);
       Assert.assertNotNull(timeAxis);
@@ -283,7 +283,7 @@ public class TestCoverageSubsetTime {
         Assert.assertTrue("time coord lower", timeAxis1D.getCoordEdge2(0) >= offsetVal);          // upper >= time
 
       }else {
-        Assert.assertEquals("offset coord", offsetVal, timeAxis1D.getCoordMidpoint(0), offsetVal*Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(offsetVal, timeAxis1D.getCoordMidpoint(0)));
       }
 
       // LOOK need to test data
@@ -317,8 +317,8 @@ public class TestCoverageSubsetTime {
       Assert.assertNotNull(runtimeAxis);
       Assert.assertEquals(3, runtimeAxis.getNcoords());
       Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, runtimeAxis.getSpacing());
-      Assert.assertEquals(0.0, runtimeAxis.getCoordMidpoint(0), Misc.maxReletiveError);
-      Assert.assertEquals(6.0, runtimeAxis.getResolution(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.0, runtimeAxis.getCoordMidpoint(0)));
+      Assert.assertTrue(Misc.nearlyEquals(6.0, runtimeAxis.getResolution()));
 
       CoverageCoordAxis timeAxis = geoCs.getAxis(AxisType.Time);
       if (timeAxis != null) {
@@ -415,7 +415,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 3, 0));
-      Assert.assertEquals(244.8, testValue, testValue * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(244.8, testValue));
     }
   }
 
@@ -446,7 +446,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 0, 0));
-      Assert.assertEquals(244.3, testValue, testValue * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(244.3, testValue));
     }
   }
 
@@ -477,7 +477,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 3, 0));
-      Assert.assertEquals(250.5, testValue, testValue * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(250.5, testValue));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
@@ -134,7 +134,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 3, 0));
-      Assert.assertTrue(Misc.nearlyEquals(0.244, testValue));
+      Assert.assertTrue(Misc.nearlyEquals(0.244f, testValue));
     }
   }
 
@@ -167,7 +167,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0,0,2,2));
-      Assert.assertTrue(Misc.nearlyEquals(0.073, testValue));
+      Assert.assertTrue(Misc.nearlyEquals(0.073f, testValue));
     }
   }
 
@@ -415,7 +415,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 3, 0));
-      Assert.assertTrue(Misc.nearlyEquals(244.8, testValue));
+      Assert.assertTrue(Misc.nearlyEquals(244.8f, testValue));
     }
   }
 
@@ -446,7 +446,7 @@ public class TestCoverageSubsetTime {
       Array data = geo.getData();
       Index ai = data.getIndex();
       float testValue = data.getFloat(ai.set(0, 0, 0, 0));
-      Assert.assertTrue(Misc.nearlyEquals(244.3, testValue));
+      Assert.assertTrue(Misc.nearlyEquals(244.3f, testValue));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCurvilinearGridPointMapping.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCurvilinearGridPointMapping.java
@@ -71,8 +71,8 @@ public class TestCurvilinearGridPointMapping {
       Assert.assertNotNull("HorizCoordSys", hcs);
 
       LatLonPoint llPnt = hcs.getLatLon(j, i);
-      Assert.assertEquals(lat, llPnt.getLatitude(), lat*Misc.maxReletiveError);
-      Assert.assertEquals(lon, llPnt.getLongitude(), lon*Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(lat, llPnt.getLatitude()));
+      Assert.assertTrue(Misc.nearlyEquals(lon, llPnt.getLongitude()));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestDtWithCoverageBuilding.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestDtWithCoverageBuilding.java
@@ -165,7 +165,7 @@ public class TestDtWithCoverageBuilding {
         Assert.assertEquals(10, time.getNcoords());
         double[] timeValuesGrib = time.getValues();
         for (int i=0; i<time.getNcoords(); i++)
-          Assert.assertEquals(timeValuesDt[i], timeValuesGrib[i], Misc.maxReletiveError);
+          Assert.assertTrue(Misc.nearlyEquals(timeValuesDt[i], timeValuesGrib[i]));
 
         CoverageCoordAxis runtime = csys.getAxis(AxisType.RunTime);
         Assert.assertNotNull(AxisType.RunTime.toString(), runtime);
@@ -173,7 +173,7 @@ public class TestDtWithCoverageBuilding {
         Assert.assertEquals(10, runtime.getNcoords());
         double[] runValuesGrib = runtime.getValues();
         for (int i=0; i<runtime.getNcoords(); i++)
-          Assert.assertEquals(runValuesDt[i], runValuesGrib[i], Misc.maxReletiveError);
+          Assert.assertTrue(Misc.nearlyEquals(runValuesDt[i], runValuesGrib[i]));
 
       }
     }

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageBuilding.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageBuilding.java
@@ -35,24 +35,18 @@ package ucar.nc2.ft.coverage;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.Formatter;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.Array;
 import ucar.nc2.Attribute;
-import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.dataset.CoordinateAxis1D;
 import ucar.nc2.ft2.coverage.*;
-import ucar.nc2.ft2.coverage.adapter.*;
 import ucar.nc2.time.CalendarDate;
-import ucar.nc2.util.CompareNetcdf2;
 import ucar.nc2.util.Misc;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
@@ -114,7 +108,7 @@ public class TestGribCoverageBuilding {
         Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, runtime.getSpacing());
         Assert.assertEquals(CoverageCoordAxis.DependenceType.independent, runtime.getDependenceType());
         Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), runtime.makeDate(0));
-        Assert.assertEquals(6.0, runtime.getResolution(), Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(6.0, runtime.getResolution()));
 
         CoverageCoordAxis time = csys.getAxis(AxisType.TimeOffset);
         Assert.assertNotNull(AxisType.TimeOffset.toString(), time);
@@ -122,13 +116,12 @@ public class TestGribCoverageBuilding {
         Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, time.getSpacing());
         Assert.assertEquals(CoverageCoordAxis.DependenceType.independent, time.getDependenceType());
         Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), time.makeDate(0));
-        Assert.assertEquals(6.0, time.getResolution(), Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(6.0, time.getResolution()));
         Assert.assertEquals(true, csys.isTime2D(time));
       }
     }
 
-  @Test
-  public void testBestTimeCoordinates() throws IOException {
+  @Test public void testBestTimeCoordinates() throws IOException {
     String filename = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km.ncx4";
     String gridName = "Pressure_surface";
 
@@ -143,14 +136,14 @@ public class TestGribCoverageBuilding {
       CoverageCoordSys csys = cov.getCoordSys();
       Assert.assertNotNull("CoverageCoordSys", csys);
 
-        CoverageCoordAxis time = csys.getAxis(AxisType.Time);
-        Assert.assertNotNull(AxisType.Time.toString(), time);
-        Assert.assertTrue(time.getClass().getName(), time instanceof CoverageCoordAxis1D);
+      CoverageCoordAxis time = csys.getAxis(AxisType.Time);
+      Assert.assertNotNull(AxisType.Time.toString(), time);
+      Assert.assertTrue(time.getClass().getName(), time instanceof CoverageCoordAxis1D);
       Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, time.getSpacing());
-        Assert.assertEquals(CoverageCoordAxis.DependenceType.independent, time.getDependenceType());
-        Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), time.makeDate(0));
-        Assert.assertEquals(6.0, time.getResolution(), Misc.maxReletiveError);
-        Assert.assertEquals(false, csys.isTime2D(time));
+      Assert.assertEquals(CoverageCoordAxis.DependenceType.independent, time.getDependenceType());
+      Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), time.makeDate(0));
+      Assert.assertTrue(Misc.nearlyEquals(6.0, time.getResolution()));
+      Assert.assertEquals(false, csys.isTime2D(time));
 
       CoverageCoordAxis runtime = csys.getAxis(AxisType.RunTime);
       Assert.assertNotNull(AxisType.RunTime.toString(), runtime);
@@ -158,8 +151,8 @@ public class TestGribCoverageBuilding {
       Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, runtime.getSpacing());
       Assert.assertEquals(CoverageCoordAxis.DependenceType.dependent, runtime.getDependenceType());
       Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), runtime.makeDate(0));
-      }
     }
+  }
 
   @Test
   public void testTimeOffsetSubsetWhenTimePresent() throws IOException {
@@ -184,7 +177,7 @@ public class TestGribCoverageBuilding {
       Assert.assertEquals(CoverageCoordAxis.Spacing.irregularPoint, time.getSpacing());
       Assert.assertEquals(CoverageCoordAxis.DependenceType.independent, time.getDependenceType());
       Assert.assertEquals(CalendarDate.parseISOformat(null, "2012-02-27T00:00:00Z"), time.makeDate(0));
-      Assert.assertEquals(6.0, time.getResolution(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(6.0, time.getResolution()));
 
       CoverageCoordAxis runtime = csys.getAxis(AxisType.RunTime);
       Assert.assertNotNull(AxisType.RunTime.toString(), runtime);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageRead.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageRead.java
@@ -151,8 +151,8 @@ public class TestGribCoverageRead {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertTrue(Misc.nearlyEquals(219.5, first));
-      Assert.assertTrue(Misc.nearlyEquals(218.6, last));
+      Assert.assertTrue(Misc.nearlyEquals(219.5f, first));
+      Assert.assertTrue(Misc.nearlyEquals(218.6f, last));
     }
   }
 
@@ -250,11 +250,11 @@ public class TestGribCoverageRead {
 
       float val = data.getFloat(0);
       System.out.printf("data val first = %f%n", val);
-      Assert.assertTrue(Misc.nearlyEquals(-0.10470009, val));
+      Assert.assertTrue(Misc.nearlyEquals(-0.10470009f, val));
 
       val = data.getFloat( (int)data.getSize()-1);
       System.out.printf("data val last = %f%n", val);
-      Assert.assertTrue(Misc.nearlyEquals(0.18079996, val));
+      Assert.assertTrue(Misc.nearlyEquals(0.18079996f, val));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageRead.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageRead.java
@@ -89,8 +89,8 @@ public class TestGribCoverageRead {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertEquals(241.699997, first, first*Misc.maxReletiveError);
-      Assert.assertEquals(225.099991, last, last*Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(241.699997, first));
+      Assert.assertTrue(Misc.nearlyEquals(225.099991, last));
     }
   }
 
@@ -120,8 +120,8 @@ public class TestGribCoverageRead {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertEquals(241.699997, first, first*Misc.maxReletiveError);
-      Assert.assertEquals(225.099991, last, last*Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(241.699997, first));
+      Assert.assertTrue(Misc.nearlyEquals(225.099991, last));
     }
   }
 
@@ -151,8 +151,8 @@ public class TestGribCoverageRead {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertEquals(219.5, first, first * Misc.maxReletiveError);
-      Assert.assertEquals(218.6, last, last * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(219.5, first));
+      Assert.assertTrue(Misc.nearlyEquals(218.6, last));
     }
   }
 
@@ -181,11 +181,11 @@ public class TestGribCoverageRead {
 
       float val = data.getFloat(40600);
       System.out.printf("data val at %d = %f%n", 40600, val);
-      Assert.assertEquals(281.627563, val, val * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(281.627563, val));
 
       val = data.getFloat(55583);
       System.out.printf("data val at %d = %f%n", 55583, val);
-      Assert.assertEquals(281.690063, val, val*Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(281.690063, val));
 
     }
   }
@@ -215,11 +215,11 @@ public class TestGribCoverageRead {
 
       float val = data.getFloat(3179);
       System.out.printf("data val at %d = %f%n", 3179, val);
-      Assert.assertEquals(98.0, val, val * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(98.0, val));
 
       val = data.getFloat(5020);
       System.out.printf("data val at %d = %f%n", 5020, val);
-      Assert.assertEquals(60.0, val, val * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(60.0, val));
 
     }
   }
@@ -250,11 +250,11 @@ public class TestGribCoverageRead {
 
       float val = data.getFloat(0);
       System.out.printf("data val first = %f%n", val);
-      Assert.assertEquals(-0.10470009, val, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(-0.10470009, val));
 
       val = data.getFloat( (int)data.getSize()-1);
       System.out.printf("data val last = %f%n", val);
-      Assert.assertEquals(0.18079996, val, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(0.18079996, val));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageSubsetP.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestGribCoverageSubsetP.java
@@ -248,7 +248,7 @@ public class TestGribCoverageSubsetP {
 
           } else {
             double val2 = timeOffsetAxis.getCoordMidpoint(0);
-            Assert.assertEquals(val2, time_offset, Misc.maxReletiveError);
+            Assert.assertTrue(Misc.nearlyEquals(val2, time_offset));
           }
         }
       }
@@ -258,7 +258,7 @@ public class TestGribCoverageSubsetP {
         Assert.assertNotNull(AxisType.Pressure.toString(), zAxis);
         Assert.assertEquals(1, zAxis.getNcoords());
         double val = ((CoverageCoordAxis1D) zAxis).getCoordMidpoint(0);
-        Assert.assertEquals(vert_level.doubleValue(), val, Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(vert_level.doubleValue(), val));
       }
     }
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
@@ -81,6 +81,9 @@ public class GribCoordsMatchGbx {
   private static final int MAX_READS = -1;
   private static final boolean showMissing = false;
 
+  // The maximum relative difference for floating-point comparisons.
+  private static final double maxRelDiff = 1e-6;
+
   public static Counters getCounters() {
     Counters countersAll = new Counters();
     countersAll.add(KIND_GRID);
@@ -446,8 +449,8 @@ public class GribCoordsMatchGbx {
       if (edge != null) {
        // double low = Math.min(edge[0], edge[1]);
         //double hi = Math.max(edge[0], edge[1]);
-        vertOk &= Misc.nearlyEquals(edge[0], plevel.getValue1());
-        vertOk &= Misc.nearlyEquals(edge[1], plevel.getValue2());
+        vertOk &= Misc.nearlyEquals(edge[0], plevel.getValue1(), maxRelDiff);
+        vertOk &= Misc.nearlyEquals(edge[1], plevel.getValue2(), maxRelDiff);
         if (!vertOk) {
           tryAgain(coords);
           logger.debug("{} {} failed on vert [{},{}] != [{},{}]", kind, name, edge[0], edge[1],
@@ -455,7 +458,7 @@ public class GribCoordsMatchGbx {
         }
       }
     } else if (vert_val != null) {
-      vertOk &= Misc.nearlyEquals(vert_val,  plevel.getValue1());
+      vertOk &= Misc.nearlyEquals(vert_val,  plevel.getValue1(), maxRelDiff);
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert {} != {}", kind, name, vert_val,  plevel.getValue1());
@@ -584,15 +587,15 @@ public class GribCoordsMatchGbx {
       vertOk &= bean.isLayer();
       double low = Math.min(edge[0], edge[1]);
       double hi = Math.max(edge[0], edge[1]);
-      vertOk &= Misc.nearlyEquals(low, bean.getLevelLowValue());
-      vertOk &= Misc.nearlyEquals(hi, bean.getLevelHighValue());
+      vertOk &= Misc.nearlyEquals(low, bean.getLevelLowValue(), maxRelDiff);
+      vertOk &= Misc.nearlyEquals(hi, bean.getLevelHighValue(), maxRelDiff);
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert [{},{}] != [{},{}]", kind, name, low, hi, bean.getLevelLowValue(),
                 bean.getLevelHighValue());
       }
     } else if (vert_val != null) {
-      vertOk &= Misc.nearlyEquals(vert_val, bean.getLevelValue1());
+      vertOk &= Misc.nearlyEquals(vert_val, bean.getLevelValue1(), maxRelDiff);
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert {} != {}", kind, name, vert_val, bean.getLevelValue1());

--- a/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
@@ -108,7 +108,7 @@ public class GribCoordsMatchGbx {
     return result;
   }
 
-  boolean closeEnough(CalendarDate date1, CalendarDate date2) {
+  boolean nearlyEquals(CalendarDate date1, CalendarDate date2) {
     return Math.abs(date1.getMillis() - date2.getMillis()) < 5000; // 5 secs
   }
 
@@ -446,8 +446,8 @@ public class GribCoordsMatchGbx {
       if (edge != null) {
        // double low = Math.min(edge[0], edge[1]);
         //double hi = Math.max(edge[0], edge[1]);
-        vertOk &= Misc.closeEnough(edge[0], plevel.getValue1());
-        vertOk &= Misc.closeEnough(edge[1], plevel.getValue2());
+        vertOk &= Misc.nearlyEquals(edge[0], plevel.getValue1());
+        vertOk &= Misc.nearlyEquals(edge[1], plevel.getValue2());
         if (!vertOk) {
           tryAgain(coords);
           logger.debug("{} {} failed on vert [{},{}] != [{},{}]", kind, name, edge[0], edge[1],
@@ -455,7 +455,7 @@ public class GribCoordsMatchGbx {
         }
       }
     } else if (vert_val != null) {
-      vertOk &= Misc.closeEnough(vert_val,  plevel.getValue1());
+      vertOk &= Misc.nearlyEquals(vert_val,  plevel.getValue1());
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert {} != {}", kind, name, vert_val,  plevel.getValue1());
@@ -558,8 +558,8 @@ public class GribCoordsMatchGbx {
         date_bounds = makeDateBounds(coords, rt_val);
       }
       if (date_bounds != null) {
-        timeOk &= closeEnough(date_bounds[0], dateFromGribRecord.getStart());
-        timeOk &= closeEnough(date_bounds[1], dateFromGribRecord.getEnd());
+        timeOk &= nearlyEquals(date_bounds[0], dateFromGribRecord.getStart());
+        timeOk &= nearlyEquals(date_bounds[1], dateFromGribRecord.getEnd());
       }
       if (!timeOk) {
         tryAgain(coords);
@@ -570,7 +570,7 @@ public class GribCoordsMatchGbx {
     } else if (time_val != null) {
       // timeOk &= timeCoord == bean.getTimeCoordValue();   // true if GC
       CalendarDate dateFromGribRecord = bean.getForecastDate();
-      timeOk &= closeEnough(time_val, dateFromGribRecord);
+      timeOk &= nearlyEquals(time_val, dateFromGribRecord);
       if (!timeOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on time {} != {}", kind, name, time_val, bean.getTimeCoord());
@@ -584,15 +584,15 @@ public class GribCoordsMatchGbx {
       vertOk &= bean.isLayer();
       double low = Math.min(edge[0], edge[1]);
       double hi = Math.max(edge[0], edge[1]);
-      vertOk &= Misc.closeEnough(low, bean.getLevelLowValue());
-      vertOk &= Misc.closeEnough(hi, bean.getLevelHighValue());
+      vertOk &= Misc.nearlyEquals(low, bean.getLevelLowValue());
+      vertOk &= Misc.nearlyEquals(hi, bean.getLevelHighValue());
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert [{},{}] != [{},{}]", kind, name, low, hi, bean.getLevelLowValue(),
                 bean.getLevelHighValue());
       }
     } else if (vert_val != null) {
-      vertOk &= Misc.closeEnough(vert_val, bean.getLevelValue1());
+      vertOk &= Misc.nearlyEquals(vert_val, bean.getLevelValue1());
       if (!vertOk) {
         tryAgain(coords);
         logger.debug("{} {} failed on vert {} != {}", kind, name, vert_val, bean.getLevelValue1());

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
@@ -84,8 +84,8 @@ public class TestGribCollectionReadingIosp {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertEquals(300.33002, first, first*Misc.maxReletiveError);
-      Assert.assertEquals(279.49, last, last*Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(300.33002, first));
+      Assert.assertTrue(Misc.nearlyEquals(279.49, last));
     }
   }
 
@@ -102,7 +102,7 @@ public class TestGribCollectionReadingIosp {
       assert data.getSize() == 2;
       float[] got = (float []) data.copyTo1DJavaArray();
       float[] expect = new float[] {103031.914f, 103064.164f};
-      Assert.assertArrayEquals(expect, got, (float) Misc.maxReletiveError);
+      Assert.assertArrayEquals(expect, got, (float) Misc.defaultMaxRelativeDiffFloat);
     }
   }
 
@@ -124,7 +124,7 @@ public class TestGribCollectionReadingIosp {
       }
       float[] got = (float []) data.copyTo1DJavaArray();
       float[] expect = new float[] {68.0f, 74.0f};
-      Assert.assertArrayEquals(expect, got, (float) Misc.maxReletiveError);
+      Assert.assertArrayEquals(expect, got, (float) Misc.defaultMaxRelativeDiffFloat);
     }
   }
 
@@ -146,7 +146,7 @@ public class TestGribCollectionReadingIosp {
       }
       float[] got = (float []) data.copyTo1DJavaArray();
       float[] expect = new float[] {57.8f, 53.1f, 91.3f, 85.5f, 80.0f, 69.3f, 32.8f, 41.8f, 88.9f, 81.3f, 70.9f, 70.6f};
-      Assert.assertArrayEquals(expect, got, (float) Misc.maxReletiveError);
+      Assert.assertArrayEquals(expect, got, (float) Misc.defaultMaxRelativeDiffFloat);
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionReadingIosp.java
@@ -84,8 +84,8 @@ public class TestGribCollectionReadingIosp {
       float first = data.getFloat(0);
       float last = data.getFloat((int)data.getSize()-1);
       System.out.printf("data first = %f last=%f%n", first, last);
-      Assert.assertTrue(Misc.nearlyEquals(300.33002, first));
-      Assert.assertTrue(Misc.nearlyEquals(279.49, last));
+      Assert.assertTrue(Misc.nearlyEquals(300.33002f, first));
+      Assert.assertTrue(Misc.nearlyEquals(279.49f, last));
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
@@ -141,7 +141,7 @@ public class TestMiscIosp {
       Attribute att = v.findAttribute(CDM.MISSING_VALUE);
       assert att != null;
       assert att.getDataType() == DataType.FLOAT;
-      assert Misc.closeEnough(att.getNumericValue().floatValue(), -9999.0f);
+      assert Misc.nearlyEquals(att.getNumericValue().floatValue(), -9999.0f);
 
       Array data = v.read();
       assert Arrays.equals(data.getShape(), new int[]{1, 1, 180, 360});
@@ -160,7 +160,7 @@ public class TestMiscIosp {
       Attribute att = v.findAttribute(CDM.MISSING_VALUE);
       assert att != null;
       assert att.getDataType() == DataType.FLOAT;
-      assert Misc.closeEnough(att.getNumericValue().floatValue(), -9999.0f);
+      assert Misc.nearlyEquals(att.getNumericValue().floatValue(), -9999.0f);
 
       Array data = v.read();
       assert Arrays.equals(data.getShape(), new int[]{1, 1, 180, 360});
@@ -180,7 +180,7 @@ public class TestMiscIosp {
       Attribute att = v.findAttribute(CDM.MISSING_VALUE);
       assert att != null;
       assert att.getDataType() == DataType.FLOAT;
-      assert Misc.closeEnough(att.getNumericValue().floatValue(), -9999.0f);
+      assert Misc.nearlyEquals(att.getNumericValue().floatValue(), -9999.0f);
 
       Array data = v.read();
       assert Arrays.equals(data.getShape(), new int[]{1, 1, 180, 360});

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestGribMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestGribMisc.java
@@ -68,7 +68,7 @@ public class TestGribMisc {
     try (NetcdfFile ncfile = NetcdfFile.open(filename, null)) {
       Variable v = ncfile.findVariable("isobaric");
       float val = v.readScalarFloat();
-      assert Misc.closeEnough(val, 92500.0) : val;
+      assert Misc.nearlyEquals(val, 92500.0) : val;
     }
   }
 
@@ -121,8 +121,8 @@ public class TestGribMisc {
       int[] origin = {0, 38, 281};
       int[] shape = {1, 1, 2};
       Array vals = v.read(origin, shape);
-      assert Misc.closeEnough(vals.getFloat(0), 0.0) : vals.getFloat(0);
-      assert Misc.closeEnough(vals.getFloat(1), 1.0) : vals.getFloat(1);
+      assert Misc.nearlyEquals(vals.getFloat(0), 0.0) : vals.getFloat(0);
+      assert Misc.nearlyEquals(vals.getFloat(1), 1.0) : vals.getFloat(1);
     }
   }
 
@@ -182,8 +182,8 @@ public class TestGribMisc {
        assert v != null : ncfile.getLocation();
        ArrayFloat vals = (ArrayFloat) (v.read("0,:,0").reduce());   // read first column - its flipped
        System.out.printf("%s: first=%f last=%f%n", v.getFullName(), vals.getFloat(0), vals.getFloat((int)vals.getSize()-1));
-       assert Misc.closeEnough( vals.getFloat(0), 243.289993);
-       assert Misc.closeEnough( vals.getFloat((int)vals.getSize()-1), 242.080002);
+       assert Misc.nearlyEquals( vals.getFloat(0), 243.289993);
+       assert Misc.nearlyEquals( vals.getFloat((int)vals.getSize()-1), 242.080002);
      }
    }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestScanMode.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestScanMode.java
@@ -47,7 +47,7 @@ public class TestScanMode {
 
     Index ima = data.getIndex();
     float val = data.getFloat(ima);
-    assert Misc.closeEnough(val, 5.0192626E-5);
+    assert Misc.nearlyEquals(val, 5.0192626E-5);
 
     gds.close();
   }
@@ -71,7 +71,7 @@ public class TestScanMode {
 
     Index ima = data.getIndex();
     float val = data.getFloat(ima);
-    assert Misc.closeEnough(val, 0.0);
+    assert Misc.nearlyEquals(val, 0.0);
 
     gds.close();
   }

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestCDL.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestCDL.java
@@ -112,7 +112,7 @@ public class TestCDL {
     try {
       double val1 = Double.parseDouble(toke1);
       double val2 = Double.parseDouble(toke2);
-      return Misc.closeEnough(val1, val2);
+      return Misc.nearlyEquals(val1, val2);
     } catch (NumberFormatException e) {
       //System.out.println(e.getMessage());
       return false;

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4reading.java
@@ -374,7 +374,7 @@ public class TestN4reading {
       System.out.printf("the %d record has %d elements for vlen member %s%n%n", index, vdata.getSize(), member);
       assert vdata.getSize() == 3;
       Index ii = vdata.getIndex();
-      assert Misc.closeEnough(vdata.getFloat(ii.set(2)), 21.5);
+      assert Misc.nearlyEquals(vdata.getFloat(ii.set(2)), 21.5);
 
       String memberName = "temp_vl";
       int count = 0;

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestCDF5Reading.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestCDF5Reading.java
@@ -68,7 +68,7 @@ public class TestCDF5Reading extends UnitTestCommon
                 visual("CDF Read", testresult);
             }
             Assert.assertTrue(String.format("***Fail: data mismatch"),
-                                              MAMath.fuzzyEquals(data, BASELINE));
+                                              MAMath.nearlyEquals(data, BASELINE));
             System.err.println("***Pass");
         }
     }

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospReading.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4IospReading.java
@@ -90,7 +90,7 @@ public class TestNc4IospReading {
       //NCdumpW.printArray(data1);
       System.out.printf("Read from jni%n");
       Array data2 = read(jni, "salinity", "0,11:12,22,:");
-      assert MAMath.fuzzyEquals(data1, data2);
+      assert MAMath.nearlyEquals(data1, data2);
       System.out.printf("data is equal%n");
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4Misc.java
+++ b/cdm-test/src/test/java/ucar/nc2/jni/netcdf/TestNc4Misc.java
@@ -348,7 +348,7 @@ public class TestNc4Misc {
       while (data.hasNext() && orgData.hasNext()) {
         float val = data.nextFloat();
         float orgval = orgData.nextFloat();
-        Assert.assertEquals(orgval, val, Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(orgval, val));
       }
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggDirectory.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggDirectory.java
@@ -138,9 +138,9 @@ public class TestOffAggDirectory extends TestCase {
     assert data.getElementType() == float.class;
 
     IndexIterator dataI = data.getIndexIterator();
-    assert Misc.closeEnough(dataI.getFloatNext(), 43.0f) : dataI.getFloatCurrent();
-    assert Misc.closeEnough(dataI.getFloatNext(), 43.01045f) : dataI.getFloatCurrent();
-    assert Misc.closeEnough(dataI.getFloatNext(), 43.020893f) : dataI.getFloatCurrent();
+    assert Misc.nearlyEquals(dataI.getFloatNext(), 43.0f) : dataI.getFloatCurrent();
+    assert Misc.nearlyEquals(dataI.getFloatNext(), 43.01045f) : dataI.getFloatCurrent();
+    assert Misc.nearlyEquals(dataI.getFloatNext(), 43.020893f) : dataI.getFloatCurrent();
 
   }
 
@@ -165,7 +165,7 @@ public class TestOffAggDirectory extends TestCase {
     int count = 0;
     IndexIterator dataI = data.getIndexIterator();
     while (dataI.hasNext())
-      assert Misc.closeEnough( dataI.getFloatNext(), vals[count++]);
+      assert Misc.nearlyEquals( dataI.getFloatNext(), vals[count++]);
   }
 
   public void testReadData(NetcdfFile ncfile) throws IOException {
@@ -197,7 +197,7 @@ public class TestOffAggDirectory extends TestCase {
     for (int i=0; i<shape[0]; i++) {
         double val = data.getDouble( tIndex.set(i, 133, 133));
         // System.out.println(" "+val);
-        assert Misc.closeEnough(vals[i], val) : val;
+        assert Misc.nearlyEquals(vals[i], val) : val;
       }
   }
 
@@ -232,7 +232,7 @@ public class TestOffAggDirectory extends TestCase {
         if (Double.isNaN(val))
           assert Double.isNaN(vals[i]);
         else
-          assert Misc.closeEnough(vals[i], val) : val;
+          assert Misc.nearlyEquals(vals[i], val) : val;
       }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
@@ -85,7 +85,7 @@ public class TestOffAggExistingTimeUnitsChange extends TestCase {
     logger.debug(NCdumpW.toString(data, "time", null));
 
     while (data.hasNext()) {
-      assert Misc.closeEnough(data.nextInt(), (count + 1) * 3);
+      assert Misc.nearlyEquals(data.nextInt(), (count + 1) * 3);
       count++;
     }
 

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcGrib.java
@@ -199,8 +199,8 @@ public class TestOffAggFmrcGrib {
         assert data.getElementType() == double.class || data.getElementType() == float.class;
 
         int last = (int) data.getSize() - 1;
-        assert Misc.closeEnough(data.getDouble(0), -832.2073364257812) : data.getDouble(0);
-        assert Misc.closeEnough(data.getDouble(last), 4369.20068359375) : data.getDouble(last);
+        assert Misc.nearlyEquals(data.getDouble(0), -832.2073364257812) : data.getDouble(0);
+        assert Misc.nearlyEquals(data.getDouble(last), 4369.20068359375) : data.getDouble(last);
     }
 
     private void testAggCoordVar(NetcdfFile ncfile, int nagg, DateUnit du, int[] runhours) {
@@ -275,7 +275,7 @@ public class TestOffAggFmrcGrib {
                 logger.debug("run={} tidx={} val={}", run, tidx, val);
 
                 if (!Double.isNaN(val)) {
-                    assert Misc.closeEnough(val, timevals[run][tidx]) :
+                    assert Misc.nearlyEquals(val, timevals[run][tidx]) :
                             "run,time=(" + run + "," + tidx + "): " + val + " != " + timevals[run][tidx];
                 }
             }

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNetcdf.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggFmrcNetcdf.java
@@ -121,9 +121,9 @@ public class TestOffAggFmrcNetcdf extends TestCase {
       assert data.getElementType() == double.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), -832.6983183345455);
-      assert Misc.closeEnough(dataI.getDoubleNext(), -751.4273183345456);
-      assert Misc.closeEnough(dataI.getDoubleNext(), -670.1563183345455);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -832.6983183345455);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -751.4273183345456);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -670.1563183345455);
 
   }
 
@@ -200,7 +200,7 @@ public class TestOffAggFmrcNetcdf extends TestCase {
     for (int i=0; i < nagg; i++)
       for (int j=0; j < noff; j++) {
         double val = data.getDouble(ima.set(i,j));
-        assert Misc.closeEnough(val, result[i][j]);
+        assert Misc.nearlyEquals(val, result[i][j]);
       }
 
 

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggForecastModel.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggForecastModel.java
@@ -178,9 +178,9 @@ public class TestOffAggForecastModel {
       assert data.getElementType() == double.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), -832.6983183345455);
-      assert Misc.closeEnough(dataI.getDoubleNext(), -751.4273183345456);
-      assert Misc.closeEnough(dataI.getDoubleNext(), -670.1563183345455);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -832.6983183345455);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -751.4273183345456);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), -670.1563183345455);
 
   }
 
@@ -266,7 +266,7 @@ public class TestOffAggForecastModel {
         for (int k=0; k<shape[2]; k++) {
           double val = data.getDouble( tIndex.set(i, j, k));
           //System.out.println(" "+val);
-          assert Misc.closeEnough(val, 100*(i+origin[0]) + 10*j + k) : val;
+          assert Misc.nearlyEquals(val, 100*(i+origin[0]) + 10*j + k) : val;
         } */
 
   }

--- a/cdm-test/src/test/java/ucar/nc2/writer/TestGribCompressByBit.java
+++ b/cdm-test/src/test/java/ucar/nc2/writer/TestGribCompressByBit.java
@@ -307,7 +307,7 @@ public class TestGribCompressByBit {
     float[] fdata = bean.readData();
     for (int i=0; i<rawData.length; i++) {
       float convert = bean.info.convert(rawData[i]);
-      if (!Misc.closeEnough(convert, fdata[i]))
+      if (!Misc.nearlyEquals(convert, fdata[i]))
         System.out.printf("%d %d %f (%f)%n", i, rawData[i], fdata[i], convert);
       if (rawData[i] < 0) {
         System.out.printf("*** %d %d %f (%f)%n", i, rawData[i], fdata[i], bean.info.convert(rawData[i]));

--- a/cdm-test/src/timing/java/ucar/nc2/util/xml/MetarField.java
+++ b/cdm-test/src/timing/java/ucar/nc2/util/xml/MetarField.java
@@ -74,7 +74,7 @@ public class MetarField {
   }
 
   void sum(double d) {
-    if (!Misc.closeEnough(d, -99999.0))
+    if (!Misc.nearlyEquals(d, -99999.0))
       sum += d; // LOOK kludge for missing data
   }
 }

--- a/cdm-test/src/timing/java/ucar/nc2/util/xml/TimeStaxReading.java
+++ b/cdm-test/src/timing/java/ucar/nc2/util/xml/TimeStaxReading.java
@@ -191,7 +191,7 @@ public class TimeStaxReading {
     }
 
     void sum(double d) {
-      if (!Misc.closeEnough(d, -99999.0))
+      if (!Misc.nearlyEquals(d, -99999.0))
         sum += d; // LOOK kludge for missing data
     }
   }   */

--- a/cdm/src/main/java/ucar/atd/dorade/DoradeRADD.java
+++ b/cdm/src/main/java/ucar/atd/dorade/DoradeRADD.java
@@ -398,7 +398,7 @@ class DoradeRADD extends DoradeDescriptor {
     //
     for (int i = 2; i < cellRanges.length; i++) {
       float space = cellRanges[i] - cellRanges[i - 1];
-      if (!Misc.closeEnough(space, cellSpacing) && (Math.abs(space / cellSpacing - 1.0) > 0.01)) {
+      if (!Misc.nearlyEquals(space, cellSpacing) && (Math.abs(space / cellSpacing - 1.0) > 0.01)) {
         throw new DescriptorException("variable cell spacing");
       }
     }

--- a/cdm/src/main/java/ucar/ma2/MAMath.java
+++ b/cdm/src/main/java/ucar/ma2/MAMath.java
@@ -710,9 +710,9 @@ public class MAMath {
 
   /**
    * Returns true if the specified arrays have the same size, signedness, and <b>approximately</b> equal corresponding
-   * elements. {@code float} elements must be within {@code 1.0e-5} of each other, as determined by
-   * {@link Misc#nearlyEquals(double, double, double)}. Similarly, {@code double} elements must be within
-   * {@code 1.0e-8} of each other.
+   * elements. {@code float} elements must be within {@link Misc#defaultMaxRelativeDiffFloat} of each other, as
+   * determined by {@link Misc#nearlyEquals(double, double, double)}. Similarly, {@code double} elements must be within
+   * {@link Misc#defaultMaxRelativeDiffDouble} of each other.
    * <p>
    * {@link #equals(Array, Array)} is an alternative to this method that requires that corresponding elements be
    * <b>exactly</b> equal. It is suitable for use in {@link Object#equals} implementations, whereas this method isn't.
@@ -739,14 +739,14 @@ public class MAMath {
       while (iter1.hasNext() && iter2.hasNext()) {
         double v1 = iter1.getDoubleNext();
         double v2 = iter2.getDoubleNext();
-        if (!Misc.nearlyEquals(v1, v2, 1.0e-8))
+        if (!Misc.nearlyEquals(v1, v2, Misc.defaultMaxRelativeDiffDouble))
           return false;
       }
     } else if (dt == DataType.FLOAT) {
       while (iter1.hasNext() && iter2.hasNext()) {
         float v1 = iter1.getFloatNext();
         float v2 = iter2.getFloatNext();
-        if (!Misc.nearlyEquals(v1, v2, 1.0e-5))
+        if (!Misc.nearlyEquals(v1, v2, Misc.defaultMaxRelativeDiffDouble))
           return false;
       }
     } else if (dt.getPrimitiveClassType() == int.class) {

--- a/cdm/src/main/java/ucar/ma2/MAMath.java
+++ b/cdm/src/main/java/ucar/ma2/MAMath.java
@@ -33,7 +33,6 @@
 package ucar.ma2;
 
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
 import ucar.nc2.util.Misc;
@@ -711,8 +710,9 @@ public class MAMath {
 
   /**
    * Returns true if the specified arrays have the same size, signedness, and <b>approximately</b> equal corresponding
-   * elements. {@code float} elements must be within {@code 1.0e-5} of each other and {@code double} elements must be
-   * within {@code 1.0e-8} of each other.
+   * elements. {@code float} elements must be within {@code 1.0e-5} of each other, as determined by
+   * {@link Misc#nearlyEquals(double, double, double)}. Similarly, {@code double} elements must be within
+   * {@code 1.0e-8} of each other.
    * <p>
    * {@link #equals(Array, Array)} is an alternative to this method that requires that corresponding elements be
    * <b>exactly</b> equal. It is suitable for use in {@link Object#equals} implementations, whereas this method isn't.
@@ -721,7 +721,7 @@ public class MAMath {
    * @param data2  the other array to be tested for equality.
    * @return true if the specified arrays have the same size, signedness, and approximately equal corresponding elems.
    */
-  public static boolean fuzzyEquals(Array data1, Array data2) {
+  public static boolean nearlyEquals(Array data1, Array data2) {
     if (data1 == data2) {  // Covers case when both are null.
       return true;
     } else if (data1 == null || data2 == null) {
@@ -739,17 +739,15 @@ public class MAMath {
       while (iter1.hasNext() && iter2.hasNext()) {
         double v1 = iter1.getDoubleNext();
         double v2 = iter2.getDoubleNext();
-        if (!Double.isNaN(v1) || !Double.isNaN(v2))
-          if (!Misc.closeEnough(v1, v2, 1.0e-8))
-            return false;
+        if (!Misc.nearlyEquals(v1, v2, 1.0e-8))
+          return false;
       }
     } else if (dt == DataType.FLOAT) {
       while (iter1.hasNext() && iter2.hasNext()) {
         float v1 = iter1.getFloatNext();
         float v2 = iter2.getFloatNext();
-        if (!Float.isNaN(v1) || !Float.isNaN(v2))
-          if (!Misc.closeEnough(v1, v2, 1.0e-5))
-            return false;
+        if (!Misc.nearlyEquals(v1, v2, 1.0e-5))
+          return false;
       }
     } else if (dt.getPrimitiveClassType() == int.class) {
       while (iter1.hasNext() && iter2.hasNext()) {
@@ -775,6 +773,12 @@ public class MAMath {
         long v2 = iter2.getLongNext();
         if (v1 != v2) return false;
       }
+    } else {
+      while (iter1.hasNext() && iter2.hasNext()) {
+        if (!Objects.equals(iter1.next(), iter2.next())) {
+          return false;
+        }
+      }
     }
 
     return true;
@@ -789,7 +793,7 @@ public class MAMath {
    * because it's <b>impossible</b> to write a strictly-conforming {@link Object#equals} implementation when an
    * epsilon is incorporated, due to the transitivity requirement.
    * <p>
-   * {@link #fuzzyEquals} is an alternative to this method that returns true if the corresponding elements are
+   * {@link #nearlyEquals} is an alternative to this method that returns true if the corresponding elements are
    * "approximately" equal to each other.
    *
    * @param array1 one array to be tested for equality.
@@ -805,14 +809,14 @@ public class MAMath {
       return false;
     }
 
-    // MAMath.isEquals() does not require DataTypes to be equal, but in so doing, it becomes non-symmetric.
+    // MAMath.nearlyEquals() does not require DataTypes to be equal, but in so doing, it becomes non-symmetric.
     // For example, suppose we have 2 arrays:
     //     ArrayLong  al;
     //     ArrayShort as;
     // If al contains elements that don't fit in a short, we could have the following:
-    //     MAMath.isEquals(al, as);  // true
-    //     MAMath.isEquals(as, al);  // false
-    // This is because when MAMath.isEquals() does comparisons, elements from the 2nd array are converted to the
+    //     MAMath.nearlyEquals(al, as);  // true
+    //     MAMath.nearlyEquals(as, al);  // false
+    // This is because when MAMath.nearlyEquals() does comparisons, elements from the 2nd array are converted to the
     // type of the 1st array.
     //
     // In our implementation, we avoid this problem--and thus preserve symmetry--by insisting that the element
@@ -823,7 +827,7 @@ public class MAMath {
       return false;
     }
 
-    // MAMath.isEquals() only requires that the 2 arrays have the same size, not the same shape. That was an
+    // MAMath.nearlyEquals() only requires that the 2 arrays have the same size, not the same shape. That was an
     // option I considered. Also, there's MAMath.conformable(), which returns true if shapes are equal after
     // reduction (e.g. { 3,4,5 } and { 3,1,4,1,5 } are conformable). By definition, conformable arrays have
     // the same size.
@@ -833,7 +837,7 @@ public class MAMath {
     // operations on them and get the same result. But imagine this:
     //     Array a1 = Array.factory(DataType.INT, new int[] { 3,4 }, new int[] { 0,1,2,3,4,5,6,7,8,9,10,11 });
     //     Array a2 = Array.factory(DataType.INT, new int[] { 2,6 }, new int[] { 0,1,2,3,4,5,6,7,8,9,10,11 });
-    // MAMath.isEquals() will consider the arrays equal because they have the same size, but:
+    // MAMath.nearlyEquals() will consider the arrays equal because they have the same size, but:
     //     a1.getInt(a1.getIndex().set(1, 1)) == 5
     //     a2.getInt(a2.getIndex().set(1, 1)) == 7
     if (!Arrays.equals(array1.getShape(), array2.getShape())) {

--- a/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
@@ -38,7 +38,6 @@ import ucar.nc2.Group;
 import ucar.nc2.Variable;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.CF;
-import ucar.nc2.util.Misc;
 import ucar.nc2.util.NamedObject;
 import ucar.unidata.util.Format;
 
@@ -732,7 +731,7 @@ public class CoordinateAxis1D extends CoordinateAxis {
       increment = (getCoordValue(n - 1) - getCoordValue(0)) / (n - 1);
       isRegular = true;
       for (int i = 1; i < getSize(); i++)
-        if (!ucar.nc2.util.Misc.closeEnough(getCoordValue(i) - getCoordValue(i - 1), increment, 5.0e-3)) {
+        if (!ucar.nc2.util.Misc.nearlyEquals(getCoordValue(i) - getCoordValue(i - 1), increment, 5.0e-3)) {
           isRegular = false;
           break;
         }
@@ -904,12 +903,12 @@ public class CoordinateAxis1D extends CoordinateAxis {
     /* flip if needed
     boolean firstLower = true; // in the first interval, is lower < upper ?
     for (int i = 0; i < value1.length; i++) {
-      if (Misc.closeEnough(value1[i], value2[i])) continue; // skip when lower == upper
+      if (Misc.nearlyEquals(value1[i], value2[i])) continue; // skip when lower == upper
       firstLower = value1[i] < value2[i];
       break;
     }
     // check first against last : lower, unless all lower equal then upper
-    boolean goesUp = (n < 2) || value1[n - 1] > value1[0] || (Misc.closeEnough(value1[n - 1], value2[0]) && value2[n - 1] > value2[0]);
+    boolean goesUp = (n < 2) || value1[n - 1] > value1[0] || (Misc.nearlyEquals(value1[n - 1], value2[0]) && value2[n - 1] > value2[0]);
     if (goesUp != firstLower) {
       double[] temp = value1;
       value1 = value2;
@@ -919,7 +918,7 @@ public class CoordinateAxis1D extends CoordinateAxis {
     // decide if they are contiguous
     boolean contig = true;
     for (int i = 0; i < n - 1; i++) {
-      if (!ucar.nc2.util.Misc.closeEnough(value1[i + 1], value2[i]))
+      if (!ucar.nc2.util.Misc.nearlyEquals(value1[i + 1], value2[i]))
         contig = false;
     }
 

--- a/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis2D.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/CoordinateAxis2D.java
@@ -408,7 +408,7 @@ public class CoordinateAxis2D extends CoordinateAxis {
       ArrayDouble.D2 values = getCoordValuesArray();
       ArrayDouble.D1 valuesForRun = (ArrayDouble.D1) values.slice(0,run_idx );
       for (int i=0; i<valuesForRun.getSize(); i++) {
-        if (Misc.closeEnough(valuesForRun.get(i), wantOffset))
+        if (Misc.nearlyEquals(valuesForRun.get(i), wantOffset))
           return i;
       }
       return -1;

--- a/cdm/src/main/java/ucar/nc2/dataset/EnhanceScaleMissingImpl.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/EnhanceScaleMissingImpl.java
@@ -438,7 +438,7 @@ class EnhanceScaleMissingImpl implements EnhanceScaleMissing {
     if (!hasMissingValue)
       return false;
     for (double aMissingValue : missingValue)
-      if (Misc.closeEnough(val, aMissingValue))
+      if (Misc.nearlyEquals(val, aMissingValue))
         return true;
     return false;
   }

--- a/cdm/src/main/java/ucar/nc2/dataset/conv/AWIPSConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/AWIPSConvention.java
@@ -257,7 +257,7 @@ public class AWIPSConvention extends CoordSysBuilder {
         Variable coord = ds.getRootGroup().findVariable(name);
         Array coordData = coord.read();
         Array newData = Array.makeArray(coord.getDataType(), values);
-        if (MAMath.fuzzyEquals(coordData, newData)) {
+        if (MAMath.nearlyEquals(coordData, newData)) {
           if (debugBreakup) parseInfo.format("  use existing coord %s%n", dim);
           return dim;
         }

--- a/cdm/src/main/java/ucar/nc2/dt/radial/CFRadialAdapter.java
+++ b/cdm/src/main/java/ucar/nc2/dt/radial/CFRadialAdapter.java
@@ -54,7 +54,7 @@ import java.io.IOException;
 
 import java.util.*;
 
-import static ucar.ma2.MAMath.fuzzyEquals;
+import static ucar.ma2.MAMath.nearlyEquals;
 
 /**
  * CF-Radial
@@ -296,7 +296,7 @@ public class CFRadialAdapter extends AbstractRadialAdapter {
             for (int i = 1; i < gar.getSize(); i++) {
               gar2.setObject(i, firstVal);
             }
-            isStationary = fuzzyEquals(gar, gar2);
+            isStationary = nearlyEquals(gar, gar2);
           } catch (IOException e) {
             log.error("Error reading latitude variable {}. Cannot determine if " +
                     "platform is stationary. Setting to default (false).", lat.getFullName());

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/FmrcDataset.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/FmrcDataset.java
@@ -718,7 +718,7 @@ class FmrcDataset {
     // look in the runIdx row of coords to see if a value matches want, return index else -1
     private int findIndex(ArrayDouble.D2 coords, int runIdx, int ntimes, double want) {
       for (int j=0; j<ntimes; j++)
-        if (Misc.closeEnough(coords.get(runIdx, j), want)) return j;
+        if (Misc.nearlyEquals(coords.get(runIdx, j), want)) return j;
       return -1;
     }
 
@@ -1133,7 +1133,7 @@ class FmrcDataset {
     // linear search - barf
      private int findIndex(double offsetHour) {
       for (int i = 0; i < offsets.length; i++)
-        if (Misc.closeEnough(offsets[i], offsetHour))
+        if (Misc.nearlyEquals(offsets[i], offsetHour))
           return i;
       return -1;
     }

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/FmrcInvLite.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/FmrcInvLite.java
@@ -275,7 +275,7 @@ public class FmrcInvLite implements java.io.Serializable {
 
           while (true) { // incr run till we find it
             double run_offset = runOffset[runIdx];
-            if (Misc.closeEnough(run_offset, tc_offset))
+            if (Misc.nearlyEquals(run_offset, tc_offset))
               break;
             runIdx++;
             if (log.isDebugEnabled()) {
@@ -386,7 +386,7 @@ public class FmrcInvLite implements java.io.Serializable {
         for (int time = 0; time < noffsets; time++) { // search for all offsets that match - presumably 0 or 1 per run
           double baseOffset = timeOffset[run * noffsets + time];
           if (Double.isNaN(baseOffset)) continue;
-          if (Misc.closeEnough(baseOffset, offset))
+          if (Misc.nearlyEquals(baseOffset, offset))
             result.add(new TimeInv(run, time, offset - timeOffset[run * noffsets])); // use offset from start of run
         }
       }
@@ -401,7 +401,7 @@ public class FmrcInvLite implements java.io.Serializable {
           double baseOffset = getTimeCoord(run, time);
           if (Double.isNaN(baseOffset)) continue;
           double runOffset = baseOffset - FmrcInvLite.this.runOffset[run]; // subtract the base offset for this run
-          if (Misc.closeEnough(runOffset, offset))
+          if (Misc.nearlyEquals(runOffset, offset))
             result.add(new TimeInv(run, time, baseOffset));
         }
       }
@@ -498,14 +498,14 @@ public class FmrcInvLite implements java.io.Serializable {
       // LOOK linear search!
       private int findIndex(int runIdx, double want) {
         for (int j = 0; j < noffsets; j++)
-          if (Misc.closeEnough(timeOffset[runIdx * noffsets + j], want)) return j;
+          if (Misc.nearlyEquals(timeOffset[runIdx * noffsets + j], want)) return j;
         return -1;
       }
 
       // LOOK linear search!
       private int findBounds(int runIdx, double b1, double b2) {
         for (int j = 0; j < noffsets; j++)
-          if (Misc.closeEnough(timeBounds[2*(runIdx * noffsets + j)], b1) && Misc.closeEnough(timeBounds[2*(runIdx * noffsets + j)+1], b2))
+          if (Misc.nearlyEquals(timeBounds[2*(runIdx * noffsets + j)], b1) && Misc.nearlyEquals(timeBounds[2*(runIdx * noffsets + j)+1], b2))
             return j;
         return -1;
       }
@@ -579,9 +579,9 @@ public class FmrcInvLite implements java.io.Serializable {
 
     @Override
     public int compareTo(TimeInv o) {
-      if (Misc.closeEnough(offset, o.offset)) return 0;
+      if (Misc.nearlyEquals(offset, o.offset)) return 0;
       if (!isInterval) return Double.compare(offset, o.offset);
-      if (Misc.closeEnough(startIntv, o.startIntv)) return 0;
+      if (Misc.nearlyEquals(startIntv, o.startIntv)) return 0;
       return Double.compare(startIntv, o.startIntv);
     }
   }
@@ -718,7 +718,7 @@ public class FmrcInvLite implements java.io.Serializable {
     RunTimeDatasetInventory(CalendarDate run) throws FileNotFoundException {
       double offset = FmrcInv.getOffsetInHours(base, run);
       for (int i = 0; i < runOffset.length; i++) {
-        if (Misc.closeEnough(runOffset[i], offset)) {
+        if (Misc.nearlyEquals(runOffset[i], offset)) {
           runIdx = i;
           break;
         }
@@ -858,7 +858,7 @@ public class FmrcInvLite implements java.io.Serializable {
       boolean ok = false;
       double[] offsets = getForecastOffsets();
       for (int i=0; i<offsets.length; i++)
-        if (Misc.closeEnough(offsets[i], offset)) ok = true;
+        if (Misc.nearlyEquals(offsets[i], offset)) ok = true;
 
       if (!ok)
         throw new FileNotFoundException("No constant offset dataset for = " + offset);

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
@@ -352,7 +352,7 @@ public class GridDatasetInv {
 
     public boolean hasOffset(double want) {
       for (double got : tc.getOffsetHours() ) {
-        if (Misc.closeEnough(want, got)) return true;
+        if (Misc.nearlyEquals(want, got)) return true;
       }
       return false;
     } */

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/TimeCoord.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/TimeCoord.java
@@ -265,9 +265,9 @@ public class TimeCoord implements Comparable {
         return false;
 
       for (int i = 0; i < bound1.length; i++) {
-        if (!ucar.nc2.util.Misc.closeEnough(bound1[i], tother.bound1[i]))
+        if (!ucar.nc2.util.Misc.nearlyEquals(bound1[i], tother.bound1[i]))
           return false;
-        if (!ucar.nc2.util.Misc.closeEnough(bound2[i], tother.bound2[i]))
+        if (!ucar.nc2.util.Misc.nearlyEquals(bound2[i], tother.bound2[i]))
           return false;
       }
       return true;
@@ -278,7 +278,7 @@ public class TimeCoord implements Comparable {
         return false;
 
       for (int i = 0; i < offset.length; i++) {
-        if (!ucar.nc2.util.Misc.closeEnough(offset[i], tother.offset[i]))
+        if (!ucar.nc2.util.Misc.nearlyEquals(offset[i], tother.offset[i]))
           return false;
       }
       return true;
@@ -287,7 +287,7 @@ public class TimeCoord implements Comparable {
 
   public int findInterval(double b1, double b2) {
     for (int i = 0; i < getNCoords(); i++)
-      if (Misc.closeEnough(bound1[i], b1) && Misc.closeEnough(bound2[i], b2))
+      if (Misc.nearlyEquals(bound1[i], b1) && Misc.nearlyEquals(bound2[i], b2))
         return i;
     return -1;
   }
@@ -295,7 +295,7 @@ public class TimeCoord implements Comparable {
   public int findIndex(double offsetHour) {
     double[] off = getOffsetTimes();
     for (int i = 0; i < off.length; i++)
-      if (Misc.closeEnough(off[i], offsetHour))
+      if (Misc.nearlyEquals(off[i], offsetHour))
         return i;
     return -1;
   }
@@ -422,23 +422,23 @@ public class TimeCoord implements Comparable {
 
       Tinv tinv = (Tinv) o;
 
-      if (!Misc.closeEnough(b2, tinv.b2)) return false;
-      if (!Misc.closeEnough(b1, tinv.b1)) return false;
+      if (!Misc.nearlyEquals(b2, tinv.b2)) return false;
+      if (!Misc.nearlyEquals(b1, tinv.b1)) return false;
 
       return true;
     }
 
     @Override
     public int hashCode() {
-      int result = (int) Math.round(b1 / Misc.maxReletiveError);
-      result = 31 * result + (int) Math.round(b2/Misc.maxReletiveError);
+      int result = (int) Math.round(b1 / Misc.defaultMaxRelativeDiffDouble);
+      result = 31 * result + (int) Math.round(b2/Misc.defaultMaxRelativeDiffDouble);
       return result;
     }
 
     @Override
     public int compareTo(Tinv o) {
-      boolean b1close = Misc.closeEnough(b1, o.b1);
-      boolean b2close = Misc.closeEnough(b2, o.b2);
+      boolean b1close = Misc.nearlyEquals(b1, o.b1);
+      boolean b2close = Misc.nearlyEquals(b2, o.b2);
       if (b1close && b2close) return 0;
       if (b2close) return Double.compare(b1, o.b1);
       return Double.compare(b2, o.b2);

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/VertCoord.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/VertCoord.java
@@ -124,7 +124,7 @@ public class VertCoord implements Comparable {
       return false;
 
     for (int i = 0; i < values1.length; i++) {
-      if (!ucar.nc2.util.Misc.closeEnough(values1[i], other.values1[i]))
+      if (!ucar.nc2.util.Misc.nearlyEquals(values1[i], other.values1[i]))
         return false;
     }
 
@@ -137,7 +137,7 @@ public class VertCoord implements Comparable {
     if (values2.length != other.values2.length)
       return false;
     for (int i = 0; i < values2.length; i++) {
-      if (!ucar.nc2.util.Misc.closeEnough(values2[i], other.values2[i]))
+      if (!ucar.nc2.util.Misc.nearlyEquals(values2[i], other.values2[i]))
         return false;
     }
 
@@ -232,7 +232,7 @@ public class VertCoord implements Comparable {
 
     public int compareTo(Object o) {
       LevelCoord other = (LevelCoord) o;
-      //if (closeEnough(value1, other.value1) && closeEnough(value2, other.value2)) return 0;
+      //if (nearlyEquals(value1, other.value1) && nearlyEquals(value2, other.value2)) return 0;
       if (mid < other.mid) return -1;
       if (mid > other.mid) return 1;
       return 0;
@@ -242,7 +242,7 @@ public class VertCoord implements Comparable {
       if (this == oo) return true;
       if (!(oo instanceof LevelCoord)) return false;
       LevelCoord other = (LevelCoord) oo;
-      return (ucar.nc2.util.Misc.closeEnough(value1, other.value1) && ucar.nc2.util.Misc.closeEnough(value2, other.value2));
+      return (ucar.nc2.util.Misc.nearlyEquals(value1, other.value1) && ucar.nc2.util.Misc.nearlyEquals(value2, other.value2));
     }
 
     public int hashCode2() {
@@ -256,8 +256,8 @@ public class VertCoord implements Comparable {
 
       LevelCoord that = (LevelCoord) o;
 
-      if (!ucar.nc2.util.Misc.closeEnough(that.value1, value1)) return false;
-      if (!ucar.nc2.util.Misc.closeEnough(that.value2, value2)) return false;
+      if (!ucar.nc2.util.Misc.nearlyEquals(that.value1, value1)) return false;
+      if (!ucar.nc2.util.Misc.nearlyEquals(that.value2, value2)) return false;
 
       return true;
     }

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
@@ -220,7 +220,7 @@ class CoordAxisHelper {
     for (int i = 0; i < axis.getNcoords(); i++) {
       double edge1 = axis.getCoordEdge1(i);
       double edge2 = axis.getCoordEdge2(i);
-      if (Misc.closeEnough(edge1, target[0]) && Misc.closeEnough(edge2, target[1]))
+      if (Misc.nearlyEquals(edge1, target[0]) && Misc.nearlyEquals(edge2, target[1]))
         return i;
     }
     return -1;
@@ -514,12 +514,12 @@ class CoordAxisHelper {
 
   int search(double want) {
     if (axis.getNcoords() == 1) {
-      return Misc.closeEnough(want, axis.getStartValue()) ? 0 : -1;
+      return Misc.nearlyEquals(want, axis.getStartValue()) ? 0 : -1;
     }
     if (axis.isRegular()) {
       double fval = (want - axis.getStartValue()) / axis.getResolution();
       double ival = Math.rint(fval);
-      return Misc.closeEnough(fval, ival) ? (int) ival : (int) -ival - 1; // LOOK
+      return Misc.nearlyEquals(fval, ival) ? (int) ival : (int) -ival - 1; // LOOK
     }
 
     // otherwise do a binary search

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
@@ -35,7 +35,6 @@ package ucar.nc2.ft2.coverage;
 
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainerHelper;
-import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.util.Indent;
@@ -145,7 +144,6 @@ public class CoverageCollection implements Closeable, CoordSysContainer {
       if (gset == null) {
         CoverageCoordSys ccsys = findCoordSys(coverage.getCoordSysName());
         if (ccsys == null) {
-          findCoordSys(coverage.getCoordSysName());
           throw new IllegalStateException("Cant find "+coverage.getCoordSysName());
         }
 
@@ -247,40 +245,6 @@ public class CoverageCollection implements Closeable, CoordSysContainer {
 
   public CoverageReader getReader() {
     return reader;
-  }
-
-  // this is used in ncss thymeleaf form
-  public CoverageCoordAxis1D getRuntimeCoordinateMax() {
-    // runtimes - LOOK should combine
-    CoverageCoordAxis max = null;
-    for (CoverageCoordAxis axis : coordAxes) {
-      if (axis.getAxisType() == AxisType.RunTime) {
-        if (max == null) max = axis;
-        else if (max.getNcoords() < axis.getNcoords()) max = axis;
-      }
-    }
-    if (max == null) return null;
-    return (max.getDependenceType() == CoverageCoordAxis.DependenceType.dependent) ? null : (CoverageCoordAxis1D) max;
-
-    /* CoverageCoordAxis1D runtimeMax = (CoverageCoordAxis1D) max;
-    if (runtimeMax.getNcoords() < 10) {
-      Formatter f = new Formatter();
-      for (int i=0; i<runtimeMax.getNcoords(); i++) {
-        CalendarDate cd = runtimeMax.makeDate(runtimeMax.getCoord(i));
-        if (i>0) f.format(", ");
-        f.format("%s", cd);
-      }
-      return f.toString();
-    }
-
-    Formatter f = new Formatter();
-    CalendarDate start = runtimeMax.makeDate(runtimeMax.getStartValue());
-    f.format("start=%s", start);
-    CalendarDate end = runtimeMax.makeDate(runtimeMax.getEndValue());
-    f.format(" ,end=%s", end);
-    f.format(" (npts=%d spacing=%s)", runtimeMax.getNcoords(), runtimeMax.getSpacing());
-
-    return f.toString(); */
   }
 
   @Override

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxisBuilder.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxisBuilder.java
@@ -209,7 +209,7 @@ public class CoverageCoordAxisBuilder {
     for (int i = 0; i < values.length - 2; i += 2) {
       double diff = values[i + 2] - values[i];  // difference of consecutive starting interval values // LOOK roundoff
       resol.count(diff);
-      if (isContiguous && !Misc.closeEnough(values[i+1], values[i+2])) // difference of this ending interval values with next starting value
+      if (isContiguous && !Misc.nearlyEquals(values[i+1], values[i+2])) // difference of this ending interval values with next starting value
         isContiguous = false;
     }
 
@@ -226,7 +226,7 @@ public class CoverageCoordAxisBuilder {
     if (ncoords == 2) {
       double diff0 = values[1] - values[0];
       double diff1 = values[3] - values[2];
-      regular = Misc.closeEnough(diff0, diff1);
+      regular = Misc.nearlyEquals(diff0, diff1);
     }
 
     if (regular && isContiguous) {

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordSys.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordSys.java
@@ -53,11 +53,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class CoverageCoordSys {
 
-  public static String makeCoordSysName(List<String> axisName) {
-    Formatter fname = new Formatter();
-    for (String axis : axisName)
-      fname.format(" %s", axis);
-    return fname.toString();
+  public static String makeCoordSysName(List<String> axisNames) {
+    StringBuilder sb = new StringBuilder();
+    for (String axisName : axisNames) {
+      sb.append(axisName).append(' ');
+    }
+    return sb.deleteCharAt(sb.length() - 1).toString();  // Nuke trailing space.
   }
 
   //////////////////////////////////////////////////

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
@@ -486,7 +486,7 @@ public class NcMLWriter {
         for (int i = 2; i < a.getSize(); i++) {
           double v1 = a.getDouble(ima.set(i));
           double v0 = a.getDouble(ima.set(i - 1));
-          if (!ucar.nc2.util.Misc.closeEnough(v1 - v0, incr))
+          if (!ucar.nc2.util.Misc.nearlyEquals(v1 - v0, incr))
             isRegular = false;
         }
 

--- a/cdm/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/src/main/java/ucar/nc2/util/Misc.java
@@ -44,98 +44,125 @@ import java.util.List;
  * @author caron
  */
 public class Misc {
-
   public static final int referenceSize = 4;   // estimates pointer size, in principle JVM dependent
   public static final int objectSize = 16;   // estimates pointer size, in principle JVM dependent
 
-  //private static double maxAbsoluteError = 1.0e-6;
-  public static final double maxReletiveError = 1.0e-6;
-
-  static public double howClose(double d1, double d2) {
-    double pd = (d1 - d2) / d1;
-    return Math.abs(pd);
-  }
-
-
-  /* http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
-    http://floating-point-gui.de/errors/comparison/
-  bool AlmostEqualRelative(float A, float B, float maxRelDiff)
-  {
-      // Calculate the difference.
-      float diff = fabs(A - B);
-      A = fabs(A);
-      B = fabs(B);
-      // Find the largest
-      float largest = (B > A) ? B : A;
-
-      if (diff <= largest * maxRelDiff)
-          return true;
-      return false;
-  } */
+  /**
+   * The default maximum {@link #relativeDifference(float, float) relative difference} that two floats can have in
+   * order to be deemed {@link #nearlyEquals(float, float) nearly equal}.
+   */
+  public static final float defaultMaxRelativeDiffFloat = 1.0e-5f;
 
   /**
-   * Check if numbers are equal with given reletive tolerance
-   *
-   * @param v1         first floating point number
-   * @param v2         second floating point number
-   * @param maxRelDiff maximum reletive difference
-   * @return true if within tolerance
+   * The default maximum {@link #relativeDifference(double, double) relative difference} that two doubles can have in
+   * order to be deemed {@link #nearlyEquals(double, double) nearly equal}.
    */
-  public static boolean closeEnough(double v1, double v2, double maxRelDiff) {
-    if (Double.isNaN(v1) && Double.isNaN(v2)) return true;
-    if (Double.isNaN(v1) || Double.isNaN(v2)) return false;   // prob not needed
-    if(v1 == v2) return true; // handle infinities
-    double diff = Math.abs(v1 - v2);
-    double largest = Math.max(Math.abs(v1), Math.abs(v2));
-    return diff <= largest * maxRelDiff;
+  public static final double defaultMaxRelativeDiffDouble = 1.0e-8;
+
+  /**
+   * Returns the absolute difference between two numbers, i.e. {@code |a - b|}.
+   *
+   * @param a  first number.
+   * @param b  second number.
+   * @return   the absolute difference.
+   */
+  public static float absoluteDifference(float a, float b) {
+    return Math.abs(a - b);
+  }
+
+  /** Same as {@link #absoluteDifference(float, float)}, but for doubles. */
+  public static double absoluteDifference(double a, double b) {
+    return Math.abs(a - b);
   }
 
   /**
-   * Check if numbers are equal with default tolerance
+   * Returns the relative difference between two numbers, i.e. {@code |a - b| / max(|a|, |b|)}.
+   * <p>
+   * For cases where {@code a == 0}, {@code b == 0}, or {@code a} and {@code b} are extremely close, traditional
+   * relative difference calculation breaks down. So, in those instances, we compute the difference relative to
+   * {@link Float#MIN_NORMAL}, i.e. {@code |a - b| / Float.MIN_NORMAL}.
    *
-   * @param v1 first floating point number
-   * @param v2 second floating point number
-   * @return true if within tolerance
+   * @param a  first number.
+   * @param b  second number.
+   * @return   the relative difference.
+   * @see <a href="http://floating-point-gui.de/errors/comparison/">The Floating-Point Guide</a>
+   * @see <a href="https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/">
+   *          Comparing Floating Point Numbers, 2012 Edition</a>
    */
-  public static boolean closeEnough(double v1, double v2) {
-    return closeEnough(v1, v2, maxReletiveError);
+  public static float relativeDifference(float a, float b) {
+    float absDiff = absoluteDifference(a, b);
+
+    if (a == b) {  // shortcut, handles infinities and NaNs
+      return 0;
+    } else if (a == 0 || b == 0 || absDiff < Float.MIN_NORMAL) {
+      return absDiff / Float.MIN_NORMAL;
+    } else {
+      float maxAbsValue = Math.max(Math.abs(a), Math.abs(b));
+      return absDiff / maxAbsValue;
+    }
   }
 
-  public static boolean closeEnough(float v1, float v2, float maxRelDiff) {
-    if (Float.isNaN(v1) && Float.isNaN(v2)) return true;
-    if (Float.isNaN(v1) || Float.isNaN(v2)) return false;   // prob not needed
+  /** Same as {@link #relativeDifference(float, float)}, but for doubles. */
+  public static double relativeDifference(double a, double b) {
+    double absDiff = absoluteDifference(a, b);
 
-    float diff = Math.abs(v1 - v2);
-    float largest = Math.max(Math.abs(v1), Math.abs(v2));
-    return diff <= largest * maxRelDiff;
+    if (a == b) {  // shortcut, handles infinities and NaNs
+      return 0;
+    } else if (a == 0 || b == 0 || absDiff < Double.MIN_NORMAL) {
+      return absDiff / Double.MIN_NORMAL;
+    } else {
+      double maxAbsValue = Math.max(Math.abs(a), Math.abs(b));
+      return absDiff / maxAbsValue;
+    }
+  }
+
+  /** Returns the result of {@link #nearlyEquals(float, float, float)}, with {@link #defaultMaxRelativeDiffFloat}. */
+  public static boolean nearlyEquals(float a, float b) {
+    return nearlyEquals(a, b, defaultMaxRelativeDiffFloat);
   }
 
   /**
-   * Check if numbers are equal with default tolerance
+   * Returns {@code true} if {@code a} and {@code b} are nearly equal. Specifically, it checks whether the
+   * {@link #relativeDifference(float, float) relative difference} of the two numbers is less than {@code maxRelDiff}.
    *
-   * @param v1 first floating point number
-   * @param v2 second floating point number
-   * @return true if within tolerance
+   * @param a  first number.
+   * @param b  second number.
+   * @param maxRelDiff  the maximum {@link #relativeDifference relative difference} the two numbers may have.
+   * @return {@code true} if {@code a} and {@code b} are nearly equal.
    */
-  public static boolean closeEnough(float v1, float v2) {
-    return closeEnough(v1, v2, maxReletiveError);
+  public static boolean nearlyEquals(float a, float b, float maxRelDiff) {
+    return relativeDifference(a, b) < maxRelDiff;
   }
 
   /**
-   * Check if numbers are equal with given absolute tolerance
-   *
-   * @param v1         first floating point number
-   * @param v2         second floating point number
-   * @param maxAbsDiff maximum absolute difference
-   * @return true if within tolerance
+   * Returns the result of {@link #nearlyEquals(double, double, double)}, with {@link #defaultMaxRelativeDiffDouble}.
    */
-  public static boolean closeEnoughAbs(double v1, double v2, double maxAbsDiff) {
-    return Math.abs(v1 - v2) <= Math.abs(maxAbsDiff);
+  public static boolean nearlyEquals(double a, double b) {
+    return nearlyEquals(a, b, defaultMaxRelativeDiffDouble);
   }
 
-  public static boolean closeEnoughAbs(float v1, float v2, float maxAbsDiff) {
-    return Math.abs(v1 - v2) <= Math.abs(maxAbsDiff);
+  /** Same as {@link #nearlyEquals(float, float, float)}, but for doubles. */
+  public static boolean nearlyEquals(double a, double b, double maxRelDiff) {
+    return relativeDifference(a, b) < maxRelDiff;
   }
+
+  /**
+   * Check if two numbers are nearly equal with given absolute tolerance.
+   *
+   * @param a  first number.
+   * @param b  second number.
+   * @param maxAbsDiff  the maximum {@link #absoluteDifference absolute difference} the two numbers may have.
+   * @return true if within tolerance.
+   */
+  public static boolean nearlyEqualsAbs(float a, float b, float maxAbsDiff) {
+    return absoluteDifference(a, b) <= Math.abs(maxAbsDiff);
+  }
+
+  /** Same as {@link #nearlyEqualsAbs(float, float, float)}, but with doubles. */
+  public static boolean nearlyEqualsAbs(double a, double b, double maxAbsDiff) {
+    return absoluteDifference(a, b) <= Math.abs(maxAbsDiff);
+  }
+
 
   static public String showInts(int[] inta) {
     if (inta == null) return "null";
@@ -222,7 +249,7 @@ public class Misc {
 
     int ndiff = 0;
     for (int i = 0; i < len; i++) {
-      if (!Misc.closeEnough(raw1[i], raw2[i]) && !Double.isNaN(raw1[i]) && !Double.isNaN(raw2[i])) {
+      if (!Misc.nearlyEquals(raw1[i], raw2[i]) && !Double.isNaN(raw1[i]) && !Double.isNaN(raw2[i])) {
         f.format(" %5d : %3f != %3f%n", i, raw1[i], raw2[i]);
         ndiff++;
       }

--- a/cdm/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/src/main/java/ucar/nc2/util/Misc.java
@@ -67,12 +67,20 @@ public class Misc {
    * @return   the absolute difference.
    */
   public static float absoluteDifference(float a, float b) {
-    return Math.abs(a - b);
+    if (Float.compare(a, b) == 0) {  // Shortcut: handles infinities and NaNs.
+      return 0;
+    } else {
+      return Math.abs(a - b);
+    }
   }
 
   /** Same as {@link #absoluteDifference(float, float)}, but for doubles. */
   public static double absoluteDifference(double a, double b) {
-    return Math.abs(a - b);
+    if (Double.compare(a, b) == 0) {  // Shortcut: handles infinities and NaNs.
+      return 0;
+    } else {
+      return Math.abs(a - b);
+    }
   }
 
   /**
@@ -92,7 +100,7 @@ public class Misc {
   public static float relativeDifference(float a, float b) {
     float absDiff = absoluteDifference(a, b);
 
-    if (a == b) {  // shortcut, handles infinities and NaNs
+    if (Float.compare(a, b) == 0) {  // Shortcut: handles infinities and NaNs.
       return 0;
     } else if (a == 0 || b == 0 || absDiff < Float.MIN_NORMAL) {
       return absDiff / Float.MIN_NORMAL;
@@ -106,7 +114,7 @@ public class Misc {
   public static double relativeDifference(double a, double b) {
     double absDiff = absoluteDifference(a, b);
 
-    if (a == b) {  // shortcut, handles infinities and NaNs
+    if (Double.compare(a, b) == 0) {  // Shortcut: handles infinities and NaNs.
       return 0;
     } else if (a == 0 || b == 0 || absDiff < Double.MIN_NORMAL) {
       return absDiff / Double.MIN_NORMAL;

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPoint.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPoint.java
@@ -32,6 +32,8 @@
  */
 package ucar.unidata.geoloc;
 
+import ucar.nc2.util.Misc;
+
 /**
  * Points on the Earth's surface, represented as (longitude,latitude),
  * in units of degrees.
@@ -57,10 +59,19 @@ public interface LatLonPoint {
   double getLatitude();
 
   /**
-   * Returns true if this represents the same point as pt.
-   *
-   * @param pt point to check
-   * @return true if this represents the same point
+   * Returns the result of {@link #nearlyEquals(LatLonPoint, double)}, with {@link Misc#defaultMaxRelativeDiffDouble}.
    */
-  boolean equals(LatLonPoint pt);
+  default boolean nearlyEquals(LatLonPoint other) {
+    return nearlyEquals(other, Misc.defaultMaxRelativeDiffDouble);
+  }
+
+  /**
+   * Returns {@code true} if this point is nearly equal to {@code other}. The "near equality" of points is determined
+   * using {@link Misc#nearlyEquals(double, double, double)}, with the specified maxRelDiff.
+   *
+   * @param other    the other point to check.
+   * @param maxRelDiff  the maximum {@link Misc#relativeDifference relative difference} the two points may have.
+   * @return {@code true} if this point is nearly equal to {@code other}.
+   */
+  boolean nearlyEquals(LatLonPoint other, double maxRelDiff);
 }

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImmutable.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImmutable.java
@@ -39,9 +39,9 @@ package ucar.unidata.geoloc;
  * @author caron
  * @since 7/29/2014
  */
-public class LatLonPointImmutable implements LatLonPoint {
-  public static final LatLonPointImmutable INVALID = new LatLonPointImmutable(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-  private final double lat, lon;
+public class LatLonPointImmutable extends LatLonPointImpl {
+  public static final LatLonPointImmutable INVALID = new LatLonPointImmutable(
+          Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
   public LatLonPointImmutable(double lat, double lon) {
     this.lat = lat;
@@ -49,43 +49,22 @@ public class LatLonPointImmutable implements LatLonPoint {
   }
 
   public LatLonPointImmutable(LatLonPoint pt) {
-    this.lat = pt.getLatitude();
-    this.lon = pt.getLongitude();
+    this(pt.getLatitude(), pt.getLongitude());
   }
 
+  /**
+   * @throws UnsupportedOperationException because instances of this class are meant to be immutable.
+   */
   @Override
-  public double getLongitude() {
-    return lon;
+  public void setLongitude(double lon) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Instances of this class are meant to be immutable.");
   }
 
+  /**
+   * @throws UnsupportedOperationException because instances of this class are meant to be immutable.
+   */
   @Override
-  public double getLatitude() {
-    return lat;
-  }
-
-  @Override
-  public boolean equals(LatLonPoint pt) {
-    if (Double.compare(pt.getLatitude(), lat) != 0) return false;
-    if (Double.compare(pt.getLongitude(), lon) != 0) return false;
-    return true;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof LatLonPoint)) return false;
-    LatLonPoint that = (LatLonPoint) o;
-    return equals(that);
-  }
-
-  @Override
-  public int hashCode() {
-    int result;
-    long temp;
-    temp = Double.doubleToLongBits(lat);
-    result = (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(lon);
-    result = 31 * result + (int) (temp ^ (temp >>> 32));
-    return result;
+  public void setLatitude(double lat) {
+    throw new UnsupportedOperationException("Instances of this class are meant to be immutable.");
   }
 }

--- a/cdm/src/main/java/ucar/unidata/geoloc/ProjectionPoint.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/ProjectionPoint.java
@@ -32,6 +32,8 @@
  */
 package ucar.unidata.geoloc;
 
+import ucar.nc2.util.Misc;
+
 /**
  * Points on the Projective geometry plane.
  *
@@ -55,11 +57,19 @@ public interface ProjectionPoint {
   double getY();
 
   /**
-   * Check for equality with the point in question
-   *
-   * @param pt point to check
-   * @return true if it represents the same point
+   * Returns the result of {@link #nearlyEquals(ProjectionPoint, double)}, with {@link Misc#defaultMaxRelativeDiffDouble}.
    */
-  boolean equals(ProjectionPoint pt);
+  default boolean nearlyEquals(ProjectionPoint other) {
+    return nearlyEquals(other, Misc.defaultMaxRelativeDiffDouble);
+  }
 
+  /**
+   * Returns {@code true} if this point is nearly equal to {@code other}. The "near equality" of points is determined
+   * using {@link Misc#nearlyEquals(double, double, double)}, with the specified maxRelDiff.
+   *
+   * @param other    the other point to check.
+   * @param maxRelDiff  the maximum {@link Misc#relativeDifference relative difference} the two points may have.
+   * @return {@code true} if this point is nearly equal to {@code other}.
+   */
+  boolean nearlyEquals(ProjectionPoint other, double maxRelDiff);
 }

--- a/cdm/src/main/java/ucar/unidata/geoloc/ProjectionPointImpl.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/ProjectionPointImpl.java
@@ -54,15 +54,6 @@ public class ProjectionPointImpl implements ProjectionPoint, java.io.Serializabl
   }
 
   /**
-   * Constructor that copies Point2D values into this.
-   *
-   * @param pt point to copy
-   *
-  public ProjectionPointImpl(Point2D pt) {
-    super(pt.getX(), pt.getY());
-  } */
-
-  /**
    * Constructor that copies ProjectionPoint values into this.
    *
    * @param pt point to copy
@@ -99,13 +90,24 @@ public class ProjectionPointImpl implements ProjectionPoint, java.io.Serializabl
     this.y = y;
   }
 
-  // must be exact compare to be consistent with hashCode
+  @Override
+  public boolean nearlyEquals(ProjectionPoint other, double maxRelDiff) {
+    return Misc.nearlyEquals(x, other.getX(), maxRelDiff) && Misc.nearlyEquals(y, other.getY(), maxRelDiff);
+  }
+
+  // Exact comparison is needed in order to be consistent with hashCode().
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ProjectionPointImpl that = (ProjectionPointImpl) o;
-    if (Double.compare(that.x, x) != 0) return false;
+    if (Double.compare(that.x, x) != 0) {
+      return false;
+    }
     return Double.compare(that.y, y) == 0;
   }
 
@@ -118,16 +120,6 @@ public class ProjectionPointImpl implements ProjectionPoint, java.io.Serializabl
     temp = Double.doubleToLongBits(y);
     result = 31 * result + (int) (temp ^ (temp >>> 32));
     return result;
-  }
-
-  /**
-   * Returns true if this represents the same point as pt, using Misc.closeEnough.
-   *
-   * @param pt2 point to check against
-   * @return true if this represents the same point as pt2.
-   */
-  public boolean equals(ProjectionPoint pt2) {
-    return Misc.closeEnough(getX(), pt2.getX()) &&  Misc.closeEnough(getY(), pt2.getY());
   }
 
   /**
@@ -158,16 +150,6 @@ public class ProjectionPointImpl implements ProjectionPoint, java.io.Serializabl
        this.x = x;
        this.y = y;
    }
-
-
-  /**
-   * set x,y location from  pt
-   *
-   * @param pt point to use for values
-   *
-  public void setLocation(Point2D pt) {
-    setLocation(pt.getX(), pt.getY());
-  } */
 
   /**
    * See if either coordinate is +/- infinite. This happens sometimes

--- a/cdm/src/main/java/ucar/unidata/geoloc/ProjectionRect.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/ProjectionRect.java
@@ -489,6 +489,7 @@ public class ProjectionRect implements java.io.Serializable {
     s.writeDouble(getHeight());
   }
 
+  // Exact comparison is needed in order to be consistent with hashCode().
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -518,17 +519,23 @@ public class ProjectionRect implements java.io.Serializable {
     return result;
   }
 
-  // cannot do approx compare and be consistent with equals
-  // so make it a seperate method
-  private static final double maxReletiveError = 1.0e-5;
-  public boolean closeEnough(ProjectionRect that) {
-    if (!Misc.closeEnough(that.height, height, maxReletiveError)) return false;
-    if (!Misc.closeEnough(that.width, width, maxReletiveError)) return false;
-    if (!Misc.closeEnough(that.x, x, maxReletiveError)) return false;
-    if (!Misc.closeEnough(that.y, y, maxReletiveError)) return false;
-
-    return true;
+  /**
+   * Returns the result of {@link #nearlyEquals(ProjectionRect, double)}, with {@link Misc#defaultMaxRelativeDiffFloat}.
+   */
+  public boolean nearlyEquals(ProjectionRect other) {
+    return nearlyEquals(other, Misc.defaultMaxRelativeDiffFloat);
   }
 
-
+  /**
+   * Returns {@code true} if this rectangle is nearly equal to {@code other}. The "near equality" of corners is
+   * determined using {@link ProjectionPoint#nearlyEquals(ProjectionPoint, double)}, with the specified maxRelDiff.
+   *
+   * @param other    the other rectangle to check.
+   * @param maxRelDiff  the maximum {@link Misc#relativeDifference relative difference} that two corners may have.
+   * @return {@code true} if this rectangle is nearly equal to {@code other}.
+   */
+  public boolean nearlyEquals(ProjectionRect other, double maxRelDiff) {
+    return this.getLowerLeftPoint() .nearlyEquals(other.getLowerLeftPoint(),  maxRelDiff) &&
+           this.getUpperRightPoint().nearlyEquals(other.getUpperRightPoint(), maxRelDiff);
+  }
 }

--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/Sinusoidal.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/Sinusoidal.java
@@ -286,7 +286,7 @@ public class Sinusoidal extends ProjectionImpl {
         double toLat_r = fromY / earthRadius;
         double toLon_r;
 
-        if (Misc.closeEnough(Math.abs(toLat_r), PI_OVER_2, 1e-10)) {
+        if (Misc.nearlyEquals(Math.abs(toLat_r), PI_OVER_2, 1e-10)) {
             toLat_r = toLat_r < 0 ? -PI_OVER_2 : +PI_OVER_2;
             toLon_r = Math.toRadians(centMeridian);  // if lat == +- pi/2, set lon = centMeridian (Snyder 248)
         } else if (Math.abs(toLat_r) < PI_OVER_2) {
@@ -295,7 +295,7 @@ public class Sinusoidal extends ProjectionImpl {
             return INVALID;  // Projection point is off the map.
         }
 
-        if (Misc.closeEnough(Math.abs(toLon_r), PI, 1e-10)) {
+        if (Misc.nearlyEquals(Math.abs(toLon_r), PI, 1e-10)) {
             toLon_r = toLon_r < 0 ? -PI : +PI;
         } else if (Math.abs(toLon_r) > PI) {
             return INVALID;  // Projection point is off the map.

--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/UtmProjection.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/UtmProjection.java
@@ -359,8 +359,8 @@ them on a map.
     UtmProjection utm = new UtmProjection(17, true);
     LatLonPoint ll = utm.projToLatLon(577.8000000000001, 2951.8);
     System.out.printf("%15.12f %15.12f%n", ll.getLatitude(), ll.getLongitude());
-    assert Misc.closeEnough(ll.getLongitude(), -80.21802662821469, 1.0e-8);
-    assert Misc.closeEnough(ll.getLatitude(), 26.685132668190793, 1.0e-8);
+    assert Misc.nearlyEquals(ll.getLongitude(), -80.21802662821469, 1.0e-8);
+    assert Misc.nearlyEquals(ll.getLatitude(), 26.685132668190793, 1.0e-8);
   }
 
 }

--- a/cdm/src/test/java/ucar/ma2/ArrayTest.java
+++ b/cdm/src/test/java/ucar/ma2/ArrayTest.java
@@ -38,7 +38,7 @@ public class ArrayTest {
     Array data = Array.factory(DataType.USHORT, new int[]{nz, ny, nx}, vals);
     double sum = MAMath.sumDouble(data);
     double sumReduce = MAMath.sumDouble(data.reduce(0));
-    assert Misc.closeEnough(sum, sumReduce);
+    assert Misc.nearlyEquals(sum, sumReduce);
   }
 
   // Demonstrates bug in https://github.com/Unidata/thredds/issues/581.

--- a/cdm/src/test/java/ucar/ma2/TestIterator.java
+++ b/cdm/src/test/java/ucar/ma2/TestIterator.java
@@ -96,7 +96,7 @@ public class TestIterator {
         for (k=0; k<p; k++) {
           double val = iter.getDoubleNext();
           double myVal = (double) (i*100+j*10+k);
-          Assert.assertEquals(val, myVal, Misc.maxReletiveError);
+          Assert.assertTrue(Misc.nearlyEquals(val, myVal));
         }
       }
     }
@@ -123,7 +123,7 @@ public class TestIterator {
         for (k=0; k<p; k++) {
           double val = iter.getDoubleNext();
           double myVal = (double) (i*100+j*10+k);
-          Assert.assertEquals(val, myVal, Misc.maxReletiveError);
+          Assert.assertTrue(Misc.nearlyEquals(val, myVal));
         }
       }
     }

--- a/cdm/src/test/java/ucar/nc2/TestReadRecord.java
+++ b/cdm/src/test/java/ucar/nc2/TestReadRecord.java
@@ -83,10 +83,10 @@ public class TestReadRecord extends TestCase {
       values = lon.read();
       assert (values instanceof ArrayFloat.D1);
       ArrayFloat.D1 fa = (ArrayFloat.D1) values;
-      assert (Misc.closeEnough(fa.get(0), -109.0f)) : fa.get(0);
-      assert (Misc.closeEnough(fa.get(1), -107.0f)) : fa.get(1);
-      assert (Misc.closeEnough(fa.get(2), -105.0f)) : fa.get(2);
-      assert (Misc.closeEnough(fa.get(3), -103.0f)) : fa.get(3);
+      assert (Misc.nearlyEquals(fa.get(0), -109.0f)) : fa.get(0);
+      assert (Misc.nearlyEquals(fa.get(1), -107.0f)) : fa.get(1);
+      assert (Misc.nearlyEquals(fa.get(2), -105.0f)) : fa.get(2);
+      assert (Misc.nearlyEquals(fa.get(3), -103.0f)) : fa.get(3);
 
       /* Now we can just use the MultiArray to access values, or
          we can copy the MultiArray elements to another array with
@@ -125,15 +125,15 @@ public class TestReadRecord extends TestCase {
       Array tValues = t.read();
       assert (tValues instanceof ArrayDouble.D3);
       ArrayDouble.D3 Ta = (ArrayDouble.D3) tValues;
-      assert Misc.closeEnough(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
-      assert Misc.closeEnough(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
+      assert Misc.nearlyEquals(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
+      assert Misc.nearlyEquals(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
 
       /* Read subset of the temperature data */
       tValues = t.read(new int[3], new int[]{2, 2, 2});
       assert (tValues instanceof ArrayDouble.D3);
       Ta = (ArrayDouble.D3) tValues;
-      assert Misc.closeEnough(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
-      assert Misc.closeEnough(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
+      assert Misc.nearlyEquals(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
+      assert Misc.nearlyEquals(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
 
       nc.close();
 
@@ -176,10 +176,10 @@ public class TestReadRecord extends TestCase {
       values = lon.read();
       assert (values instanceof ArrayFloat.D1);
       ArrayFloat.D1 fa = (ArrayFloat.D1) values;
-      assert (Misc.closeEnough(fa.get(0), -109.0f)) : fa.get(0);
-      assert (Misc.closeEnough(fa.get(1), -107.0f)) : fa.get(1);
-      assert (Misc.closeEnough(fa.get(2), -105.0f)) : fa.get(2);
-      assert (Misc.closeEnough(fa.get(3), -103.0f)) : fa.get(3);
+      assert (Misc.nearlyEquals(fa.get(0), -109.0f)) : fa.get(0);
+      assert (Misc.nearlyEquals(fa.get(1), -107.0f)) : fa.get(1);
+      assert (Misc.nearlyEquals(fa.get(2), -105.0f)) : fa.get(2);
+      assert (Misc.nearlyEquals(fa.get(3), -103.0f)) : fa.get(3);
 
       /* Now we can just use the MultiArray to access values, or
          we can copy the MultiArray elements to another array with

--- a/cdm/src/test/java/ucar/nc2/TestReadSection.java
+++ b/cdm/src/test/java/ucar/nc2/TestReadSection.java
@@ -100,7 +100,7 @@ public class TestReadSection extends TestCase {
     while (s1.hasNext()) {
       double d1 = s1.getDoubleNext();
       double d2 = s2.getDoubleNext();
-      assert Misc.closeEnough(d1, d2) : count+" "+d1 +" != "+d2;
+      assert Misc.nearlyEquals(d1, d2) : count+" "+d1 +" != "+d2;
       count++;
     }
 
@@ -164,7 +164,7 @@ public class TestReadSection extends TestCase {
     while (s1.hasNext()) {
       double d1 = s1.getDoubleNext();
       double d2 = s2.getDoubleNext();
-      assert Misc.closeEnough( d1, d2) : count+" "+d1 +" != "+d2;
+      assert Misc.nearlyEquals( d1, d2) : count+" "+d1 +" != "+d2;
       count++;
     }
 

--- a/cdm/src/test/java/ucar/nc2/TestWriteRecord.java
+++ b/cdm/src/test/java/ucar/nc2/TestWriteRecord.java
@@ -263,10 +263,10 @@ public class TestWriteRecord {
         values = lon.read();
         assert (values instanceof ArrayFloat.D1);
         ArrayFloat.D1 fa = (ArrayFloat.D1) values;
-        assert (Misc.closeEnough(fa.get(0), -109.0f)) : fa.get(0);
-        assert (Misc.closeEnough(fa.get(1), -107.0f)) : fa.get(1);
-        assert (Misc.closeEnough(fa.get(2), -105.0f)) : fa.get(2);
-        assert (Misc.closeEnough(fa.get(3), -103.0f)) : fa.get(3);
+        assert (Misc.nearlyEquals(fa.get(0), -109.0f)) : fa.get(0);
+        assert (Misc.nearlyEquals(fa.get(1), -107.0f)) : fa.get(1);
+        assert (Misc.nearlyEquals(fa.get(2), -105.0f)) : fa.get(2);
+        assert (Misc.nearlyEquals(fa.get(3), -103.0f)) : fa.get(3);
 
         /* Now we can just use the MultiArray to access values, or
            we can copy the MultiArray elements to another array with
@@ -308,15 +308,15 @@ public class TestWriteRecord {
         Array    tValues = t.read();
         assert (tValues instanceof ArrayDouble.D3);
         ArrayDouble.D3 Ta = (ArrayDouble.D3) tValues;
-        assert Misc.closeEnough(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
-        assert Misc.closeEnough(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
+        assert Misc.nearlyEquals(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
+        assert Misc.nearlyEquals(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
 
         /* Read subset of the temperature data */
         tValues = t.read(new int[3], new int[] { 2, 2, 2 });
         assert (tValues instanceof ArrayDouble.D3);
         Ta = (ArrayDouble.D3) tValues;
-        assert Misc.closeEnough(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
-        assert Misc.closeEnough(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
+        assert Misc.nearlyEquals(Ta.get(0, 0, 0), 1.0f) : Ta.get(0, 0, 0);
+        assert Misc.nearlyEquals(Ta.get(1, 1, 1), 10.0f) : Ta.get(1, 1, 1);
 
       } catch (InvalidRangeException e) {
           e.printStackTrace();

--- a/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffset.java
+++ b/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffset.java
@@ -112,17 +112,17 @@ public class TestScaleOffset {
       assert vs != null;
       readEnhanced = vs.read();
       //TestCompare.compareData(readEnhanced, unpacked);
-      closeEnough(packed, unpacked, readEnhanced, 1.0 / so.scale);
+      nearlyEquals(packed, unpacked, readEnhanced, 1.0 / so.scale);
     }
 
     Array cnvertPacked = MAMath.convert2Unpacked(readPacked, so);
     //TestCompare.compareData(readUnpacked, unpacked);
-    closeEnough(packed, cnvertPacked, readEnhanced, 1.0 / so.scale);
+    nearlyEquals(packed, cnvertPacked, readEnhanced, 1.0 / so.scale);
 
     doSubset(filename);
   }
 
-  void closeEnough(Array packed, Array data1, Array data2, double close) {
+  void nearlyEquals(Array packed, Array data1, Array data2, double close) {
     IndexIterator iterp = packed.getIndexIterator();
     IndexIterator iter1 = data1.getIndexIterator();
     IndexIterator iter2 = data2.getIndexIterator();

--- a/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingForStructure.java
+++ b/cdm/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingForStructure.java
@@ -138,7 +138,7 @@ public class TestScaleOffsetMissingForStructure extends TestCase {
       if (count == 0)
         assert Float.isNaN(dval) : dval;
       else
-        assert TestAll.closeEnough(dval, 1040.8407) : dval;
+        assert TestAll.nearlyEquals(dval, 1040.8407) : dval;
       count++;
     } */
 

--- a/cdm/src/test/java/ucar/nc2/dataset/TestStandardVar.java
+++ b/cdm/src/test/java/ucar/nc2/dataset/TestStandardVar.java
@@ -424,7 +424,7 @@ public class TestStandardVar extends TestCase {
     ima = A.getIndex();
 
     val = A.getFloat(ima.set(1,1));
-    assert Misc.closeEnough(val, -999.99) : val;
+    assert Misc.nearlyEquals(val, -999.99) : val;
     assert v.isMissing(val);
   }
 

--- a/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
@@ -1,12 +1,12 @@
 package ucar.nc2.ft.point;
 
-import com.google.common.math.DoubleMath;
 import ucar.ma2.Array;
 import ucar.ma2.MAMath;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureMembers;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.ft.*;
+import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.EarthLocation;
 import ucar.unidata.geoloc.Station;
 
@@ -159,9 +159,9 @@ public class PointTestUtil {
 
         if (!equals(pointFeat1.getLocation(), pointFeat2.getLocation())) {
             return false;
-        } else if (!DoubleMath.fuzzyEquals(pointFeat1.getObservationTime(), pointFeat2.getObservationTime(), 1.0e-8)) {
+        } else if (!Misc.nearlyEquals(pointFeat1.getObservationTime(), pointFeat2.getObservationTime(), 1.0e-8)) {
             return false;
-        } else if (!DoubleMath.fuzzyEquals(pointFeat1.getNominalTime(), pointFeat2.getNominalTime(), 1.0e-8)) {
+        } else if (!Misc.nearlyEquals(pointFeat1.getNominalTime(), pointFeat2.getNominalTime(), 1.0e-8)) {
             return false;
         } else if (!equals(pointFeat1.getFeatureData(), pointFeat2.getFeatureData())) {
             return false;
@@ -181,13 +181,9 @@ public class PointTestUtil {
             return false;
         }
 
-        if (!DoubleMath.fuzzyEquals(loc1.getLatitude(), loc2.getLatitude(), 1.0e-8)) {
+        if (!loc1.getLatLon().nearlyEquals(loc2.getLatLon(), 1.0e-8)) {
             return false;
-        } else if (!DoubleMath.fuzzyEquals(loc1.getLongitude(), loc2.getLongitude(), 1.0e-8)) {
-            return false;
-        } else if (!DoubleMath.fuzzyEquals(loc1.getAltitude(), loc2.getAltitude(), 1.0e-8)) {
-            return false;
-        } else if (!Objects.deepEquals(loc1.getLatLon(), loc2.getLatLon())) {
+        } else if (!Misc.nearlyEquals(loc1.getAltitude(), loc2.getAltitude(), 1.0e-8)) {
             return false;
         } else if (!Objects.deepEquals(loc1.isMissing(), loc2.isMissing())) {
             return false;

--- a/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
+++ b/cdm/src/test/java/ucar/nc2/ft/point/PointTestUtil.java
@@ -211,7 +211,7 @@ public class PointTestUtil {
             Array memberArray1 = sdata1.getArray(memberName);
             Array memberArray2 = sdata2.getArray(memberName);
 
-            if (!MAMath.fuzzyEquals(memberArray1, memberArray2)) {
+            if (!MAMath.nearlyEquals(memberArray1, memberArray2)) {
                 return false;
             }
         }

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
@@ -145,7 +145,7 @@ public class TestAggExistingCoordVars extends TestCase {
       IndexIterator dataI = data.getIndexIterator();
       while (dataI.hasNext()) {
         double val = dataI.getDoubleNext();
-        assert Misc.closeEnough(val, result[count]) : val +" != "+ result[count];
+        assert Misc.nearlyEquals(val, result[count]) : val +" != "+ result[count];
         count++;
       }
 
@@ -225,7 +225,7 @@ public class TestAggExistingCoordVars extends TestCase {
       int count = 0;
       IndexIterator dataI = data.getIndexIterator();
       while (dataI.hasNext()) {
-        assert Misc.closeEnough(dataI.getDoubleNext(), result[count]);
+        assert Misc.nearlyEquals(dataI.getDoubleNext(), result[count]);
         count++;
       }
 

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
@@ -146,9 +146,9 @@ public class TestAggSynGrid {
       assert data.getElementType() == float.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), 41.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 40.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 39.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 41.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 40.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 39.0);
     } catch (IOException io) {
     }
 
@@ -210,7 +210,7 @@ public class TestAggSynGrid {
           for (int k = 0; k < shape[2]; k++) {
             double val = data.getDouble(tIndex.set(i, j, k));
             // System.out.println(" "+val);
-            assert Misc.closeEnough(val, 100 * i + 10 * j + k) : val;
+            assert Misc.nearlyEquals(val, 100 * i + 10 * j + k) : val;
           }
 
     } catch (IOException io) {
@@ -238,7 +238,7 @@ public class TestAggSynGrid {
           for (int k = 0; k < shape[2]; k++) {
             double val = data.getDouble(tIndex.set(i, j, k));
             //System.out.println(" "+val);
-            assert Misc.closeEnough(val, 100 * (i + origin[0]) + 10 * j + k) : val;
+            assert Misc.nearlyEquals(val, 100 * (i + origin[0]) + 10 * j + k) : val;
           }
 
     } catch (InvalidRangeException io) {

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggSynthetic.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggSynthetic.java
@@ -318,9 +318,9 @@ public class TestAggSynthetic extends TestCase {
     assert (data instanceof ArrayDouble);
     IndexIterator dataI = data.getIndexIterator();
     double val = dataI.getDoubleNext();
-    assert Misc.closeEnough(val, 0.0) : val;
-    assert Misc.closeEnough(dataI.getDoubleNext(), 10.0) : dataI.getDoubleCurrent();
-    assert Misc.closeEnough(dataI.getDoubleNext(), 99.0) : dataI.getDoubleCurrent();
+    assert Misc.nearlyEquals(val, 0.0) : val;
+    assert Misc.nearlyEquals(dataI.getDoubleNext(), 10.0) : dataI.getDoubleCurrent();
+    assert Misc.nearlyEquals(dataI.getDoubleNext(), 99.0) : dataI.getDoubleCurrent();
   }
 
   public void testAggCoordVarScan(NetcdfFile ncfile) throws IOException {

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggUnion.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggUnion.java
@@ -248,9 +248,9 @@ public class TestAggUnion extends TestCase {
       assert data.getElementType() == float.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), 41.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 40.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 39.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 41.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 40.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 39.0);
     } catch (IOException io) {
     }
 
@@ -403,11 +403,11 @@ public class TestAggUnion extends TestCase {
       assert data.getElementType() == double.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), 1.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 2.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 3.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 4.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 2.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 1.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 2.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 3.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 4.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 2.0);
     } catch (IOException io) {
       io.printStackTrace();
     }

--- a/cdm/src/test/java/ucar/nc2/ncml/TestAggUnionSimple.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestAggUnionSimple.java
@@ -247,9 +247,9 @@ public class TestAggUnionSimple extends TestCase {
       assert data.getElementType() == float.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), 10.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 9.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 8.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 10.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 9.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 8.0);
     } catch (IOException io) {
     }
 

--- a/cdm/src/test/java/ucar/nc2/ncml/TestNcMLModifyAtts.java
+++ b/cdm/src/test/java/ucar/nc2/ncml/TestNcMLModifyAtts.java
@@ -155,9 +155,9 @@ public class TestNcMLModifyAtts extends TestCase {
       assert data.getElementType() == float.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough(dataI.getDoubleNext(), 41.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 40.0);
-      assert Misc.closeEnough(dataI.getDoubleNext(), 39.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 41.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 40.0);
+      assert Misc.nearlyEquals(dataI.getDoubleNext(), 39.0);
     } catch (IOException io) {}
 
   }
@@ -297,11 +297,11 @@ public class TestNcMLModifyAtts extends TestCase {
       assert data.getElementType() == double.class;
 
       IndexIterator dataI = data.getIndexIterator();
-      assert Misc.closeEnough( dataI.getDoubleNext(),1.0);
-      assert Misc.closeEnough( dataI.getDoubleNext(),2.0);
-      assert Misc.closeEnough( dataI.getDoubleNext(),3.0);
-      assert Misc.closeEnough( dataI.getDoubleNext(),4.0);
-      assert Misc.closeEnough( dataI.getDoubleNext(),2.0);
+      assert Misc.nearlyEquals( dataI.getDoubleNext(),1.0);
+      assert Misc.nearlyEquals( dataI.getDoubleNext(),2.0);
+      assert Misc.nearlyEquals( dataI.getDoubleNext(),3.0);
+      assert Misc.nearlyEquals( dataI.getDoubleNext(),4.0);
+      assert Misc.nearlyEquals( dataI.getDoubleNext(),2.0);
     } catch (IOException io) {}
   }
 

--- a/cdm/src/test/java/ucar/nc2/units/TestBasic.java
+++ b/cdm/src/test/java/ucar/nc2/units/TestBasic.java
@@ -62,7 +62,7 @@ public class TestBasic extends TestCase {
       if (debug) System.out.println("5 knots is " +
         knot.convertTo(5, meterPerSecondUnit) +
         ' ' + format.format(meterPerSecondUnit));
-      assert(Misc.closeEnough(2.5722222, knot.convertTo(5, meterPerSecondUnit)));
+      assert Misc.nearlyEquals(2.5722222f, knot.convertTo(5, meterPerSecondUnit));
 
     } catch (Exception e) {
       System.out.println("Exception " + e);
@@ -84,7 +84,7 @@ public class TestBasic extends TestCase {
 
     try {
       if (debug) System.out.println("t2.convertTo(0.0, t1) " +t2.convertTo(0.0, t1));
-      assert(Misc.closeEnough(86400.0, t2.convertTo(0.0, t1)));
+      assert(Misc.nearlyEquals(86400.0, t2.convertTo(0.0, t1)));
     } catch (Exception e) {
       System.out.println("testTimeConversion failed 2 =" +e);
     }
@@ -105,7 +105,7 @@ public class TestBasic extends TestCase {
 
     try {
       System.out.println("t2.convertTo(0.0, t1) " +t2.convertTo(0.0, t1));
-      // assert(closeEnough(86400.0, t2.convertTo(0.0, t1)));
+      // assert(nearlyEquals(86400.0, t2.convertTo(0.0, t1)));
     } catch (Exception e) {
       System.out.println("testTimeConversion failed 2 =" +e);
     }

--- a/cdm/src/test/java/ucar/nc2/units/TestDateUnits.java
+++ b/cdm/src/test/java/ucar/nc2/units/TestDateUnits.java
@@ -142,7 +142,7 @@ public class TestDateUnits {
 
     value = du.makeValue(d);
     System.out.println("testDateValue " + value + " == " + formatter.toDateTimeStringISO(d));
-    assert Misc.closeEnough(value, 365) : value;
+    assert Misc.nearlyEquals(value, 365) : value;
   }
 
   private void showUnitInfo(Unit uu) {

--- a/cdm/src/test/java/ucar/nc2/units/TestTimeUnits.java
+++ b/cdm/src/test/java/ucar/nc2/units/TestTimeUnits.java
@@ -89,7 +89,7 @@ public class TestTimeUnits extends TestCase  {
     assert tu.getValue() == 33.0;
     assert 3600.0 * tu.getValue() == tu.getValueInSeconds() : tu.getValue() +" "+tu.getValueInSeconds();
     assert tu.getUnitString().equals( unitBefore);
-    assert Misc.closeEnough(tu.getValueInSeconds(), 11.0 * secsBefore) : (tu.getValueInSeconds())+" "+ secsBefore;
+    assert Misc.nearlyEquals(tu.getValueInSeconds(), 11.0 * secsBefore) : (tu.getValueInSeconds())+" "+ secsBefore;
 
     System.out.println();
     tu.setValueInSeconds( 3600.0);
@@ -98,7 +98,7 @@ public class TestTimeUnits extends TestCase  {
     assert tu.getValue() == 1.0;
     assert tu.getValueInSeconds() == 3600.0 : tu.getValueInSeconds();
     assert tu.getUnitString().equals( unitBefore);
-    assert Misc.closeEnough( 3.0 * tu.getValueInSeconds(), secsBefore) : tu.getValueInSeconds()+" "+secsBefore;
+    assert Misc.nearlyEquals( 3.0 * tu.getValueInSeconds(), secsBefore) : tu.getValueInSeconds()+" "+secsBefore;
 
     TimeUnit day = new TimeUnit(1.0, "day");
     double hoursInDay = day.convertTo(1.0, tu);

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestBasic.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestBasic.java
@@ -144,30 +144,30 @@ public class TestBasic extends TestCase {
     LatLonRect b;
     LatLonPoint p = new LatLonPointImpl(30.0, 30.0);
     b = testExtend(makeLatLonBoundingBox(10.0, 10.0), p);
-    assert(p.equals(b.getUpperRightPoint()));
+    assert(p.nearlyEquals(b.getUpperRightPoint()));
 
     p = new LatLonPointImpl(-30.0, -30.0);
     b = testExtend(makeLatLonBoundingBox(10.0, 10.0), p);
-    assert(p.equals(b.getLowerLeftPoint()));
+    assert(p.nearlyEquals(b.getLowerLeftPoint()));
 
     p = new LatLonPointImpl(30.0, 190.0);
     b = testExtend(makeLatLonBoundingBox(50.0, 100.0), p);
-    assert(p.equals(b.getUpperRightPoint()));
+    assert(p.nearlyEquals(b.getUpperRightPoint()));
     assert ( b.crossDateline());
 
     p = new LatLonPointImpl(-30.0, -50.0);
     b = testExtend(makeLatLonBoundingBox(50.0, 100.0), p);
-    assert(p.equals(b.getLowerLeftPoint()));
+    assert(p.nearlyEquals(b.getLowerLeftPoint()));
     assert ( !b.crossDateline());
 
     p = new LatLonPointImpl(-30.0, 100.0);
     b = testExtend(makeLatLonBoundingBox2(140.0, 50.0), p);
-    assert(p.equals(b.getLowerLeftPoint()));
+    assert(p.nearlyEquals(b.getLowerLeftPoint()));
     assert ( b.crossDateline());
 
     p = new LatLonPointImpl(30.0, 55.0);
     b = testExtend(makeLatLonBoundingBox2(140.0, 50.0), p);
-    assert(p.equals(b.getUpperRightPoint()));
+    assert(p.nearlyEquals(b.getUpperRightPoint()));
     assert ( b.crossDateline());
 
   }

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestLatLonProjection.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestLatLonProjection.java
@@ -74,7 +74,7 @@ public class TestLatLonProjection extends TestCase {
       ProjectionRect ma2 = p.latLonToProjBB(llbb);
       LatLonRect p2 = p.projToLatLonBB(ma2);
 
-      Assert.assertEquals(llbb + " => " + ma2 + " => " + p2, llbb, p2);
+      Assert.assertTrue(llbb + " => " + ma2 + " => " + p2, llbb.nearlyEquals(p2));
     }
   }
 
@@ -89,7 +89,7 @@ public class TestLatLonProjection extends TestCase {
       ProjectionRect ma2 = p.latLonToProjBB(llbb);
       LatLonRect p2 = p.projToLatLonBB(ma2);
 
-      Assert.assertEquals(llbb + " => " + ma2 + " => " + p2, llbb, p2);
+      Assert.assertTrue(llbb + " => " + ma2 + " => " + p2, llbb.nearlyEquals(p2));
     }
   }
 

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestLatLonToProjBB.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestLatLonToProjBB.java
@@ -37,7 +37,6 @@ import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.unidata.geoloc.projection.LambertConformal;
-import ucar.nc2.util.Misc;
 
 import java.lang.invoke.MethodHandles;
 
@@ -53,7 +52,7 @@ public class TestLatLonToProjBB extends TestCase {
   void doTest(ProjectionImpl p, LatLonRect rect) {
     ProjectionRect prect = p.latLonToProjBB( rect);
     ProjectionRect prect2 = p.latLonToProjBB2( rect);
-    if (!equals( prect, prect2)) {
+    if (!prect.nearlyEquals(prect2)) {
       System.out.println("\nFAIL Projection= " + p);
       System.out.println("  llbb= " + rect.toString2());
       System.out.println("  latLonToProjBB= " + prect);
@@ -80,16 +79,6 @@ public class TestLatLonToProjBB extends TestCase {
   public void testLC() {
     doTests(new LambertConformal(40.0, 0, 20.0, 60.0), 0);
   }
-
-  boolean equals(ProjectionRect prect1, ProjectionRect prect2) {
-    boolean b1 = equals( prect1.getLowerLeftPoint(), prect2.getLowerLeftPoint());
-    boolean b2 = equals( prect1.getUpperRightPoint(), prect2.getUpperRightPoint());
-    return b1 && b2;
-  }
-
-  boolean equals(ProjectionPoint pt1, ProjectionPoint pt2) {
-      return Misc.closeEnough(pt1.getX(), pt2.getX()) &&  Misc.closeEnough(pt1.getY(), pt2.getY());
-    }
 
   public void utestProblem() {
     ProjectionImpl p = new LambertConformal(40.0, 0, 20.0, 60.0);

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestLongitudeNormalization.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestLongitudeNormalization.java
@@ -68,7 +68,7 @@ public class TestLongitudeNormalization {
     double compute = lonNormalFrom(lon, from);
     if (expectedDiff != null) {
       if (show) System.out.printf("(%f from %f) = %f, diff = %f expectedDiff %f%n", lon, from, compute, compute - lon, expectedDiff);
-      Assert.assertEquals(expectedDiff, compute - lon, lon * Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(expectedDiff, compute - lon));
     } else {
       if (show) System.out.printf("(%f from %f) = %f, diff = %f%n", lon, from, compute, compute - lon);
     }

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestLongitudeWrap.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestLongitudeWrap.java
@@ -44,7 +44,7 @@ public class TestLongitudeWrap {
   public void doit() {
     double compute = lonDiff(lat1, lat2);
     System.out.printf("(%f - %f) = %f, expect %f%n", lat1, lat2, compute, expected);
-    Assert.assertEquals(expected, compute, expected * Misc.maxReletiveError);
+    Assert.assertTrue(Misc.nearlyEquals(expected, compute));
     Assert.assertTrue(Math.abs(compute) < 360.0);
   }
 

--- a/cdm/src/test/java/ucar/unidata/geoloc/TestProjections.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/TestProjections.java
@@ -431,8 +431,8 @@ public class TestProjections {
       LatLonPoint ll = proj.projToLatLon(startP);
       ProjectionPoint endP = proj.latLonToProj(ll);
 
-      assert (TestAll.closeEnough(startP.getX(), endP.getX()));
-      assert (TestAll.closeEnough(startP.getY(), endP.getY()));
+      assert (TestAll.nearlyEquals(startP.getX(), endP.getX()));
+      assert (TestAll.nearlyEquals(startP.getY(), endP.getY()));
     }  */
 
     if (show)

--- a/cdm/src/test/java/ucar/unidata/geoloc/projection/TestProjectionTiming.java
+++ b/cdm/src/test/java/ucar/unidata/geoloc/projection/TestProjectionTiming.java
@@ -78,8 +78,8 @@ public class TestProjectionTiming extends TestCase {
         LatLonPoint endL = proj.projToLatLon( p);
 
         if (checkit) {
-          assert Misc.closeEnough(from[0][i], endL.getLatitude()) : "lat: "+from[0][i] + "!="+ endL.getLatitude();
-          assert closeEnoughLon(from[1][i], endL.getLongitude())  : "lon: "+from[1][i] + "!="+ endL.getLongitude();
+          assert Misc.nearlyEquals(from[0][i], endL.getLatitude()) : "lat: "+from[0][i] + "!="+ endL.getLatitude();
+          assert nearlyEqualsLon(from[1][i], endL.getLongitude())  : "lon: "+from[1][i] + "!="+ endL.getLongitude();
         }
       }
     }
@@ -96,8 +96,8 @@ public class TestProjectionTiming extends TestCase {
 
         if (checkit) {
           for (int i=0; i<NPTS; i++) {
-            assert Misc.closeEnough(from[0][i], result2[0][i]) : "lat: "+from[0][i] + "!="+ result2[0][i];
-            assert closeEnoughLon(from[1][i], result2[1][i])  : "lon: "+from[1][i] + "!="+ result2[1][i];
+            assert Misc.nearlyEquals(from[0][i], result2[0][i]) : "lat: "+from[0][i] + "!="+ result2[0][i];
+            assert nearlyEqualsLon(from[1][i], result2[1][i])  : "lon: "+from[1][i] + "!="+ result2[1][i];
           }
         }
     }
@@ -108,8 +108,8 @@ public class TestProjectionTiming extends TestCase {
 
   }
 
-  public static boolean closeEnoughLon( double v1, double v2) {
-    return Misc.closeEnough(LatLonPointImpl.lonNormal(v1), LatLonPointImpl.lonNormal(v2) );
+  public static boolean nearlyEqualsLon( double v1, double v2) {
+    return Misc.nearlyEquals(LatLonPointImpl.lonNormal(v1), LatLonPointImpl.lonNormal(v2) );
   }
 
   public void testEachProjection() {

--- a/docs/internal/testingCdmAndTds.html
+++ b/docs/internal/testingCdmAndTds.html
@@ -27,7 +27,8 @@ file in the "user.home" directory. An example:</p>
 <p>The following static variables are provided for accessing the above directories:</p><ul><li>upcShareDir:String - "//zero/share/"</li><li>upcShareTestDataDir:String - "//zero/share/testdata/" [NOTE: No longer exists]</li><li>upcShareThreddsDataDir:String - "//zero/share/thredds/data/"</li><li>upcShareDirFile:File -&nbsp;"//zero/share"</li><li>testDataDir:File - "//newshemp/testdata</li><li>cdmTestDataDir:String - "cdm/target/test/tmp/"</li><li>temporaryDataDir:String - "target/test/tmp/"</li></ul><p>Note
 that all the String variables end with a slash ("/"). All are checked
 that they exist (error messages are output if they don't or can't be
-created).</p><p>The following static methods are provided:</p><ul><li>closeEnough(double,double):boolean</li><li>closeEnough(double,double,double):boolean</li><li>closeEnough(float,float):boolean</li><li>openAllInDir(String dirName, FileFilter ff)</li><li>readAllDir(String dirName, FileFilter ff)</li><li>...</li></ul><p></p>
+created).</p><p>The following static methods are provided:</p><ul><li>nearlyEquals(double,double):boolean</li><li>
+  nearlyEquals(double,double,double):boolean</li><li>nearlyEquals(float,float):boolean</li><li>openAllInDir(String dirName, FileFilter ff)</li><li>readAllDir(String dirName, FileFilter ff)</li><li>...</li></ul><p></p>
 
 <h3>CDM ucar.unidata.utils.TestFileDirUtils</h3><p>Static utility methods for creating directories and files.</p>
 

--- a/docs/website/tds/UpgradingTo5.adoc
+++ b/docs/website/tds/UpgradingTo5.adoc
@@ -168,7 +168,7 @@ This means, among other things, that corresponding floating-point elements must 
 some epsilon of each other.
 * Added method `hashCode(Array array)`. It is intended for use in `Object.hashCode()` implementations and is
 compatible with `equals(Array, Array)`.
-* Renamed `isEqual(Array, Array)` to `fuzzyEquals(Array, Array)`. This was done to avoid (some) confusion with the new
+* Renamed `isEqual(Array, Array)` to `nearlyEquals(Array, Array)`. This was done to avoid (some) confusion with the new
 `equals(Array, Array)`, and to highlight that this method performs *approximate* comparison of floating-point numbers,
 instead of the exact comparison done by `equals(Array, Array)`.
 

--- a/grib/src/main/java/ucar/coord/CoordinateEns.java
+++ b/grib/src/main/java/ucar/coord/CoordinateEns.java
@@ -105,7 +105,7 @@ public class CoordinateEns implements Coordinate {
   public int getIndexByMember(double need) {
     for (int i = 0; i < ensSorted.size(); i++) {
       EnsCoord.Coord coord = ensSorted.get(i);
-      if (Misc.closeEnough(need, coord.getEnsMember())) return i;
+      if (Misc.nearlyEquals(need, coord.getEnsMember())) return i;
     }
     return -1;
   }

--- a/grib/src/main/java/ucar/coord/CoordinateSharer.java
+++ b/grib/src/main/java/ucar/coord/CoordinateSharer.java
@@ -374,7 +374,7 @@ public class CoordinateSharer<T> {
     }
 
     // try to merge runtime whose values differ by < smooshTolerence
-    public boolean closeEnough(RuntimeSmoosher that) {
+    public boolean nearlyEquals(RuntimeSmoosher that) {
       Sets.SetView<Long> common = Sets.intersection(this.coordSet, that.coordSet);
       int total = Math.min(this.runtime.getSize(), that.runtime.getSize());
 

--- a/grib/src/main/java/ucar/coord/CoordinateVert.java
+++ b/grib/src/main/java/ucar/coord/CoordinateVert.java
@@ -90,7 +90,7 @@ public class CoordinateVert implements Coordinate {
     } else {
       for (int i=0; i<levelSorted.size(); i++) {
         VertCoord.Level level = levelSorted.get(i);
-        if (Misc.closeEnough(need, level.getValue1())) return i;
+        if (Misc.nearlyEquals(need, level.getValue1())) return i;
       }
       return -1;
     }

--- a/grib/src/main/java/ucar/nc2/grib/VertCoord.java
+++ b/grib/src/main/java/ucar/nc2/grib/VertCoord.java
@@ -33,6 +33,8 @@
 
 package ucar.nc2.grib;
 
+import ucar.nc2.util.Misc;
+
 import javax.annotation.concurrent.Immutable;
 
 import java.util.*;
@@ -144,7 +146,7 @@ public class VertCoord {
       return false;
 
     for (int i = 0; i < coords.size(); i++) {
-      if (!coords.get(i).closeEnough(other.coords.get(i)))
+      if (!coords.get(i).nearlyEquals(other.coords.get(i)))
         return false;
     }
 
@@ -252,8 +254,8 @@ public class VertCoord {
     }
 
     // cannot do approx equals and be consistent with hashCode, so make seperate call
-    public boolean closeEnough(Level other) {
-      return (ucar.nc2.util.Misc.closeEnough(value1, other.value1) && ucar.nc2.util.Misc.closeEnough(value2, other.value2));
+    public boolean nearlyEquals(Level other) {
+      return Misc.nearlyEquals(value1, other.value1) && Misc.nearlyEquals(value2, other.value2);
     }
 
     public String toString() {
@@ -286,4 +288,3 @@ public class VertCoord {
     boolean isVerticalCoordinate();
   }
 }
-

--- a/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
@@ -1014,13 +1014,6 @@ public class GribCoverageDataset implements CoverageReader, CoordAxisReader {
     return axisNames;
   }
 
-  private String makeCoordSysName(List<String> axes) {
-    Formatter fname = new Formatter();
-    for (String axis : axes)
-      fname.format(" %s", axis);
-    return fname.toString();
-  }
-
   private Coverage makeCoverage(GribCollectionImmutable.VariableIndex gribVar, Map<Coordinate, List<CoverageCoordAxis>> coord2axisMap) {
 
     AttributeContainerHelper atts = new AttributeContainerHelper(gribVar.makeVariableName());
@@ -1056,7 +1049,7 @@ public class GribCoverageDataset implements CoverageReader, CoordAxisReader {
       }
     } */
 
-    String coordSysName = makeCoordSysName(makeAxisNameList(gribVar, coord2axisMap));
+    String coordSysName = CoverageCoordSys.makeCoordSysName(makeAxisNameList(gribVar, coord2axisMap));
 
     return new Coverage(gribVar.makeVariableName(), DataType.FLOAT, atts.getAttributes(), coordSysName, gribVar.makeVariableUnits(),
             gribVar.makeVariableDescription(), this, gribVar);

--- a/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
@@ -413,7 +413,7 @@ public class GribCoverageDataset implements CoverageReader, CoordAxisReader {
 
   private int alreadyHaveAtIndex(RuntimeSmoosher tester) {
     for (int i = 0; i < runtimes.size(); i++)
-      if (runtimes.get(i).closeEnough(tester)) return i;
+      if (runtimes.get(i).nearlyEquals(tester)) return i;
     return -1;
   }
   */

--- a/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/Grib1Gds.java
@@ -406,7 +406,7 @@ public abstract class Grib1Gds {
       float calcDelta = (lo2 - lo1) / (nx-1); // more accurate - deltaLon may have roundoff
       if (deltaLon != GribNumbers.UNDEFINED) deltaLon *= scale3; // undefined for thin grids
       else deltaLon = calcDelta;
-      if (!Misc.closeEnough(deltaLon, calcDelta)) {
+      if (!Misc.nearlyEquals(deltaLon, calcDelta)) {
         log.debug("deltaLon != calcDeltaLon");
         deltaLon = calcDelta;
       }
@@ -439,7 +439,7 @@ public abstract class Grib1Gds {
         deltaLat = calcDelta;
       }  */
 
-      if (!Misc.closeEnough(deltaLat, calcDelta)) {
+      if (!Misc.nearlyEquals(deltaLat, calcDelta)) {
         log.debug("deltaLat != calcDeltaLat");
         deltaLat = calcDelta;
       }
@@ -496,10 +496,10 @@ public abstract class Grib1Gds {
       if (!super.equals(o)) return false;
 
       LatLon other = (LatLon) o;
-      if (!Misc.closeEnoughAbs(la1, other.la1, maxReletiveErrorPos * deltaLat)) return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, other.lo1, maxReletiveErrorPos * deltaLon)) return false;
-      if (!Misc.closeEnough(deltaLat, other.deltaLat)) return false;
-      if (!Misc.closeEnough(deltaLon, other.deltaLon)) return false;
+      if (!Misc.nearlyEqualsAbs(la1, other.la1, maxReletiveErrorPos * deltaLat)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.nearlyEqualsAbs(lo1, other.lo1, maxReletiveErrorPos * deltaLon)) return false;
+      if (!Misc.nearlyEquals(deltaLat, other.deltaLat)) return false;
+      if (!Misc.nearlyEquals(deltaLon, other.deltaLon)) return false;
       return true;
     }
 
@@ -508,8 +508,8 @@ public abstract class Grib1Gds {
       if (hashCode == 0) {
         int useLat = (int) (la1 / (maxReletiveErrorPos * deltaLat));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) (lo1 / (maxReletiveErrorPos * deltaLon));
-        int useDeltaLon = (int) (deltaLon / Misc.maxReletiveError);
-        int useDeltaLat = (int) (deltaLat / Misc.maxReletiveError);
+        int useDeltaLon = (int) (deltaLon / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) (deltaLat / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;
@@ -772,11 +772,11 @@ Grid definition –   polar stereographic
 
       PolarStereographic that = (PolarStereographic) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-      if (!Misc.closeEnough(lov, that.lov)) return false;
-      if (!Misc.closeEnough(dY, that.dY)) return false;
-      if (!Misc.closeEnough(dX, that.dX)) return false;
+      if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
+      if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+      if (!Misc.nearlyEquals(lov, that.lov)) return false;
+      if (!Misc.nearlyEquals(dY, that.dY)) return false;
+      if (!Misc.nearlyEquals(dX, that.dX)) return false;
 
       if (projCenterFlag != that.projCenterFlag) return false;
 
@@ -788,9 +788,9 @@ Grid definition –   polar stereographic
       if (hashCode == 0) {
         int useLat = (int) (la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) (lo1 / (maxReletiveErrorPos * dX));
-        int useLov = (int) (lov / Misc.maxReletiveError);
-        int useDeltaLon = (int) (dX / Misc.maxReletiveError);
-        int useDeltaLat = (int) (dY / Misc.maxReletiveError);
+        int useLov = (int) (lov / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLon = (int) (dX / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) (dY / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;
@@ -949,14 +949,14 @@ Grid definition –   polar stereographic
 
       LambertConformal that = (LambertConformal) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-      if (!Misc.closeEnough(lad, that.lad)) return false;
-      if (!Misc.closeEnough(lov, that.lov)) return false;
-      if (!Misc.closeEnough(dY, that.dY)) return false;
-      if (!Misc.closeEnough(dX, that.dX)) return false;
-      if (!Misc.closeEnough(latin1, that.latin1)) return false;
-      if (!Misc.closeEnough(latin2, that.latin2)) return false;
+      if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, relative to grid size
+      if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+      if (!Misc.nearlyEquals(lad, that.lad)) return false;
+      if (!Misc.nearlyEquals(lov, that.lov)) return false;
+      if (!Misc.nearlyEquals(dY, that.dY)) return false;
+      if (!Misc.nearlyEquals(dX, that.dX)) return false;
+      if (!Misc.nearlyEquals(latin1, that.latin1)) return false;
+      if (!Misc.nearlyEquals(latin2, that.latin2)) return false;
 
       return true;
     }
@@ -966,12 +966,12 @@ Grid definition –   polar stereographic
       if (hashCode == 0) {
         int useLat = (int) (la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) (lo1 / (maxReletiveErrorPos * dX));
-        int useLad = (int) (lad / Misc.maxReletiveError);
-        int useLov = (int) (lov / Misc.maxReletiveError);
-        int useDeltaLon = (int) (dX / Misc.maxReletiveError);
-        int useDeltaLat = (int) (dY / Misc.maxReletiveError);
-        int useLatin1 = (int) (latin1 / Misc.maxReletiveError);
-        int useLatin2 = (int) (latin2 / Misc.maxReletiveError);
+        int useLad = (int) (lad / Misc.defaultMaxRelativeDiffFloat);
+        int useLov = (int) (lov / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLon = (int) (dX / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) (dY / Misc.defaultMaxRelativeDiffFloat);
+        int useLatin1 = (int) (latin1 / Misc.defaultMaxRelativeDiffFloat);
+        int useLatin2 = (int) (latin2 / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;
@@ -1096,11 +1096,11 @@ Grid definition –   polar stereographic
 
        Mercator that = (Mercator) o;
 
-       if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
-       if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-       if (!Misc.closeEnough(latin, that.latin)) return false;
-       if (!Misc.closeEnough(dY, that.dY)) return false;
-       if (!Misc.closeEnough(dX, that.dX)) return false;
+       if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY)) return false;   // allow some slop, reletive to grid size
+       if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+       if (!Misc.nearlyEquals(latin, that.latin)) return false;
+       if (!Misc.nearlyEquals(dY, that.dY)) return false;
+       if (!Misc.nearlyEquals(dX, that.dX)) return false;
 
        return true;
      }
@@ -1110,9 +1110,9 @@ Grid definition –   polar stereographic
        if (hashCode == 0) {
          int useLat = (int) (la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
          int useLon = (int) (lo1 / (maxReletiveErrorPos * dX));
-         int useLad = (int) (latin / Misc.maxReletiveError);
-         int useDeltaLon = (int) (dX / Misc.maxReletiveError);
-         int useDeltaLat = (int) (dY / Misc.maxReletiveError);
+         int useLad = (int) (latin / Misc.defaultMaxRelativeDiffFloat);
+         int useDeltaLon = (int) (dX / Misc.defaultMaxRelativeDiffFloat);
+         int useDeltaLat = (int) (dY / Misc.defaultMaxRelativeDiffFloat);
 
          int result = super.hashCode();
          result = 31 * result + useLat;
@@ -1200,7 +1200,7 @@ Grid definition –   polar stereographic
       if (!super.equals(o)) return false;
 
       RotatedLatLon other = (RotatedLatLon) o;
-      return Misc.closeEnough(angleRotation, other.angleRotation);
+      return Misc.nearlyEquals(angleRotation, other.angleRotation);
     }
 
     @Override

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
@@ -413,7 +413,7 @@ public abstract class Grib2Gds {
       super.finish();
 
       if (lo2 < lo1) lo2 += 360.0F;
-      if (Misc.closeEnough(lo1, lo2)) { // canadian met has global with lo1 = lo2 = 180
+      if (Misc.nearlyEquals(lo1, lo2)) { // canadian met has global with lo1 = lo2 = 180
         lo1 -= 360.0F;
       }
 
@@ -421,7 +421,7 @@ public abstract class Grib2Gds {
       float scale = getScale();
       deltaLon = getOctet4(64) * scale;
       float calcDelta = (lo2 - lo1) / (getNx() - 1); // more accurate - deltaLon may have roundoff
-      if (!Misc.closeEnough(deltaLon, calcDelta)) {
+      if (!Misc.nearlyEquals(deltaLon, calcDelta)) {
         log.debug("deltaLon {} != calcDeltaLon {}", deltaLon, calcDelta);
         deltaLon = calcDelta;
       }
@@ -429,7 +429,7 @@ public abstract class Grib2Gds {
       deltaLat = getOctet4(68) * scale;
       if (la2 < la1) deltaLat = -deltaLat;
       calcDelta = (la2 - la1) / (getNy() - 1); // more accurate - deltaLat may have roundoff
-      if (!Misc.closeEnough(deltaLat, calcDelta)) {
+      if (!Misc.nearlyEquals(deltaLat, calcDelta)) {
         log.debug("deltaLat {} != calcDeltaLat {}", deltaLat, calcDelta);
         deltaLat = calcDelta;
       }
@@ -447,11 +447,11 @@ public abstract class Grib2Gds {
       if (!super.equals(o)) return false;
 
       LatLon other = (LatLon) o;
-      if (!Misc.closeEnoughAbs(la1, other.la1, maxReletiveErrorPos * deltaLat))
+      if (!Misc.nearlyEqualsAbs(la1, other.la1, maxReletiveErrorPos * deltaLat))
         return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, other.lo1, maxReletiveErrorPos * deltaLon)) return false;
-      if (!Misc.closeEnoughAbs(la2, other.la2, maxReletiveErrorPos * deltaLat)) return false;
-      if (!Misc.closeEnoughAbs(lo2, other.lo2, maxReletiveErrorPos * deltaLon)) return false;
+      if (!Misc.nearlyEqualsAbs(lo1, other.lo1, maxReletiveErrorPos * deltaLon)) return false;
+      if (!Misc.nearlyEqualsAbs(la2, other.la2, maxReletiveErrorPos * deltaLat)) return false;
+      if (!Misc.nearlyEqualsAbs(lo2, other.lo2, maxReletiveErrorPos * deltaLon)) return false;
       return true;
     }
 
@@ -768,12 +768,12 @@ Template 3.10 (Grid definition template 3.10 - Mercator)
 
       Mercator that = (Mercator) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+      if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY))
         return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-      if (!Misc.closeEnoughAbs(lad, that.lad, maxReletiveErrorPos * dY)) return false;
-      if (!Misc.closeEnough(dY, that.dY)) return false;
-      if (!Misc.closeEnough(dX, that.dX)) return false;
+      if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+      if (!Misc.nearlyEqualsAbs(lad, that.lad, maxReletiveErrorPos * dY)) return false;
+      if (!Misc.nearlyEquals(dY, that.dY)) return false;
+      if (!Misc.nearlyEquals(dX, that.dX)) return false;
 
       return true;
     }
@@ -784,8 +784,8 @@ Template 3.10 (Grid definition template 3.10 - Mercator)
         int useLat = (int) Math.round(la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) Math.round(lo1 / (maxReletiveErrorPos * dX));
         int useLad = (int) Math.round(lad / (maxReletiveErrorPos * dY));
-        int useDeltaLon = (int) Math.round(dX / Misc.maxReletiveError);
-        int useDeltaLat = (int) Math.round(dY / Misc.maxReletiveError);
+        int useDeltaLon = (int) Math.round(dX / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) Math.round(dY / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;
@@ -902,13 +902,13 @@ Template 3.20 (Grid definition template 3.20 - polar stereographic projection)
 
       PolarStereographic that = (PolarStereographic) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+      if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY))
         return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-      if (!Misc.closeEnough(lad, that.lad)) return false;
-      if (!Misc.closeEnough(lov, that.lov)) return false;
-      if (!Misc.closeEnough(dY, that.dY)) return false;
-      if (!Misc.closeEnough(dX, that.dX)) return false;
+      if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+      if (!Misc.nearlyEquals(lad, that.lad)) return false;
+      if (!Misc.nearlyEquals(lov, that.lov)) return false;
+      if (!Misc.nearlyEquals(dY, that.dY)) return false;
+      if (!Misc.nearlyEquals(dX, that.dX)) return false;
 
       if (projCenterFlag != that.projCenterFlag) return false;
 
@@ -920,10 +920,10 @@ Template 3.20 (Grid definition template 3.20 - polar stereographic projection)
       if (hashCode == 0) {
         int useLat = (int) Math.round(la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) Math.round(lo1 / (maxReletiveErrorPos * dX));
-        int useLad = (int) Math.round(lad / Misc.maxReletiveError);
-        int useLov = (int) Math.round(lov / Misc.maxReletiveError);
-        int useDeltaLon = (int) Math.round(dX / Misc.maxReletiveError);
-        int useDeltaLat = (int) Math.round(dY / Misc.maxReletiveError);
+        int useLad = (int) Math.round(lad / Misc.defaultMaxRelativeDiffFloat);
+        int useLov = (int) Math.round(lov / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLon = (int) Math.round(dX / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) Math.round(dY / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;
@@ -1063,15 +1063,15 @@ Template 3.30 (Grid definition template 3.30 - Lambert conformal)
 
       LambertConformal that = (LambertConformal) o;
 
-      if (!Misc.closeEnoughAbs(la1, that.la1, maxReletiveErrorPos * dY))
+      if (!Misc.nearlyEqualsAbs(la1, that.la1, maxReletiveErrorPos * dY))
         return false;   // allow some slop, reletive to grid size
-      if (!Misc.closeEnoughAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
-      if (!Misc.closeEnough(lad, that.lad)) return false;
-      if (!Misc.closeEnough(lov, that.lov)) return false;
-      if (!Misc.closeEnough(dY, that.dY)) return false;
-      if (!Misc.closeEnough(dX, that.dX)) return false;
-      if (!Misc.closeEnough(latin1, that.latin1)) return false;
-      if (!Misc.closeEnough(latin2, that.latin2)) return false;
+      if (!Misc.nearlyEqualsAbs(lo1, that.lo1, maxReletiveErrorPos * dX)) return false;
+      if (!Misc.nearlyEquals(lad, that.lad)) return false;
+      if (!Misc.nearlyEquals(lov, that.lov)) return false;
+      if (!Misc.nearlyEquals(dY, that.dY)) return false;
+      if (!Misc.nearlyEquals(dX, that.dX)) return false;
+      if (!Misc.nearlyEquals(latin1, that.latin1)) return false;
+      if (!Misc.nearlyEquals(latin2, that.latin2)) return false;
 
       return true;
     }
@@ -1081,12 +1081,12 @@ Template 3.30 (Grid definition template 3.30 - Lambert conformal)
       if (hashCode == 0) {
         int useLat = (int) Math.round(la1 / (maxReletiveErrorPos * dY));  //  Two equal objects must have the same hashCode() value
         int useLon = (int) Math.round(lo1 / (maxReletiveErrorPos * dX));
-        int useLad = (int) Math.round(lad / Misc.maxReletiveError);
-        int useLov = (int) Math.round(lov / Misc.maxReletiveError);
-        int useDeltaLon = (int) Math.round(dX / Misc.maxReletiveError);
-        int useDeltaLat = (int) Math.round(dY / Misc.maxReletiveError);
-        int useLatin1 = (int) Math.round(latin1 / Misc.maxReletiveError);
-        int useLatin2 = (int) Math.round(latin2 / Misc.maxReletiveError);
+        int useLad = (int) Math.round(lad / Misc.defaultMaxRelativeDiffFloat);
+        int useLov = (int) Math.round(lov / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLon = (int) Math.round(dX / Misc.defaultMaxRelativeDiffFloat);
+        int useDeltaLat = (int) Math.round(dY / Misc.defaultMaxRelativeDiffFloat);
+        int useLatin1 = (int) Math.round(latin1 / Misc.defaultMaxRelativeDiffFloat);
+        int useLatin2 = (int) Math.round(latin2 / Misc.defaultMaxRelativeDiffFloat);
 
         int result = super.hashCode();
         result = 31 * result + useLat;

--- a/it/src/test/java/thredds/server/cdmr/TestCdmRemoteServer.java
+++ b/it/src/test/java/thredds/server/cdmr/TestCdmRemoteServer.java
@@ -95,7 +95,7 @@ public class TestCdmRemoteServer {
       Assert.assertNotNull("time axis", time);
       double[] expect = new double[]{0., 6.0, 12.0, 18.0};
       double[] have = (double []) time.getCoordsAsArray().get1DJavaArray(DataType.DOUBLE);
-      Assert.assertArrayEquals(expect, have, Misc.maxReletiveError);
+      Assert.assertArrayEquals(expect, have, Misc.defaultMaxRelativeDiffDouble);
     }
   }
 }

--- a/it/src/test/java/thredds/server/cdmr/TestCdmRemoteServer2.java
+++ b/it/src/test/java/thredds/server/cdmr/TestCdmRemoteServer2.java
@@ -96,7 +96,7 @@ public class TestCdmRemoteServer2 {
       double[] expect = new double[]{366.0, 1096.485, 1826.97, 2557.455, 3287.94, 4018.425, 4748.91, 5479.395, 6209.88, 6940.365, 7670.85, 8401.335};
       Array data = time.getCoordsAsArray();
       for (int i = 0; i < expect.length; i++)
-        assert Misc.closeEnough(expect[i], data.getDouble(i));
+        assert Misc.nearlyEquals(expect[i], data.getDouble(i));
 
     }
   }

--- a/it/src/test/java/thredds/server/cdmrf/TestGridCoverageRemoteP.java
+++ b/it/src/test/java/thredds/server/cdmrf/TestGridCoverageRemoteP.java
@@ -186,7 +186,7 @@ public class TestGridCoverageRemoteP {
 
           } else {
             double val2 = timeOffsetAxis.getCoordMidpoint(0);
-            Assert.assertEquals(val2, time_offset, Misc.maxReletiveError);
+            Assert.assertTrue(Misc.nearlyEquals(val2, time_offset));
           }
         }
       }
@@ -196,7 +196,7 @@ public class TestGridCoverageRemoteP {
         Assert.assertNotNull(AxisType.Pressure.toString(), zAxis);
         Assert.assertEquals(1, zAxis.getNcoords());
         double val = zAxis.getCoordMidpoint(0);
-        Assert.assertEquals(vert_level.doubleValue(), val, Misc.maxReletiveError);
+        Assert.assertTrue(Misc.nearlyEquals(vert_level.doubleValue(), val));
       }
     }
 

--- a/it/src/test/java/thredds/server/dap4/TestDap4.java
+++ b/it/src/test/java/thredds/server/dap4/TestDap4.java
@@ -2,7 +2,6 @@
 package thredds.server.dap4;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -59,7 +58,7 @@ public class TestDap4 {
       Assert.assertNotNull("time axis", time);
       double[] expect = new double[]{0., 6.0, 12.0, 18.0};
       double[] have = time.getCoordValues();
-      Assert.assertArrayEquals(expect, have, Misc.maxReletiveError);
+      Assert.assertArrayEquals(expect, have, Misc.defaultMaxRelativeDiffDouble);
     }
   }
 }

--- a/it/src/test/java/thredds/server/fileserver/TestHTTP.java
+++ b/it/src/test/java/thredds/server/fileserver/TestHTTP.java
@@ -107,14 +107,14 @@ public class TestHTTP  {
     assert( null != att);
     assert( !att.isArray());
     assert( 1 == att.getLength());
-    assert( 1.2 == att.getNumericValue().doubleValue());
+    assert( Misc.nearlyEquals(1.2f, att.getNumericValue().floatValue()));
 
     att = temp.findAttribute("versionF");
     assert( null != att);
     assert( !att.isArray());
     assert( 1 == att.getLength());
     assert( 1.2f == att.getNumericValue().floatValue());
-    assert( Misc.closeEnough(1.2, att.getNumericValue().doubleValue()));
+    assert( Misc.nearlyEquals(1.2f, att.getNumericValue().floatValue()));
 
     att = temp.findAttribute("versionI");
     assert( null != att);

--- a/it/src/test/java/thredds/server/ncss/TestGridAsPointP.java
+++ b/it/src/test/java/thredds/server/ncss/TestGridAsPointP.java
@@ -157,7 +157,7 @@ public class TestGridAsPointP {
     Assert.assertEquals((int) ntimes, elements.size());
     elem0 = elements.get(0);
     double val = Double.parseDouble(elem0.getContent(0).getValue());
-    Assert.assertEquals(dataVal, val, Misc.maxReletiveError * dataVal);
+    Assert.assertTrue(Misc.nearlyEquals(dataVal, val));
   }
 
   @Test

--- a/it/src/test/java/thredds/server/opendap/TestTdsDodsServer.java
+++ b/it/src/test/java/thredds/server/opendap/TestTdsDodsServer.java
@@ -144,7 +144,7 @@ public class TestTdsDodsServer {
       Assert.assertNotNull("time axis", time);
       Assert.assertEquals(1, time.getSize());
       Array data = time.read();
-      Assert.assertEquals(102840.0, data.getFloat(0), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(102840.0, data.getFloat(0)));
     }
   }
 

--- a/it/src/test/java/thredds/server/wcs/TestWcsServer.java
+++ b/it/src/test/java/thredds/server/wcs/TestWcsServer.java
@@ -159,15 +159,15 @@ public class TestWcsServer {
       HorizCoordSys hcs = csys.getHorizCoordSys();
       CoverageCoordAxis1D xaxis = hcs.getXAxis();
       Assert.assertEquals(291, xaxis.getNcoords());
-      Assert.assertEquals(10.5, xaxis.getCoordMidpoint(0), Misc.maxReletiveError);
-      Assert.assertEquals(300.5, xaxis.getEndValue(), Misc.maxReletiveError); // LOOK is that ok? BB = 10-300: its just catching the edge
-      Assert.assertEquals(1.0, xaxis.getResolution(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(10.5, xaxis.getCoordMidpoint(0)));
+      Assert.assertTrue(Misc.nearlyEquals(300.5, xaxis.getEndValue())); // LOOK is that ok? BB = 10-300: its just catching the edge
+      Assert.assertTrue(Misc.nearlyEquals(1.0, xaxis.getResolution()));
 
       CoverageCoordAxis1D yaxis = hcs.getYAxis();
       Assert.assertEquals(81, yaxis.getNcoords());
-      Assert.assertEquals(79.5, yaxis.getCoordMidpoint(0), Misc.maxReletiveError);
-      Assert.assertEquals(-.5, yaxis.getEndValue(), Misc.maxReletiveError); // LOOK is that ok? BB = 0-80: its just catching the edge
-      Assert.assertEquals(-1.0, yaxis.getResolution(), Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(79.5, yaxis.getCoordMidpoint(0)));
+      Assert.assertTrue(Misc.nearlyEquals(-.5, yaxis.getEndValue())); // LOOK is that ok? BB = 0-80: its just catching the edge
+      Assert.assertTrue(Misc.nearlyEquals(-1.0, yaxis.getResolution()));
     }
   }
 
@@ -236,7 +236,7 @@ public class TestWcsServer {
       Assert.assertEquals(1, vert.getNcoords());
       double vertCoord = vert.getCoordMidpoint(0);
       logger.debug("date = {}", date);
-      Assert.assertEquals(800.0, vertCoord, Misc.maxReletiveError);
+      Assert.assertTrue(Misc.nearlyEquals(800.0, vertCoord));
     }
   }
 

--- a/it/src/test/java/thredds/tds/TestTdsNcml.java
+++ b/it/src/test/java/thredds/tds/TestTdsNcml.java
@@ -158,7 +158,7 @@ public class TestTdsNcml {
     logger.debug(NCdumpW.toString(data, "time", null));
 
     while (data.hasNext()) {
-      assert Misc.closeEnough(data.nextInt(), (count + 1) * 3);
+      assert Misc.nearlyEquals(data.nextInt(), (count + 1) * 3);
       count++;
     }
 

--- a/it/src/test/java/thredds/tds/TestWaveModel.java
+++ b/it/src/test/java/thredds/tds/TestWaveModel.java
@@ -121,7 +121,7 @@ public class TestWaveModel {
       double[] expect = new double[]{21., 45.};
       Array data = time.getCoordsAsArray();
       for (int i = 0; i < expect.length; i++)
-        assert Misc.closeEnough(expect[i], data.getDouble(i));
+        assert Misc.nearlyEquals(expect[i], data.getDouble(i));
 
       CoverageCoordAxis runtime = gcs.getAxis(AxisType.RunTime);
       Assert.assertNotNull("runtime axis", runtime);
@@ -130,7 +130,7 @@ public class TestWaveModel {
       expect = new double[]{0, 24};
       data = runtime.getCoordsAsArray();
       for (int i = 0; i < expect.length; i++)
-        assert Misc.closeEnough(expect[i], data.getDouble(i));
+        assert Misc.nearlyEquals(expect[i], data.getDouble(i));
     }
   }
 

--- a/it/src/test/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
+++ b/it/src/test/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
@@ -159,7 +159,7 @@ public class TestGridSubsetThredds {
 
       ProjectionRect pr = gcs2.getProjection().getDefaultMapArea();
       logger.debug("projection mapArea = {}", pr);
-      assert (pr.closeEnough(gcs2.getBoundingBox()));
+      assert (pr.nearlyEquals(gcs2.getBoundingBox()));
     }
   }
 
@@ -189,7 +189,7 @@ public class TestGridSubsetThredds {
 
       ProjectionRect pr = gcs2.getProjection().getDefaultMapArea();
       logger.debug("projection mapArea = {}", pr);
-      assert (pr.closeEnough(gcs2.getBoundingBox()));
+      assert (pr.nearlyEquals(gcs2.getBoundingBox()));
     }
   }
 

--- a/opendap/src/test/java/ucar/nc2/dods/TestDODSSubset.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestDODSSubset.java
@@ -98,7 +98,7 @@ public class TestDODSSubset {
 
     for (int i=0; i<5; i++) {
       double val = ad.get(i);
-      assert Misc.closeEnough(val, tFloat64[i], 1.0e-9);
+      assert Misc.nearlyEquals(val, tFloat64[i], 1.0e-9);
     }
 
     dodsfile.close();

--- a/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
@@ -83,6 +83,8 @@
         </div>
 
         <div id="pointSubset" class="tabPane sidebarInput" th:fragment="pointSubset">
+          <h5>Nearest to location (in decimal degrees)</h5>
+
           <div class="verticalInputBoxesGrid vibg_2boxes">
             <label class="vibg_label1" for="latitude">Latitude:</label>
             <input class="vibg_box1" type="text" name="latitude" id="latitude" size="10" required/>

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridCoverageSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridCoverageSubsettingTest.java
@@ -199,7 +199,7 @@ public class GridCoverageSubsettingTest {
 
       System.out.printf("Expected ProjectionRect=%s%n", expect.rect.toString2(6));
       System.out.printf("Actual ProjectionRect=%s%n", prect.toString2(6));
-      assertTrue(expect.rect.closeEnough(prect));
+      assertTrue(expect.rect.nearlyEquals(prect));
     }
 
     //ucar.nc2.dt.grid.GridDataset gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));

--- a/ui/src/main/java/ucar/nc2/ui/grib/Grib2DataPanel.java
+++ b/ui/src/main/java/ucar/nc2/ui/grib/Grib2DataPanel.java
@@ -1036,7 +1036,7 @@ public class Grib2DataPanel extends JPanel {
       Formatter f= new Formatter();
       if (minScale == Double.MAX_VALUE)
         f.format("N/A");
-      if (Misc.closeEnough(minScale, maxScale))
+      if (Misc.nearlyEquals(minScale, maxScale))
         f.format("%g",minScale);
       else
         f.format("(%g,%g)",minScale,maxScale);

--- a/ui/src/test/java/ucar/util/prefs/TestJavaUtilPreferences.java
+++ b/ui/src/test/java/ucar/util/prefs/TestJavaUtilPreferences.java
@@ -68,11 +68,11 @@ public class TestJavaUtilPreferences {
 
       userRoot.putDouble("testD", 3.14157);
       double d = userRoot.getDouble("testD", 0.0);
-      assert Misc.closeEnough(d, 3.14157) : "double failed";
+      assert Misc.nearlyEquals(d, 3.14157) : "double failed";
 
       userRoot.putFloat("testF", 1.23456F);
       float f = userRoot.getFloat("testF", 0.0F);
-      assert Misc.closeEnough(f, 1.23456F) : "float failed";
+      assert Misc.nearlyEquals(f, 1.23456F) : "float failed";
 
       userRoot.putLong("testL", 12345678900L);
       long ll = userRoot.getLong("testL", 0);
@@ -120,7 +120,7 @@ public class TestJavaUtilPreferences {
       }
 
       float f = subNode.getFloat("testF", 0.0F);
-      assert Misc.closeEnough(f, 1.23456F) : "float failed";
+      assert Misc.nearlyEquals(f, 1.23456F) : "float failed";
 
       long ll = subNode.getLong("testL", 0);
       assert ll == 12345678900L : "long failed";

--- a/ui/src/test/java/ucar/util/prefs/TestXMLStore.java
+++ b/ui/src/test/java/ucar/util/prefs/TestXMLStore.java
@@ -100,10 +100,10 @@ public class TestXMLStore {
     PreferencesExt prefs = store.getPreferences();
 
     double d = prefs.getDouble("testD", 0.0);
-    assert Misc.closeEnough(d, 3.14157) : "double failed " + d;
+    assert Misc.nearlyEquals(d, 3.14157) : "double failed " + d;
 
     float f = prefs.getFloat("testF", 0.0F);
-    assert Misc.closeEnough(f, 1.23456F) : "float failed";
+    assert Misc.nearlyEquals(f, 1.23456F) : "float failed";
 
     long ll = prefs.getLong("testL", 0);
     assert ll == 12345678900L : "long failed";
@@ -133,10 +133,10 @@ public class TestXMLStore {
     Preferences prefs = store.getPreferences().node("SemperUbi");
 
     double d = prefs.getDouble("testD", 0.0);
-    assert Misc.closeEnough(d, 3.14158) : "double failed";
+    assert Misc.nearlyEquals(d, 3.14158) : "double failed";
 
     float f = prefs.getFloat("testF", 0.0F);
-    assert Misc.closeEnough(f, 1.23457F) : "float failed";
+    assert Misc.nearlyEquals(f, 1.23457F) : "float failed";
 
     long ll = prefs.getLong("testL", 0);
     assert ll == 12345678901L : "long failed";

--- a/ui/src/test/java/ucar/util/prefs/TestXMLStoreChains.java
+++ b/ui/src/test/java/ucar/util/prefs/TestXMLStoreChains.java
@@ -106,7 +106,7 @@ public class TestXMLStoreChains {
       assert ival == 2 : "testChain fail 1 " + ival;
 
       double dval  = node.getDouble("TestDouble", 0.0);
-      assert Misc.closeEnough(dval, 3.14159) : "testChain fail 2 " + dval;
+      assert Misc.nearlyEquals(dval, 3.14159) : "testChain fail 2 " + dval;
 
       node.putDouble("TestDouble", 3.14159);
       node.putDouble("TestFloat", -999.0);
@@ -119,7 +119,7 @@ public class TestXMLStoreChains {
       prefs = store.getPreferences();
       node = prefs.node("/myApp");
       dval  = node.getDouble("TestDouble", 0.0);
-      assert Misc.closeEnough(dval, 0.0) : "testChain fail 2 " + dval;
+      assert Misc.nearlyEquals(dval, 0.0) : "testChain fail 2 " + dval;
 
       // but not if they are in the default
       store = XMLStore.createFromFile(storeFile, null);
@@ -218,10 +218,10 @@ public class TestXMLStoreChains {
 
     node = prefs.node("/myApp");
     double dval  = node.getDouble("TestDouble", 0.0);
-    assert Misc.closeEnough(dval, 3.14159) : "testStandardChain fail 6 " + dval;
+    assert Misc.nearlyEquals(dval, 3.14159) : "testStandardChain fail 6 " + dval;
 
     float fval  = node.getFloat("TestFloat", 0.0F);
-    assert Misc.closeEnough(fval, -999.0F) : "testStandardChain fail 7 " + fval;
+    assert Misc.nearlyEquals(fval, -999.0F) : "testStandardChain fail 7 " + fval;
 
   }
 

--- a/visad/src/main/java/ucar/nc2/iosp/grid/GridDefRecord.java
+++ b/visad/src/main/java/ucar/nc2/iosp/grid/GridDefRecord.java
@@ -577,7 +577,7 @@ public abstract class GridDefRecord {
   }
 
   /**
-   * Compare GridDefRecords, the numerics will use closeEnough so values that
+   * Compare GridDefRecords, the numerics will use nearlyEquals so values that
    * differ in 3 or 4th decimal places will return equal. This is being coded
    * because the NDFD model dx differ in the 3 decimal place otherwise equal.
    */
@@ -599,7 +599,7 @@ public abstract class GridDefRecord {
         //double
         double d = local.getDouble( key );
         double od = other.getDouble( key );
-        if( ! Misc.closeEnough(d, od) )
+        if( ! Misc.nearlyEquals(d, od) )
           return false;
       } else if( val.matches( "^[0-9]+")) {
         // int

--- a/visad/src/main/java/ucar/nc2/iosp/grid/GridVertCoord.java
+++ b/visad/src/main/java/ucar/nc2/iosp/grid/GridVertCoord.java
@@ -503,7 +503,7 @@ public class GridVertCoord implements Comparable<GridVertCoord> {
      */
     public int compareTo(Object o) {
       LevelCoord other = (LevelCoord) o;
-      // if (closeEnough(value1, other.value1) && closeEnough(value2, other.value2)) return 0;
+      // if (nearlyEquals(value1, other.value1) && nearlyEquals(value2, other.value2)) return 0;
       if (mid < other.mid) {
         return -1;
       }
@@ -527,8 +527,8 @@ public class GridVertCoord implements Comparable<GridVertCoord> {
         return false;
       }
       LevelCoord other = (LevelCoord) oo;
-      return (ucar.nc2.util.Misc.closeEnough(value1, other.value1)
-          && ucar.nc2.util.Misc.closeEnough(value2, other.value2));
+      return (ucar.nc2.util.Misc.nearlyEquals(value1, other.value1)
+          && ucar.nc2.util.Misc.nearlyEquals(value2, other.value2));
     }
 
     /**
@@ -558,11 +558,11 @@ public class GridVertCoord implements Comparable<GridVertCoord> {
     for (int i = 0; i < levels.size(); i++) {
       LevelCoord lc = (LevelCoord) levels.get(i);
       if (usesBounds) {
-        if (ucar.nc2.util.Misc.closeEnough(lc.value1, val) && ucar.nc2.util.Misc.closeEnough(lc.value2, val2)) {
+        if (ucar.nc2.util.Misc.nearlyEquals(lc.value1, val) && ucar.nc2.util.Misc.nearlyEquals(lc.value2, val2)) {
           return i;
         }
       } else {
-        if (ucar.nc2.util.Misc.closeEnough(lc.value1, val)) {
+        if (ucar.nc2.util.Misc.nearlyEquals(lc.value1, val)) {
           return i;
         }
       }

--- a/waterml/src/main/java/ucar/nc2/ogc/erddap/util/ErddapEDUnits.java
+++ b/waterml/src/main/java/ucar/nc2/ogc/erddap/util/ErddapEDUnits.java
@@ -4,7 +4,7 @@
  */
 package ucar.nc2.ogc.erddap.util;
 
-import com.google.common.math.DoubleMath;
+import ucar.nc2.util.Misc;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -98,7 +98,7 @@ public class ErddapEDUnits {
 
                 //use 'factor', since it is more forgiving than udunitsToUcum converter
                 String u;
-                if (DoubleMath.fuzzyEquals(baf[1], 0.001, 1e-6)) {  // Can't simply do "baf[1] == 0.001".
+                if (Misc.nearlyEquals(baf[1], 0.001, 1e-6)) {  // Can't simply do "baf[1] == 0.001".
                     u = "ms";
                 } else if (baf[1] == 1) {
                     u = "s";


### PR DESCRIPTION
We have a lot of duplicate code for comparing floating-point numbers, some of it bad. In this commit, I've tried to nuke dupes and concentrate the "core" comparison code into the `ucar.nc2.util.Misc` class. All other comparison code builds off of what's in `Misc`.

Notes:
* The centerpiece is the `Misc.nearlyEquals()` family of methods, formerly named `Misc.closeEnough()`. The previous implementation was actually pretty good, but I've improved it slightly for certain edge cases. See http://floating-point-gui.de/errors/comparison/.
* I've settled on the name "nearlyEquals" for any method that compares floats. Previously we had several different names for these, including "closeEnough", "fuzzyEquals", and "equals".
* Added/updated various ancillary methods/fields in `Misc` for comparing floats. They're used occasionally in our test suite.
* The new comparison code caused a handful of tests to break, usually because the default epsilon was too small for the level of precision that the tests were operating at. I believe I've fixed all of those.
* Added `nearlyEquals()` methods to `LatLonPoint`, `ProjectionPoint`, `LatLonRect`, and `ProjectionRect`. My need for these methods is what caused me to go off on this big refactoring tangent in the first place!
* For those `LatLon*` and `Projection*` classes, I made sure that each also has an `equals()` method that performs exact floating point comparison, which is required for consistency with `hashCode()`.
* Refactored `LatLonPointImmutable` to extend `LatLonPointImpl` (so that it can inherit useful methods), while remaining immutable.

This PR also includes some unrelated tweaks to NCSS, because I was working on NCSS before the floating-point stuff.
* In NCSS, add a label to the lat/lon point subset pane.
* Rewrite `CoverageCoordSys.makeCoorSysName()` to eliminate extraneous whitespace.
* Nuke `CoverageCollection.getRuntimeCoordinateMax()`, which NCSS no longer needs.

I tested these commits on Jenkins. [Here](https://jenkins-aws.unidata.ucar.edu/job/cwardgar/12/testReport/) is the results. Pretty clean. I cannot account for the `TestGribUnits` failures; they don't appear to be related to the `nearlyEquals()` changes.