### PR TITLE
 Calculate correct boundaries for coverages that cross longitude seam

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageCurvilinear.java
@@ -83,7 +83,7 @@ public class TestCoverageCurvilinear {
 
       HorizCoordSys hcs = gds.getHorizCoordSys();
       Assert.assertNotNull(endpoint, hcs);
-      Assert.assertTrue(endpoint, !hcs.getIsProjection());
+      Assert.assertTrue(endpoint, !hcs.isProjection());
       Assert.assertNull(endpoint, hcs.getTransform());
 
       String covName = "Mixed_layer_depth_surface";
@@ -111,7 +111,7 @@ public class TestCoverageCurvilinear {
 
       HorizCoordSys hcs = gds.getHorizCoordSys();
       Assert.assertNotNull(endpoint, hcs);
-      Assert.assertTrue(endpoint, !hcs.getIsProjection());
+      Assert.assertTrue(endpoint, !hcs.isProjection());
       Assert.assertNull(endpoint, hcs.getTransform());
 
       String covName = "Mixed_layer_depth_surface";

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizStride.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizStride.java
@@ -81,7 +81,7 @@ public class TestCoverageHorizStride {
 
       HorizCoordSys hcs = gds.getHorizCoordSys();
       Assert.assertNotNull(endpoint, hcs);
-      Assert.assertTrue(endpoint, !hcs.getIsProjection());
+      Assert.assertTrue(endpoint, !hcs.isProjection());
       Assert.assertNull(endpoint, hcs.getTransform());
 
       String covName = "Mixed_layer_depth_surface";

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
@@ -107,27 +107,19 @@ public class CoverageCollection implements Closeable, CoordSysContainer {
     this.hcs = wireHorizCoordSys();
     this.reader = reader;
 
-    if (hcs.getIsProjection()) {
+    if (hcs.isProjection()) {
       if (projBoundingBox != null)
         this.projBoundingBox = projBoundingBox;
       else
-        this.projBoundingBox = hcs.makeProjectionBB();
-      this.latLonBoundingBox = hcs.makeLatlonBB(this.projBoundingBox);
-
+        this.projBoundingBox = hcs.calcProjectionBoundingBox();
     } else {
-      if (latLonBoundingBox != null)
-        this.latLonBoundingBox = latLonBoundingBox;
-      else
-        this.latLonBoundingBox = hcs.makeLatlonBB(null);
-
-      // ?? not sure if this is needed
-      if (this.latLonBoundingBox != null)
-        this.projBoundingBox = new ProjectionRect(
-              new ProjectionPointImpl(this.latLonBoundingBox.getLonMin(), this.latLonBoundingBox.getLatMin()),
-              this.latLonBoundingBox.getWidth(), this.latLonBoundingBox.getHeight());
-      else
-        this.projBoundingBox = null;
+      this.projBoundingBox = null;
     }
+
+    if (latLonBoundingBox != null)
+      this.latLonBoundingBox = latLonBoundingBox;
+    else
+      this.latLonBoundingBox = hcs.calcLatLonBoundingBox();
   }
 
   private List<CoordSysSet> wireObjectsTogether(List<Coverage> coverages) {

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
@@ -220,6 +220,10 @@ public class CoverageCoordAxis1D extends CoverageCoordAxis { // implements Itera
     throw new IllegalStateException("Unknown spacing=" + spacing);
   }
 
+  public double getCoordEdgeFirst() {
+    return getCoordEdge1(0);
+  }
+
   public double getCoordEdgeLast() {
     return getCoordEdge2(ncoords - 1);
   }

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageAdapter.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageAdapter.java
@@ -229,6 +229,9 @@ public class DtCoverageAdapter implements CoverageReader, CoordAxisReader {
     // 1D case
     if (dtCoordAxis instanceof CoordinateAxis1D) {
       CoordinateAxis1D axis1D = (CoordinateAxis1D) dtCoordAxis;
+      // Fix discontinuities in longitude axis. These occur when the axis crosses the date line.
+      axis1D.correctLongitudeWrap();
+
       startValue = axis1D.getCoordValue(0);
       endValue = axis1D.getCoordValue((int) dtCoordAxis.getSize() - 1);
 

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageBoundariesExtractor.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageBoundariesExtractor.java
@@ -34,23 +34,18 @@
 package ucar.nc2.ft2.coverage.writer;
 
 import ucar.nc2.ft2.coverage.*;
-import ucar.unidata.geoloc.LatLonPoint;
-import ucar.unidata.geoloc.LatLonPointImpl;
-import ucar.unidata.geoloc.LatLonRect;
-import ucar.unidata.geoloc.ProjectionImpl;
+import ucar.unidata.geoloc.LatLonPointNoNormalize;
 
-import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 
 /**
- * Describe
+ * Provides methods for extracting the coverage boundaries in standard GIS text formats: WKT & GeoJSON.
  *
  * @author caron
  * @since 10/7/2015.
  */
 public class CoverageBoundariesExtractor {
-
   /**
    * Takes a CoverageCollection and returns the boundary as a polygon in WKT,
    * used in OpenLayers widget in NCSS
@@ -72,20 +67,8 @@ public class CoverageBoundariesExtractor {
     this.gridDataset = gridDataset;
   }
 
-  // public for testing
-  public List<LatLonPoint> getBoundaryPoints() {
-    List<LatLonPoint> latlons;
-    HorizCoordSys hcs = gridDataset.getHorizCoordSys();
-    if (hcs.getIsProjection()) {
-      latlons = getLatLonsFromProjection(hcs);
-    } else {
-      latlons = hcs.isLatLon2D() ? getLatLons2D((HorizCoordSys2D) hcs) : getLatLons1D(hcs);
-    }
-    return latlons;
-  }
-
   public String getBoundaryAsWKT() {
-    List<LatLonPoint> latlons = getBoundaryPoints();
+    List<LatLonPointNoNormalize> latlons = gridDataset.getHorizCoordSys().calcConnectedLatLonBoundaryPoints(50, 100);
 
     //Build string from lists
     //Crosses dateLine?
@@ -108,140 +91,6 @@ public class CoverageBoundariesExtractor {
 
     result.format("))");
     return result.toString();
-  }
-
-  private List<LatLonPoint> getLatLonsFromProjection(HorizCoordSys hcs) {
-    List<LatLonPoint> latLonPoints = new ArrayList<>();
-
-    ProjectionImpl fromProj = hcs.getTransform().getProjection();
-
-    CoverageCoordAxis1D xAxis = hcs.getXAxis();
-    CoverageCoordAxis1D yAxis = hcs.getYAxis();
-    int nx = xAxis.getNcoords();
-    int ny = yAxis.getNcoords();
-    int stridex = Math.max(1, nx / 100); // dont need more than 100 points
-    int stridey = Math.max(1, ny / 100); // dont need more than 100 points
-
-    double y0 = yAxis.getCoordEdge1(0);
-    LatLonPoint prev = fromProj.projToLatLon(xAxis.getCoordEdge1(0), y0);
-    latLonPoints.add(prev);
-
-    // Bottom edge y=0
-    for (int i = 0; i < nx; i+=stridex) {
-      LatLonPoint point = fromProj.projToLatLon(xAxis.getCoordEdge2(i), y0);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Right edge x= nx-1
-    double xlast = xAxis.getCoordEdgeLast();
-    for (int j = 0; j < ny; j+=stridey) {
-      LatLonPoint point = fromProj.projToLatLon(xlast, yAxis.getCoordEdge2(j));
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Top edge y = ny-1
-    double ylast = yAxis.getCoordEdgeLast();
-    for (int i = nx - 1; i >= 0; i-=stridex) {
-      LatLonPoint point = fromProj.projToLatLon(xAxis.getCoordEdge1(i), ylast);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Left edge x = 0
-    double x0 = xAxis.getCoordEdge1(0);
-    for (int j = ny - 1; j >= 0; j-=stridey) {
-      LatLonPoint point = fromProj.projToLatLon(x0, yAxis.getCoordEdge1(j));
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    return latLonPoints;
-  }
-
-  private void check(LatLonPoint prev, LatLonPoint point) {
-    if (point.getLongitude() < minLon) minLon = point.getLongitude();
-    if (point.getLongitude() > maxLon) maxLon = point.getLongitude();
-
-    if (Math.abs(prev.getLongitude() - point.getLongitude()) > maxDiffLon)
-      maxDiffLon = Math.abs(prev.getLongitude() - point.getLongitude());
-  }
-
-  private List<LatLonPoint> getLatLons1D(HorizCoordSys hcs) {
-    LatLonRect latLonBB = hcs.makeLatlonBB(null);
-
-    List<LatLonPoint> latLonPoints = new ArrayList<>();
-    latLonPoints.add(latLonBB.getLowerLeftPoint());
-    latLonPoints.add(latLonBB.getLowerRightPoint());
-    latLonPoints.add(latLonBB.getUpperRightPoint());
-    latLonPoints.add(latLonBB.getUpperLeftPoint());
-
-    return latLonPoints;
-  }
-
-  private List<LatLonPoint> getLatLons2D(HorizCoordSys2D hcs) {
-    List<LatLonPoint> latLonPoints = new ArrayList<>();
-
-    LatLonAxis2D latAxis = hcs.getLatAxis2D();
-    LatLonAxis2D lonAxis = hcs.getLonAxis2D();
-    int[] shape = latAxis.getShape(); // same for both
-
-    int ny = shape[0];
-    int nx = shape[1];
-    int stridex = Math.max(1, nx / 100); // dont need more than 100 points
-    int stridey = Math.max(1, ny / 100); // dont need more than 100 points
-
-    double y0 = latAxis.getCoord(0, 0);
-    double x0 = lonAxis.getCoord(0, 0);
-    LatLonPointImpl prev = new LatLonPointImpl(y0, x0);
-    latLonPoints.add( prev);
-
-    // Bottom edge y=0
-    for (int i = 0; i < nx; i+=stridex) {
-      double y = latAxis.getCoord(0, i);
-      double x = lonAxis.getCoord(0, i);
-      LatLonPointImpl point = new LatLonPointImpl(y, x);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Right edge x= nx-1
-    for (int j = 0; j < ny; j+=stridey) {
-      double y = latAxis.getCoord(j, nx-1);
-      double x = lonAxis.getCoord(j, nx-1);
-      LatLonPointImpl point = new LatLonPointImpl(y, x);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Top edge y = ny-1
-    for (int i = nx - 1; i >= 0; i-=stridex) {
-      double y = latAxis.getCoord(ny-1, i);
-      double x = lonAxis.getCoord(ny-1, i);
-      LatLonPointImpl point = new LatLonPointImpl(y, x);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    // Left edge x = 0
-    for (int j = ny - 1; j >= 0; j-=stridey) {
-      double y = latAxis.getCoord(j, 0);
-      double x = lonAxis.getCoord(j, 0);
-      LatLonPointImpl point = new LatLonPointImpl(y, x);
-      check(prev, point);
-      latLonPoints.add(point);
-      prev = point;
-    }
-
-    return latLonPoints;
   }
 
   /*

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPoint.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPoint.java
@@ -61,17 +61,17 @@ public interface LatLonPoint {
   /**
    * Returns the result of {@link #nearlyEquals(LatLonPoint, double)}, with {@link Misc#defaultMaxRelativeDiffDouble}.
    */
-  default boolean nearlyEquals(LatLonPoint other) {
-    return nearlyEquals(other, Misc.defaultMaxRelativeDiffDouble);
+  default boolean nearlyEquals(LatLonPoint that) {
+    return nearlyEquals(that, Misc.defaultMaxRelativeDiffDouble);
   }
 
   /**
-   * Returns {@code true} if this point is nearly equal to {@code other}. The "near equality" of points is determined
+   * Returns {@code true} if this point is nearly equal to {@code that}. The "near equality" of points is determined
    * using {@link Misc#nearlyEquals(double, double, double)}, with the specified maxRelDiff.
    *
-   * @param other    the other point to check.
+   * @param that    the other point to check.
    * @param maxRelDiff  the maximum {@link Misc#relativeDifference relative difference} the two points may have.
-   * @return {@code true} if this point is nearly equal to {@code other}.
+   * @return {@code true} if this point is nearly equal to {@code that}.
    */
-  boolean nearlyEquals(LatLonPoint other, double maxRelDiff);
+  boolean nearlyEquals(LatLonPoint that, double maxRelDiff);
 }

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImmutable.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImmutable.java
@@ -34,7 +34,7 @@
 package ucar.unidata.geoloc;
 
 /**
- * An immutable LatLonPoint
+ * An immutable {@link LatLonPoint}.
  *
  * @author caron
  * @since 7/29/2014
@@ -44,8 +44,8 @@ public class LatLonPointImmutable extends LatLonPointImpl {
           Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
   public LatLonPointImmutable(double lat, double lon) {
-    this.lat = lat;
-    this.lon = lon;
+    this.lat = latNormal(lat);
+    this.lon = lonNormal(lon);
   }
 
   public LatLonPointImmutable(LatLonPoint pt) {

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImpl.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImpl.java
@@ -311,8 +311,14 @@ public class LatLonPointImpl implements LatLonPoint, java.io.Serializable {
 
   @Override
   public boolean nearlyEquals(LatLonPoint that, double maxRelDiff) {
-    return Misc.nearlyEquals(that.getLatitude(),  this.lat, maxRelDiff) &&
-           Misc.nearlyEquals(that.getLongitude(), this.lon, maxRelDiff);
+    boolean lonOk = Misc.nearlyEquals(that.getLongitude(), this.lon, maxRelDiff);
+    if (!lonOk) {
+      // We may be in a situation where "this.lon ≈ -180" and "that.lon ≈ +180", or vice versa.
+      // Those longitudes are equivalent, but not "nearlyEquals()". So, we normalize them both to lie in
+      // [0, 360] and compare them again.
+      lonOk = Misc.nearlyEquals(lonNormal360(that.getLongitude()), lonNormal360(this.lon), maxRelDiff);
+    }
+    return lonOk && Misc.nearlyEquals(that.getLatitude(), this.lat, maxRelDiff);
   }
 
   // Exact comparison is needed in order to be consistent with hashCode().

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImpl.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointImpl.java
@@ -310,12 +310,9 @@ public class LatLonPointImpl implements LatLonPoint, java.io.Serializable {
   }
 
   @Override
-  public boolean nearlyEquals(LatLonPoint other, double maxRelDiff) {
-    boolean lonOk = Misc.nearlyEquals(other.getLongitude(), this.lon, maxRelDiff);
-    if (!lonOk) {
-      lonOk = Misc.nearlyEquals(lonNormal360(other.getLongitude()), lonNormal360(this.lon), maxRelDiff);
-    }
-    return lonOk && Misc.nearlyEquals(other.getLatitude(), this.lat, maxRelDiff);
+  public boolean nearlyEquals(LatLonPoint that, double maxRelDiff) {
+    return Misc.nearlyEquals(that.getLatitude(),  this.lat, maxRelDiff) &&
+           Misc.nearlyEquals(that.getLongitude(), this.lon, maxRelDiff);
   }
 
   // Exact comparison is needed in order to be consistent with hashCode().

--- a/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointNoNormalize.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/LatLonPointNoNormalize.java
@@ -1,0 +1,85 @@
+package ucar.unidata.geoloc;
+
+import ucar.nc2.util.Misc;
+
+import java.util.Objects;
+
+/**
+ * Similar to {@link LatLonPoint}, but this class does not normalize its latitude and longitude, even for comparison.
+ * That is, latitudes may lie outside of [-90, 90] and longitudes may lie outside of [-180, 180].
+ *
+ * @author cwardgar
+ * @since 2018-03-08
+ */
+public class LatLonPointNoNormalize {
+    /** East latitude in degrees, not necessarily in [-90, 90]. */
+    private final double lat;
+
+    /** North longitude in degrees, not necessarily in [-180, 180]. */
+    private final double lon;
+
+    public LatLonPointNoNormalize(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+
+    /**
+     * Returns the latitude, not necessarily in [-90, 90].
+     *
+     * @return latitude (degrees)
+     */
+    public double getLatitude() {
+        return lat;
+    }
+
+    /**
+     * Returns the longitude, not necessarily in [-180, 180].
+     *
+     * @return longitude (degrees)
+     */
+    public double getLongitude() {
+        return lon;
+    }
+
+    /**
+     * Returns the result of {@link #nearlyEquals(LatLonPointNoNormalize, double)}, with
+     * {@link Misc#defaultMaxRelativeDiffDouble}.
+     */
+    public boolean nearlyEquals(LatLonPointNoNormalize that) {
+        return nearlyEquals(that, Misc.defaultMaxRelativeDiffDouble);
+    }
+
+    /**
+     * Returns {@code true} if this point is nearly equal to {@code that}. The "near equality" of points is determined
+     * using {@link Misc#nearlyEquals(double, double, double)}, with the specified maxRelDiff.
+     *
+     * @param that    the other point to check.
+     * @param maxRelDiff  the maximum {@link Misc#relativeDifference relative difference} the two points may have.
+     * @return {@code true} if this point is nearly equal to {@code that}.
+     */
+    public boolean nearlyEquals(LatLonPointNoNormalize that, double maxRelDiff) {
+        return Misc.nearlyEquals(this.getLatitude(), that.getLatitude(), maxRelDiff) &&
+               Misc.nearlyEquals(this.getLongitude(), that.getLongitude(), maxRelDiff);
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LatLonPointNoNormalize that = (LatLonPointNoNormalize) o;
+
+        return Double.compare(this.getLatitude(),  that.getLatitude())  == 0 &&
+               Double.compare(this.getLongitude(), that.getLongitude()) == 0;
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(lat, lon);
+    }
+
+    @Override public String toString() {
+        return String.format("(%.4f, %.4f)", lat, lon);
+    }
+}

--- a/cdm/src/test/groovy/ucar/nc2/ft2/coverage/HorizCoordSysCrossSeamBoundarySpec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft2/coverage/HorizCoordSysCrossSeamBoundarySpec.groovy
@@ -1,0 +1,271 @@
+package ucar.nc2.ft2.coverage
+
+import spock.lang.Specification
+import ucar.unidata.geoloc.LatLonPointImpl
+import ucar.unidata.geoloc.LatLonPointNoNormalize
+import ucar.unidata.geoloc.LatLonRect
+import ucar.unidata.geoloc.ProjectionPoint
+import ucar.unidata.geoloc.ProjectionPointImpl
+import ucar.unidata.geoloc.ProjectionRect
+
+/**
+ * Asserts that HorizCoordSys calculates correct boundaries for coverages that cross the international date line.
+ * Tests for projection, latLon1D, and latLon2D CRSs are included. The projection and latLon2D datasets are based
+ * on a PolarStereographic_Projection.
+ *
+ * @author cwardgar
+ * @since 2018-02-26
+ */
+class HorizCoordSysCrossSeamBoundarySpec extends Specification {
+    def "calcProjectionBoundaryPoints()"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamProjection.ncml")
+    
+        and: "get actual points"
+        List<ProjectionPoint> actualPoints = horizCoordSys.calcProjectionBoundaryPoints()
+        
+        and: "declare expected points"
+        List<ProjectionPoint> expectedPoints = convertCoordsToPoints(false, [
+                [-2450, -4500], [-2450, -3500], [-2450, -2500], [-2450, -1500],  // Bottom edge
+                [-2450, -500],  [-1550, -500],  [-650, -500],   [250, -500],     // Right edge
+                [1150, -500],   [1150, -1500],  [1150, -2500],  [1150, -3500],   // Top edge
+                [1150, -4500],  [250, -4500],   [-650, -4500],  [-1550, -4500],  // Left edge
+        ])
+        
+        expect: "expected equals actual"
+        expectedPoints == actualPoints
+    }
+    
+    def "calcProjectionBoundaryPoints(2, 2)"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamProjection.ncml")
+    
+        and: "get actual points"
+        // Results in strideY == 2 and strideX == 2.
+        List<ProjectionPoint> actualPoints = horizCoordSys.calcProjectionBoundaryPoints(2, 2)
+    
+        and: "declare expected points"
+        List<ProjectionPoint> expectedPoints = convertCoordsToPoints(false, [
+                [-2450, -4500], [-2450, -2500],  // Bottom edge
+                [-2450, -500],  [-650, -500],    // Right edge
+                [1150, -500],   [1150, -2500],   // Top edge
+                [1150, -4500],  [-650, -4500],   // Left edge
+        ])
+    
+        expect: "expected equals actual"
+        expectedPoints == actualPoints
+    }
+    
+    def "calcConnectedLatLonBoundaryPoints() - lat/lon 1D"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon1D.ncml")
+        
+        and: "get actual points"
+        List<LatLonPointNoNormalize> actualPoints = horizCoordSys.calcConnectedLatLonBoundaryPoints()
+        
+        and: "declare expected points"
+        List<LatLonPointNoNormalize> expectedPoints = convertCoordsToPoints(true, [
+                [0, 130],  [0, 150],  [0, 170],  [0, 190],  [0, 210],   // Bottom edge
+                [0, 230],  [10, 230], [20, 230], [30, 230], [40, 230],  // Right edge
+                [50, 230], [50, 210], [50, 190], [50, 170], [50, 150],  // Top edge
+                [50, 130], [40, 130], [30, 130], [20, 130], [10, 130]   // Left edge
+        ])
+        
+        expect: "expected equals actual"
+        expectedPoints == actualPoints
+    }
+    
+    def "calcConnectedLatLonBoundaryPoints(2, 3) - lat/lon 1D"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon1D.ncml")
+        
+        and: "get actual points"
+        // Results in strideY == 3 and strideX == 2.
+        List<LatLonPointNoNormalize> actualPoints = horizCoordSys.calcConnectedLatLonBoundaryPoints(2, 3)
+        
+        and: "declare expected points"
+        List<LatLonPointNoNormalize> expectedPoints = convertCoordsToPoints(true, [
+                [0, 130],  [0, 170],  [0, 210],   // Bottom edge
+                [0, 230],  [30, 230],             // Right edge
+                [50, 230], [50, 190], [50, 150],  // Top edge
+                [50, 130], [20, 130],             // Left edge
+        ])
+        
+        expect: "expected equals actual"
+        expectedPoints == actualPoints
+    }
+    
+    def "calcConnectedLatLonBoundaryPoints() - projection"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamProjection.ncml")
+        
+        and: "get actual points"
+        List<LatLonPointNoNormalize> actualPoints = horizCoordSys.calcConnectedLatLonBoundaryPoints()
+        
+        and: "declare expected points"
+        List<LatLonPointNoNormalize> expectedPoints = convertCoordsToPoints(true, [
+                [43.3711, -166.4342], [50.4680, -160.0080], [57.1887, -150.5787], [62.8319, -136.4768],  // Bottom edge
+                [66.2450, -116.5346], [74.3993, -122.8787], [82.1083, -142.5686], [84.6159, -221.5651],  // Right edge
+                [77.9578, -261.5014], [71.9333, -232.4762], [63.9355, -219.7024], [55.5660, -213.1890],  // Top edge
+                [47.3219, -209.3354], [48.4777, -198.1798], [48.1430, -186.7808], [46.3647, -175.9940]   // Left edge
+        ])
+        
+        expect: "same number of actualPoints as expectedPoints"
+        actualPoints.size() == expectedPoints.size()
+        
+        and: "corresponding points are nearly equal"
+        for (int i = 0; i < actualPoints.size(); ++i) {
+            assert actualPoints[i].nearlyEquals(expectedPoints[i], 1e-5)
+        }
+    }
+    
+    def "calcConnectedLatLonBoundaryPoints() - lat/lon 2D"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon2D.ncml")
+    
+        and: "get actual points"
+        List<LatLonPointNoNormalize> actualPoints = horizCoordSys.calcConnectedLatLonBoundaryPoints()
+        println actualPoints
+    
+        and: "declare expected points"
+        List<LatLonPointNoNormalize> expectedPoints = convertCoordsToPoints(true, [
+                // Verified by visually inspecting the coverage drawing in ToolsUI.
+                // Note how these boundary points differ from the ones we calculated in the test above, even though
+                // "crossSeamProjection.ncml" and "crossSeamLatLon2D.ncml" represent the same grid. That's because the
+                // edges in "calcConnectedLatLonBoundaryPoints() - projection" were calculated in projection coordinates
+                // and THEN converted to lat/lon. THESE edges, on the other hand, were calculated from 2D lat/lon
+                // midpoints generated from the projection. Taking that path, there's an unavoidable loss of precision.
+                [44.8740, -169.5274], [51.7795, -157.6634], [58.6851, -145.7993], [64.2176, -125.9033],  // Bottom edge
+                [69.7501, -106.0074], [76.0530, -134.4232], [82.3559, -162.8391], [83.7438, -207.9060],  // Right edge
+                [85.1317, -252.9728], [75.7804, -237.0202], [66.4291, -221.0677], [57.3500, -213.7392],  // Top edge
+                [48.2709, -206.4107], [48.0159, -197.4671], [47.7609, -188.5235], [46.3175, -179.0254],  // Left edge
+        ])
+    
+        expect: "same number of actualPoints as expectedPoints"
+        actualPoints.size() == expectedPoints.size()
+    
+        and: "corresponding points are nearly equal"
+        for (int i = 0; i < actualPoints.size(); ++i) {
+            assert actualPoints[i].nearlyEquals(expectedPoints[i], 1e-5)
+        }
+    }
+    
+    def "calcConnectedLatLonBoundaryPoints(2, 2) - lat/lon 2D"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon2D.ncml")
+        
+        and: "get actual points"
+        // Results in strideY == 2 and strideX == 2.
+        List<LatLonPointNoNormalize> actualPoints = horizCoordSys.calcConnectedLatLonBoundaryPoints(2, 2)
+        
+        and: "declare expected points"
+        List<LatLonPointNoNormalize> expectedPoints = convertCoordsToPoints(true, [
+                [44.8740, -169.5274], [58.6851, -145.7993],  // Bottom edge
+                [69.7501, -106.0074], [82.3559, -162.8391],  // Right edge
+                [85.1317, -252.9728], [66.4291, -221.0677],  // Top edge
+                [48.2709, -206.4107], [47.7609, -188.5235],  // Left edge
+        ])
+        
+        expect: "same number of actualPoints as expectedPoints"
+        actualPoints.size() == expectedPoints.size()
+        
+        and: "corresponding points are nearly equal"
+        for (int i = 0; i < actualPoints.size(); ++i) {
+            assert actualPoints[i].nearlyEquals(expectedPoints[i], 1e-5)
+        }
+    }
+    
+    
+    def "calcProjectionBoundingBox"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamProjection.ncml")
+        
+        and: "get actual bounding box"
+        ProjectionRect actualBB = horizCoordSys.calcProjectionBoundingBox()
+        
+        and: "declare expected bounding box"
+        ProjectionRect expectedBB = new ProjectionRect(
+                new ProjectionPointImpl(-4500, -2450), new ProjectionPointImpl(-500, 1150))
+    
+        expect: "expected equals actual"
+        expectedBB == actualBB
+    }
+    
+    def "calcLatLonBoundingBox - 1DLatLon"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon1D.ncml")
+        
+        and: "get actual bounding box"
+        LatLonRect actualBB = horizCoordSys.calcLatLonBoundingBox()
+        
+        and: "declare expected bounding box"
+        // Derived by manually finding the minimum and maximum lat & lon values of the expected points in the
+        // "calcConnectedLatLonBoundaryPoints() - lat/lon 1D" test.
+        LatLonRect expectedBB = new LatLonRect(new LatLonPointImpl(0, 130), new LatLonPointImpl(50, 230))
+        
+        expect: "expected equals actual"
+        expectedBB == actualBB
+    }
+    
+    def "calcLatLonBoundingBox - projection"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamProjection.ncml")
+    
+        and: "get actual bounding box"
+        LatLonRect actualBB = horizCoordSys.calcLatLonBoundingBox()
+    
+        and: "declare expected bounding box"
+        // Derived by manually finding the minimum and maximum lat & lon values of the expected points in the
+        // "calcConnectedLatLonBoundaryPoints() - projection" test.
+        LatLonRect expectedBB = new LatLonRect(
+                new LatLonPointImpl(43.3711, -261.5014), new LatLonPointImpl(84.6159, -116.5346))
+    
+        expect: "expected equals actual"
+        expectedBB.nearlyEquals(actualBB)
+    }
+    
+    def "calcLatLonBoundingBox - 2DLatLon"() {
+        setup: "get the HorizCoordSys of the dataset"
+        HorizCoordSys horizCoordSys = getHorizCoordSysOfDataset("crossSeamLatLon2D.ncml")
+        
+        and: "get actual bounding box"
+        LatLonRect actualBB = horizCoordSys.calcLatLonBoundingBox()
+        
+        and: "declare expected bounding box"
+        // Derived by manually finding the minimum and maximum lat & lon values of the expected points in the
+        // "calcConnectedLatLonBoundaryPoints() - lat/lon 2D" test.
+        LatLonRect expectedBB = new LatLonRect(
+                new LatLonPointImpl(44.8740, -252.9728), new LatLonPointImpl(85.1317, -106.0074))
+        
+        expect: "expected equals actual"
+        expectedBB.nearlyEquals(actualBB)
+    }
+    
+    
+    private HorizCoordSys getHorizCoordSysOfDataset(String resourceName) {
+        File file = new File(getClass().getResource(resourceName).toURI())
+    
+        CoverageDatasetFactory.open(file.absolutePath).withCloseable { FeatureDatasetCoverage featDsetCov ->
+            // Assert that featDsetCov was opened without failure and it contains 1 CoverageCollection.
+            assert featDsetCov != null
+            assert featDsetCov.getCoverageCollections().size() == 1
+    
+            // Return HorizCoordSys from single CoverageCollection.
+            CoverageCollection covColl = featDsetCov.getCoverageCollections().get(0)
+            return covColl.getHorizCoordSys()
+        }
+    }
+    
+    // Each List<Double> contains coords in "y x" order.
+    private def convertCoordsToPoints(boolean coordsAreLatLons, List<List<Double>> coords) {
+        def points = []
+        coords.each { List<Double> coord ->
+            if (coordsAreLatLons) {
+                points << new LatLonPointNoNormalize(coord.get(0), coord.get(1))
+            } else {
+                points << new ProjectionPointImpl(coord.get(1), coord.get(0))
+            }
+        }
+        return points
+    }
+}

--- a/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamLatLon1D.ncml
+++ b/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamLatLon1D.ncml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <dimension name="lat" length="5" />
+    <dimension name="lon" length="5" />
+    
+    <variable name="temp" shape="lat lon" type="double">
+        <attribute name="long_name" value="surface temperature" />
+        <attribute name="units" value="C" />
+        <values start="1" increment="1" />
+    </variable>
+    
+    <variable name="lat" shape="lat" type="float">
+        <attribute name="units" value="degrees_north" />
+        <values>5 15 25 35 45</values>
+    </variable>
+    
+    <variable name="lon" shape="lon" type="float">
+        <attribute name="units" value="degrees_east" />
+        <values>140 160 180 -160 -140</values>
+    </variable>
+    
+    <attribute name="Conventions" value="CF-1.6" />
+</netcdf>

--- a/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamLatLon2D.ncml
+++ b/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamLatLon2D.ncml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <dimension name="y" length="4" />
+    <dimension name="x" length="4" />
+    
+    <variable name="Temperature_surface" shape="y x" type="float">
+        <attribute name="long_name" value="Temperature @ Ground or water surface" />
+        <attribute name="units" value="K" />
+        <attribute name="coordinates" value="lat lon" />
+        <values start="1" increment="1" />
+    </variable>
+    
+    <variable name="lat" shape="y x" type="double">
+        <attribute name="units" value="degrees_north" />
+        <attribute name="standard_name" value="latitude" />
+        <!--
+            These were generated from the projection in crossSeamProjection.ncml using the following Groovy code:
+            
+            for (int j = 0; j < horizCoordSys.yAxis.ncoords; ++j) {
+                for (int i = 0; i < horizCoordSys.xAxis.ncoords; ++i) {
+                    double y = horizCoordSys.yAxis.getCoordMidpoint(j)
+                    double x = horizCoordSys.xAxis.getCoordMidpoint(i)
+                    println horizCoordSys.transform.projection.projToLatLon(x, y).latitude
+                }
+            }
+        -->
+        <values>
+            48.771275207078986 56.257940168398875 63.23559652027781 68.69641273007204
+            51.52824383539942  59.91283563136657  68.26407960692367 75.7452461192097
+            52.765818800755305 61.615297053148296 70.80822358575152 80.19456756234185
+            52.28356434154232  60.94659393490472  69.78850194830888 78.27572828144659
+        </values>
+    </variable>
+    
+    <variable name="lon" shape="y x" type="double">
+        <attribute name="units" value="degrees_east" />
+        <attribute name="standard_name" value="longitude" />
+        <!-- These were generated similarly to the latitudes. -->
+        <values>
+            -168.434948822922   -161.3099324740202  -150.0              -131.56505117707798
+            -179.6237487511738  -174.86369657175186 -166.1892062570269  -147.27368900609372
+             167.86240522611175  168.81407483429038  170.71059313749964  176.3099324740202
+             155.0737544933483   151.8659776936037   145.70995378081128  130.00797980144134
+        </values>
+    </variable>
+    
+    <attribute name="Conventions" value="CF-1.6" />
+</netcdf>

--- a/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamProjection.ncml
+++ b/cdm/src/test/resources/ucar/nc2/ft2/coverage/crossSeamProjection.ncml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <dimension name="y" length="4" />
+    <dimension name="x" length="4" />
+    
+    <variable name="Temperature_surface" shape="y x" type="float">
+        <attribute name="long_name" value="Temperature @ Ground or water surface" />
+        <attribute name="units" value="K" />
+        <attribute name="grid_mapping" value="PolarStereographic_Projection" />
+        <attribute name="coordinates" value="y x" />
+        <values start="1" increment="1" />
+    </variable>
+    
+    <variable name="y" shape="y" type="float">
+        <attribute name="standard_name" value="projection_y_coordinate" />
+        <attribute name="units" value="km" />
+        <values>-2000 -1100 -200 700</values>
+    </variable>
+    
+    <variable name="x" shape="x" type="float">
+        <attribute name="standard_name" value="projection_x_coordinate" />
+        <attribute name="units" value="km" />
+        <values>-4000 -3000 -2000 -1000</values>
+    </variable>
+    
+    <variable name="PolarStereographic_Projection" shape="" type="int">
+        <attribute name="grid_mapping_name" value="stereographic" />
+        <attribute name="longitude_of_projection_origin" type="double" value="255.0" />
+        <attribute name="latitude_of_projection_origin" type="double" value="90.0" />
+        <attribute name="scale_factor_at_projection_origin" type="double" value="0.9330127018922193" />
+        <attribute name="earth_radius" type="double" value="6371229.0" />
+        <values>0</values>
+    </variable>
+    
+    <attribute name="Conventions" value="CF-1.6" />
+</netcdf>

--- a/tds/src/main/webapp/WEB-INF/templates/ncssGrid.html
+++ b/tds/src/main/webapp/WEB-INF/templates/ncssGrid.html
@@ -35,12 +35,12 @@
           <button type="button" onclick="selectTab(latLonSubset, this)" class="defaultButton">Lat/lon box</button>
 
           <button type="button" onclick="selectTab(coordinateSubset, this)"
-                  th:if="${gcd.horizCoordSys.isProjection}">Proj X/Y box</button>
+                  th:if="${gcd.horizCoordSys.isProjection()}">Proj X/Y box</button>
         </div>
 
         <div th:replace="templates/commonFragments :: latLonSubset" />
 
-        <div id="coordinateSubset" class="tabPane sidebarInput" th:if="${gcd.horizCoordSys.isProjection}">
+        <div id="coordinateSubset" class="tabPane sidebarInput" th:if="${gcd.horizCoordSys.isProjection()}">
           <h5>Bounding box (in projection coords)</h5>
 
           <div class="boundingBoxGrid">


### PR DESCRIPTION
Added `HorizCoordSys.calcConnectedLatLonBoundaryPoints()`, which calculates the lat/lon boundary of the CRS.
* It has optional parameters that limit the resolution.
* It works for projection, latLon1D, and latLon2D CRSs.
* Its boundary points are "connected", meaning that longitude values of adjacent elements are adjusted to eliminate discontinuities resulting from crossing the seam. Consequently, when cross-seam boundaries are turned into WKT polygons and plotted in NCSS's OpenLayers map, they'll be properly interpreted.
* Similar code used to live in `CoverageBoundariesExtractor`, but it was incomplete and/or buggy. I nuked all the old stuff.

Rewrote `HorizCoordSys.calcLatLonBoundingBox()` to properly handle coverages that straddle the seam.
* It builds upon `calcConnectedLatLonBoundaryPoints()`. In fact, its implementation is quite simple once we have that.
* `HorizCoordSys2D` used to have its own implementation, but the `HorizCoordSys` version now handles all CRSs properly. Nuked it.

Added extensive Javadoc for the new/updated boundary methods.
* It was quite a tricky problem, as the docs will show. The ultimate solution turned out to be relatively simple, but it took awhile for me to get there (and realize that it worked).

Added `HorizCoordSysCrossSeamBoundarySpec`, which extensively tests the boundary methods.
* It builds `HorizCoordSys` objects from the new `crossSeam*.ncml` test resources.

Did some other minor refactoring in `HorizCoordSys`, and updated the classes that depend on it.
* Renamed `getIsProjection()` to `isProjection()`.
* Renamed `makeProjectionBB()` to `calcProjectionBoundingBox()`.
* Renamed `makeLatLonBB()` to `calcLatLonBoundingBox()`.
* Converted axis field names to camelCase.

`DtCoverageAdapter` now produces 1D longitude axes with "connected" values. It appears that we used to do that in the analogous `dt.grid` stack, but that the adjustment was lost in the transition to coverage. Hopefully this change doesn't break anything.

Added `LatLonPointNoNormalize`, a container in which latitudes may lie outside of [-90, 90] and longitudes may lie outside of [-180, 180].