### PR TITLE
Fix "Add 2D Lat/Lon to file" option in NCSS

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageMisc.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageMisc.java
@@ -66,9 +66,9 @@ public class TestCoverageMisc {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
-  public void TestCoverageSize() throws IOException, InvalidRangeException {
+  public void TestCoverageSize() throws IOException {
     String endpoint = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
-    System.out.printf("open %s%n", endpoint);
+    logger.info("open {}", endpoint);
 
     try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
       assert cc != null;
@@ -94,7 +94,7 @@ public class TestCoverageMisc {
   @Test
   public void TestCFWriterCoverageSize() throws IOException, InvalidRangeException {
     String endpoint = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
-    System.out.printf("open %s%n", endpoint);
+    logger.info("open {}", endpoint);
 
     try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
       assert cc != null;
@@ -109,14 +109,14 @@ public class TestCoverageMisc {
       Assert.assertTrue(opt.isPresent());
 
       long size = opt.get();
-      Assert.assertEquals(25243920, size);
+      Assert.assertEquals(25245084, size);  // Includes sizes of non-coverage variables.
     }
   }
 
   @Test
-  public void TestCoverageSubsetWithFullLatlonBounds() throws IOException, InvalidRangeException {
+  public void TestCoverageSubsetWithFullLatlonBounds() throws IOException {
     String endpoint = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
-    System.out.printf("open %s%n", endpoint);
+    logger.info("open {}", endpoint);
 
     try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
       assert cc != null;
@@ -136,9 +136,9 @@ public class TestCoverageMisc {
       ProjectionRect projBB = gds.getProjBoundingBox();
       ProjectionImpl proj = csys.getProjection();
       ProjectionRect projBB2 = proj.latLonToProjBB(llbb);
-      System.out.printf("ProjRect =%s%n", projBB);
-      System.out.printf("LatLonBB =%s%n", llbb);
-      System.out.printf("ProjRect2=%s%n", projBB2);
+      logger.info("ProjRect = {}", projBB);
+      logger.info("LatLonBB = {}", llbb);
+      logger.info("ProjRect2 = {}", projBB2);
 
       SubsetParams subset = new SubsetParams().setLatLonBoundingBox(gds.getLatlonBoundingBox()); // should be the same!
       Optional<CoverageCoordSys> opt = csys.subset(subset);
@@ -151,9 +151,9 @@ public class TestCoverageMisc {
   }
 
   @Test
-  public void TestCoverageSubsetWithFullLatlonBoundsPS() throws IOException, InvalidRangeException {
+  public void TestCoverageSubsetWithFullLatlonBoundsPS() throws IOException {
     String endpoint = TestDir.cdmUnitTestDir + "tds/ncep/DGEX_Alaska_12km_20100524_0000.grib2"; // Polar stereographic
-    System.out.printf("open %s%n", endpoint);
+    logger.info("open {}", endpoint);
 
     try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
       assert cc != null;
@@ -173,9 +173,9 @@ public class TestCoverageMisc {
       ProjectionRect projBB = gds.getProjBoundingBox();
       ProjectionImpl proj = csys.getProjection();
       ProjectionRect projBB2 = proj.latLonToProjBB(llbb);
-      System.out.printf("ProjRect =%s%n", projBB);
-      System.out.printf("LatLonBB =%s%n", llbb);
-      System.out.printf("ProjRect2=%s%n", projBB2);
+      logger.info("ProjRect = {}", projBB);
+      logger.info("LatLonBB = {}", llbb);
+      logger.info("ProjRect2 = {}", projBB2);
 
       SubsetParams subset = new SubsetParams().setLatLonBoundingBox(gds.getLatlonBoundingBox()); // should be the same!
       Optional<CoverageCoordSys> opt = csys.subset(subset);
@@ -192,7 +192,7 @@ public class TestCoverageMisc {
   @Test
   public void TestCFWriterCoverageRead() throws IOException, InvalidRangeException {
     String endpoint = TestDir.cdmUnitTestDir + "ncss/test/GFS_CONUS_80km_20120227_0000.grib1.nc4";
-    System.out.printf("open %s%n", endpoint);
+    logger.info("open {}", endpoint);
 
     try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
       assert cc != null;
@@ -210,8 +210,7 @@ public class TestCoverageMisc {
       SubsetParams subset = new SubsetParams().setVertCoord(300.0).setTimeOffset(42.0);
       GeoReferencedArray geo = cover.readData(subset);
       Array data = geo.getData();
-      System.out.printf("%s%n", Misc.showInts(data.getShape()));
+      logger.info("{}", Misc.showInts(data.getShape()));
     }
   }
-
 }

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter2.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter2.java
@@ -33,6 +33,7 @@
  */
 package ucar.nc2.ft2.coverage.writer;
 
+import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
@@ -40,27 +41,23 @@ import ucar.nc2.*;
 import ucar.nc2.constants.*;
 import ucar.nc2.ft2.coverage.*;
 import ucar.nc2.time.CalendarDate;
-import ucar.nc2.util.Misc;
 import ucar.nc2.util.Optional;
 import ucar.unidata.geoloc.*;
+import ucar.unidata.geoloc.projection.LatLonProjection;
 
 import java.io.IOException;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Write CF Compliant Grid file from a Coverage.
  * First, single coverage only.
  * - The idea is to subset the coordsys, use that for the file's metadata.
- * - Then subset the grid, and write out the data. chack that the grid's metadata matches.
+ * - Then subset the grid, and write out the data. Check that the grid's metadata matches.
  *
  * @author caron
  * @since 5/8/2015
  */
 public class CFGridCoverageWriter2 {
-
   static private final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CFGridCoverageWriter2.class);
   static private final boolean show = false;
 
@@ -70,52 +67,170 @@ public class CFGridCoverageWriter2 {
   /**
    * Write a netcdf/CF file from a CoverageDataset
 
-   * @param gdsOrg       the CoverageDataset
-   * @param gridNames    the list of coverage names to be written, or null for all
-   * @param subset       defines the requested subset
-   * @param addLatLon    add 2D lat/lon coordinates if needed
-   * @param testSizeOnly dont write, just return expected size
-   * @param writer       this does the actual writing, may be null if testSizeOnly=true
-   * @return total bytes written
+   * @param gdsOrg            the CoverageDataset
+   * @param gridNames         the list of coverage names to be written, or null for all
+   * @param subset            defines the requested subset, or null to include everything in gdsOrg
+   * @param tryToAddLatLon2D  add 2D lat/lon coordinates, if possible
+   * @param testSizeOnly      dont write, just return expected size
+   * @param writer            this does the actual writing, may be null if testSizeOnly=true
+   * @return  the total number of bytes that the variables in the output file occupy. This is NOT the same as the
+   *          size of the the whole output file, but it's close.
    * @throws IOException
    * @throws InvalidRangeException
    */
   public static ucar.nc2.util.Optional<Long> writeOrTestSize(CoverageCollection gdsOrg, List<String> gridNames,
-                               SubsetParams subset,
-                               boolean addLatLon,
-                               boolean testSizeOnly,
-                               NetcdfFileWriter writer) throws IOException, InvalidRangeException {
-
+          SubsetParams subset, boolean tryToAddLatLon2D, boolean testSizeOnly, NetcdfFileWriter writer)
+          throws IOException, InvalidRangeException {
     CFGridCoverageWriter2 writer2 = new CFGridCoverageWriter2();
-    return writer2.writeFile(gdsOrg, gridNames, subset, addLatLon, testSizeOnly, writer);
+    return writer2.writeFile(gdsOrg, gridNames, subset, tryToAddLatLon2D, testSizeOnly, writer);
   }
 
-  private ucar.nc2.util.Optional<Long> writeFile(CoverageCollection gdsOrg, List<String> gridNames, SubsetParams subsetParams, boolean addLatLon, boolean testSizeOnly,
-                               NetcdfFileWriter writer) throws IOException, InvalidRangeException {
+  private ucar.nc2.util.Optional<Long> writeFile(CoverageCollection gdsOrg, List<String> gridNames,
+          SubsetParams subsetParams, boolean tryToAddLatLon2D, boolean testSizeOnly, NetcdfFileWriter writer)
+          throws IOException, InvalidRangeException {
+    if (gridNames == null) {  // want all of them
+      gridNames = new LinkedList<>();
 
-    // we need global atts, subsetted axes, the transforms, and the coverages with attributes and referencing subsetted axes
+      for (Coverage coverage : gdsOrg.getCoverages()) {
+        gridNames.add(coverage.getName());
+      }
+    }
+
+    if (subsetParams == null) {
+      subsetParams = new SubsetParams();
+    }
+
+    if (writer == null) {
+      if (testSizeOnly) {
+        writer = NetcdfFileWriter.createNew(null, false);  // null location. It's ok; we'll never write the file.
+      } else {
+        throw new NullPointerException("writer must be non-null when testSizeOnly == false.");
+      }
+    }
+
+    // We need global attributes, subsetted axes, transforms, and the coverages with attributes and referencing
+    // subsetted axes.
     Optional<CoverageCollection> opt = CoverageSubsetter2.makeCoverageDatasetSubset(gdsOrg, gridNames, subsetParams);
     if (!opt.isPresent())
       return ucar.nc2.util.Optional.empty(opt.getErrorMessage());
 
     CoverageCollection subsetDataset = opt.get();
 
-    long total_size = 0;
-    for (Coverage grid : subsetDataset.getCoverages()) {
-      total_size += grid.getSizeInBytes();
-    }
-
-    if (testSizeOnly)
-      return Optional.of(total_size);
-
     ////////////////////////////////////////////////////////////////////
 
-    // check size is ok
-    boolean isLargeFile = isLargeFile(total_size);
-    writer.setLargeFile(isLargeFile);
-
     addGlobalAttributes(subsetDataset, writer);
+    addDimensions(subsetDataset, writer);
+    addCoordinateAxes(subsetDataset, writer);
+    addCoverages(subsetDataset, writer);
+    addCoordTransforms(subsetDataset, writer);
 
+    boolean shouldAddLatLon2D = shouldAddLatLon2D(tryToAddLatLon2D, subsetDataset);
+    if (shouldAddLatLon2D) {
+      addLatLon2D(subsetDataset, writer);
+    }
+
+    addCFAnnotations(subsetDataset, writer, shouldAddLatLon2D);
+
+    long totalSizeOfVars = 0;
+    // This is a hack to get the root group of writer's underlying NetcdfFile. See the method's Javadoc.
+    Group rootGroup = writer.addGroup(null, null);
+
+    // In this class, we've only added vars to the root group, so this is all we need to worry about for size calc.
+    for (Variable var : rootGroup.getVariables()) {
+      totalSizeOfVars += var.getSize() * var.getElementSize();
+    }
+
+    if (!testSizeOnly) {
+      // Actually create file and write variable data to it.
+      writer.setLargeFile(isLargeFile(totalSizeOfVars));
+      writer.create();
+
+      writeCoordinateData(subsetDataset, writer);
+      writeCoverageData(gdsOrg, subsetParams, subsetDataset, writer);
+
+      if (shouldAddLatLon2D) {
+        writeLatLon2D(subsetDataset, writer);
+      }
+
+      writer.close();
+    }
+
+    return Optional.of(totalSizeOfVars);
+  }
+
+  /**
+   * Returns {@code true} if we should add 2D latitude & longitude variables to the output file.
+   * This method could return {@code false} for several reasons:
+   *
+   * <ul>
+   *     <li>{@code !tryToAddLatLon2D}</li>
+   *     <li>{@code subsetDataset.getHorizCoordSys().isLatLon2D()}</li>
+   *     <li>{@code !subsetDataset.getHorizCoordSys().isProjection()}</li>
+   *     <li>{@code subsetDataset.getHorizCoordSys() instanceof LatLonProjection}</li>
+   * </ul>
+   *
+   * @param tryToAddLatLon2D  attempt to add 2D lat/lon vars to output file.
+   * @param subsetDataset     subsetted version of the original CoverageCollection.
+   * @return  {@code true} if we should add 2D latitude & longitude variables to the output file.
+   */
+  private boolean shouldAddLatLon2D(boolean tryToAddLatLon2D, CoverageCollection subsetDataset) {
+    if (!tryToAddLatLon2D) {  // We don't even want 2D lat/lon vars.
+      return false;
+    }
+
+    HorizCoordSys horizCoordSys = subsetDataset.getHorizCoordSys();
+    if (horizCoordSys.isLatLon2D()) {  // We already have 2D lat/lon vars.
+      return false;
+    }
+    if (!horizCoordSys.isProjection()) {  // CRS doesn't contain a projection, meaning we can't calc 2D lat/lon vars.
+      return false;
+    }
+
+    Projection proj = horizCoordSys.getTransform().getProjection();
+    if (proj instanceof LatLonProjection) {  // Projection is a "fake"; we already have lat/lon.
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean isLargeFile(long total_size) {
+    boolean isLargeFile = false;
+    long maxSize = Integer.MAX_VALUE;
+    if (total_size > maxSize) {
+      logger.debug("Request size = {} Mbytes", total_size / 1000 / 1000);
+      isLargeFile = true;
+    }
+    return isLargeFile;
+  }
+
+  private void addGlobalAttributes(CoverageCollection gds, NetcdfFileWriter writer) {
+    // global attributes
+    for (Attribute att : gds.getGlobalAttributes()) {
+      if (att.getShortName().equals(CDM.FILE_FORMAT)) continue;
+      if (att.getShortName().equals(_Coordinate._CoordSysBuilder)) continue;
+      writer.addGroupAttribute(null, att);
+    }
+
+    Attribute att = gds.findAttributeIgnoreCase(CDM.CONVENTIONS);
+    if (att == null || !att.getStringValue().startsWith("CF-"))  // preserve prev version of CF Convention if exists
+      writer.addGroupAttribute(null, new Attribute(CDM.CONVENTIONS, "CF-1.0"));
+
+    writer.addGroupAttribute(null, new Attribute("History",
+            "Translated to CF-1.0 Conventions by Netcdf-Java CDM (CFGridCoverageWriter2)\n" +
+                    "Original Dataset = " + gds.getName() + "; Translation Date = " + CalendarDate.present()));
+
+    LatLonRect llbb = gds.getLatlonBoundingBox();
+    if (llbb != null) {
+      // this will replace any existing
+      writer.addGroupAttribute(null, new Attribute(ACDD.LAT_MIN, llbb.getLatMin()));
+      writer.addGroupAttribute(null, new Attribute(ACDD.LAT_MAX, llbb.getLatMax()));
+      writer.addGroupAttribute(null, new Attribute(ACDD.LON_MIN, llbb.getLonMin()));
+      writer.addGroupAttribute(null, new Attribute(ACDD.LON_MAX, llbb.getLonMax()));
+    }
+  }
+
+  private void addDimensions(CoverageCollection subsetDataset, NetcdfFileWriter writer) {
     // each independent coordinate is a dimension
     Map<String, Dimension> dimHash = new HashMap<>();
     for (CoverageCoordAxis axis : subsetDataset.getCoordAxes()) {
@@ -131,8 +246,9 @@ public class CFGridCoverageWriter2 {
         }
       }
     }
+  }
 
-    // add coordinates
+  private void addCoordinateAxes(CoverageCollection subsetDataset, NetcdfFileWriter writer) {
     for (CoverageCoordAxis axis : subsetDataset.getCoordAxes()) {
       String dims;
 
@@ -160,96 +276,13 @@ public class CFGridCoverageWriter2 {
         v.addAttribute(new Attribute(CF.BOUNDS, axis.getName()+BOUNDS));
       if (axis.getAxisType() == AxisType.TimeOffset)
         v.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME_OFFSET));
-
     }
+  }
 
-    // add grids
+  private void addCoverages(CoverageCollection subsetDataset, NetcdfFileWriter writer) {
     for (Coverage grid : subsetDataset.getCoverages()) {
       Variable v = writer.addVariable(null, grid.getName(), grid.getDataType(), grid.getIndependentAxisNamesOrdered());
       addVariableAttributes(v, grid.getAttributes());
-    }
-
-    // coordTransforms
-    for (CoverageTransform ct : subsetDataset.getCoordTransforms()) {
-      Variable ctv = writer.addVariable(null, ct.getName(), DataType.INT, ""); // scalar coordinate transform variable - container for transform info
-      for (Attribute att : ct.getAttributes())
-        ctv.addAttribute(att);
-    }
-
-    addCFAnnotations(subsetDataset, writer, addLatLon);
-
-    // finish define mode
-    writer.create();
-
-    // write the coordinate data
-    for (CoverageCoordAxis axis : subsetDataset.getCoordAxes()) {
-      Variable v = writer.findVariable(axis.getName());
-      if (v != null) {
-        if (show) System.out.printf("CFGridCoverageWriter2 write axis %s%n", v.getNameAndDimensions());
-        writer.write(v, axis.getCoordsAsArray());
-      } else {
-        logger.error("CFGridCoverageWriter2 No variable for %s%n", axis.getName());
-      }
-
-      if (axis.isInterval()) {
-        Variable vb = writer.findVariable(axis.getName() + BOUNDS);
-        writer.write(vb, axis.getCoordBoundsAsArray());
-      }
-    }
-
-    // write the grid data
-    for (Coverage grid : subsetDataset.getCoverages()) {
-      // we need to call readData on the original
-      Coverage gridOrg = gdsOrg.findCoverage(grid.getName());
-      GeoReferencedArray array = gridOrg.readData(subsetParams);
-
-      // test conform to whatever axis.getCoordsAsArray() returns
-      checkConformance(gridOrg, grid, array, gdsOrg.getName());
-
-      Variable v = writer.findVariable(grid.getName());
-      if (show) System.out.printf("CFGridCoverageWriter2 write grid %s%n", v.getNameAndDimensions());
-      writer.write(v, array.getData());
-    }
-
-    writer.close();
-
-    return Optional.of(total_size);
-  }
-
-  private boolean isLargeFile(long total_size) {
-    boolean isLargeFile = false;
-    long maxSize = Integer.MAX_VALUE;
-    if (total_size > maxSize) {
-      logger.debug("Request size = {} Mbytes", total_size / 1000 / 1000);
-      isLargeFile = true;
-    }
-    return isLargeFile;
-  }
-
-  private void addGlobalAttributes(CoverageCollection gds, NetcdfFileWriter writer) {
-    // global attributes
-    for (Attribute att : gds.getGlobalAttributes()) {
-      if (att.getShortName().equals(CDM.FILE_FORMAT)) continue;
-      if (att.getShortName().equals(_Coordinate._CoordSysBuilder)) continue;
-      writer.addGroupAttribute(null, att);
-    }
-
-    Attribute att = gds.findAttributeIgnoreCase(CDM.CONVENTIONS);
-    if (att == null || !att.getStringValue().startsWith("CF-"))  // preserve previous version of CF Convention if it exists
-      writer.addGroupAttribute(null, new Attribute(CDM.CONVENTIONS, "CF-1.0"));
-
-    writer.addGroupAttribute(null, new Attribute("History",
-            "Translated to CF-1.0 Conventions by Netcdf-Java CDM (CFGridCoverageWriter)\n" +
-                    "Original Dataset = " + gds.getName() + "; Translation Date = " + CalendarDate.present()));
-
-
-    LatLonRect llbb = gds.getLatlonBoundingBox();
-    if (llbb != null) {
-      // this will replace any existing
-      writer.addGroupAttribute(null, new Attribute(ACDD.LAT_MIN, llbb.getLatMin()));
-      writer.addGroupAttribute(null, new Attribute(ACDD.LAT_MAX, llbb.getLatMax()));
-      writer.addGroupAttribute(null, new Attribute(ACDD.LON_MIN, llbb.getLonMin()));
-      writer.addGroupAttribute(null, new Attribute(ACDD.LON_MAX, llbb.getLonMax()));
     }
   }
 
@@ -261,8 +294,42 @@ public class CFGridCoverageWriter2 {
     }
   }
 
-  private void addCFAnnotations(CoverageCollection gds, NetcdfFileWriter writer, boolean addLatLon) {
+  private void addCoordTransforms(CoverageCollection subsetDataset, NetcdfFileWriter writer) {
+    for (CoverageTransform ct : subsetDataset.getCoordTransforms()) {
+      // scalar coordinate transform variable - container for transform info
+      Variable ctv = writer.addVariable(null, ct.getName(), DataType.INT, "");
 
+      for (Attribute att : ct.getAttributes())
+        ctv.addAttribute(att);
+    }
+  }
+
+  private void addLatLon2D(CoverageCollection subsetDataset, NetcdfFileWriter writer) {
+    HorizCoordSys horizCoordSys = subsetDataset.getHorizCoordSys();
+    CoverageCoordAxis1D xAxis = horizCoordSys.getXAxis();
+    CoverageCoordAxis1D yAxis = horizCoordSys.getYAxis();
+
+    Dimension xDim = writer.findDimension(xAxis.getName());
+    Dimension yDim = writer.findDimension(yAxis.getName());
+    assert xDim != null : "We should've added X dimension in addDimensions().";
+    assert yDim != null : "We should've added Y dimension in addDimensions().";
+
+    List<Dimension> dims = Arrays.asList(yDim, xDim);
+
+    Variable latVar = writer.addVariable("lat", DataType.DOUBLE, dims);
+    latVar.addAttribute(new Attribute(CDM.UNITS, CDM.LAT_UNITS));
+    latVar.addAttribute(new Attribute(CF.STANDARD_NAME, CF.LATITUDE));
+    latVar.addAttribute(new Attribute(CDM.LONG_NAME, "latitude coordinate"));
+    latVar.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.Lat.toString()));
+
+    Variable lonVar = writer.addVariable("lon", DataType.DOUBLE, dims);
+    lonVar.addAttribute(new Attribute(CDM.UNITS, CDM.LON_UNITS));
+    lonVar.addAttribute(new Attribute(CF.STANDARD_NAME, CF.LONGITUDE));
+    lonVar.addAttribute(new Attribute(CDM.LONG_NAME, "longitude coordinate"));
+    lonVar.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.Lon.toString()));
+  }
+
+  private void addCFAnnotations(CoverageCollection gds, NetcdfFileWriter writer, boolean shouldAddLatLon2D) {
     for (Coverage grid : gds.getCoverages()) {
       CoverageCoordSys gcs = grid.getCoordSys();
 
@@ -273,11 +340,18 @@ public class CFGridCoverageWriter2 {
       }
 
       // annotate Variable for CF
-      Formatter sbuff = new Formatter();
-      for (String s : grid.getCoordSys().getAxisNames())
-        sbuff.format("%s ", s);
-      // if (addLatLon) sbuff.format("lat lon"); LOOK
-      newV.addAttribute(new Attribute(CF.COORDINATES, sbuff.toString()));
+      Formatter coordsAttribValFormatter = new Formatter();
+      for (String axisName : grid.getCoordSys().getAxisNames()) {
+        coordsAttribValFormatter.format("%s ", axisName);
+      }
+
+      if (shouldAddLatLon2D) {
+        assert writer.findVariable("lat") != null : "We should've added lat variable in addLatLon2D()";
+        assert writer.findVariable("lon") != null : "We should've added lon variable in addLatLon2D()";
+        coordsAttribValFormatter.format("lat lon");
+      }
+
+      newV.addAttribute(new Attribute(CF.COORDINATES, coordsAttribValFormatter.toString()));
 
       // add reference to coordinate transform variables
       CoverageTransform ct = gcs.getHorizTransform();
@@ -293,10 +367,15 @@ public class CFGridCoverageWriter2 {
         logger.error("CFGridCoverageWriter2 cant find " + axis.getName() + " in writer ");
         continue;
       }
-      /* if ((axis.getAxisType() == AxisType.Height) || (axis.getAxisType() == AxisType.Pressure) || (axis.getAxisType() == AxisType.GeoZ)) {
+
+      // LOOK: Commented out because CoverageCoordAxis doesn't have any info about "positive" wrt vertical axes.
+      // To fix, we'd need to add that metadata when building the CRS.
+      /* if ((axis.getAxisType() == AxisType.Height) || (axis.getAxisType() == AxisType.Pressure) ||
+            (axis.getAxisType() == AxisType.GeoZ)) {
         if (null != axis.getPositive())
           newV.addAttribute(new Attribute(CF.POSITIVE, axis.getPositive()));
       } */
+
       if (axis.getAxisType() == AxisType.Lat) {
         newV.addAttribute(new Attribute(CDM.UNITS, CDM.LAT_UNITS));
         newV.addAttribute(new Attribute(CF.STANDARD_NAME, CF.LATITUDE));
@@ -317,7 +396,81 @@ public class CFGridCoverageWriter2 {
     }
   }
 
-  private void checkConformance(Coverage gridOrg, Coverage gridSubset, GeoReferencedArray geo, String where) {
+  private void writeCoordinateData(CoverageCollection subsetDataset, NetcdfFileWriter writer)
+          throws IOException, InvalidRangeException {
+    for (CoverageCoordAxis axis : subsetDataset.getCoordAxes()) {
+      Variable v = writer.findVariable(axis.getName());
+      if (v != null) {
+        if (show) System.out.printf("CFGridCoverageWriter2 write axis %s%n", v.getNameAndDimensions());
+        writer.write(v, axis.getCoordsAsArray());
+      } else {
+        logger.error("CFGridCoverageWriter2 No variable for %s%n", axis.getName());
+      }
+
+      if (axis.isInterval()) {
+        Variable vb = writer.findVariable(axis.getName() + BOUNDS);
+        writer.write(vb, axis.getCoordBoundsAsArray());
+      }
+    }
+  }
+
+  private void writeCoverageData(CoverageCollection gdsOrg, SubsetParams subsetParams,
+          CoverageCollection subsetDataset, NetcdfFileWriter writer) throws IOException, InvalidRangeException {
+    for (Coverage coverage : subsetDataset.getCoverages()) {
+      // we need to call readData on the original
+      Coverage coverageOrg = gdsOrg.findCoverage(coverage.getName());
+      GeoReferencedArray array = coverageOrg.readData(subsetParams);
+
+      // test conform to whatever axis.getCoordsAsArray() returns
+      checkConformance(coverage, array, gdsOrg.getName());
+
+      Variable v = writer.findVariable(coverage.getName());
+      if (show) System.out.printf("CFGridCoverageWriter2 write coverage %s%n", v.getNameAndDimensions());
+      writer.write(v, array.getData());
+    }
+  }
+
+  private void writeLatLon2D(CoverageCollection subsetDataset, NetcdfFileWriter writer)
+          throws IOException, InvalidRangeException {
+    HorizCoordSys horizCoordSys = subsetDataset.getHorizCoordSys();
+    CoverageCoordAxis1D xAxis = horizCoordSys.getXAxis();
+    CoverageCoordAxis1D yAxis = horizCoordSys.getYAxis();
+
+    Projection proj = horizCoordSys.getTransform().getProjection();
+    ProjectionPointImpl projPoint = new ProjectionPointImpl();
+    LatLonPointImpl latlonPoint = new LatLonPointImpl();
+
+    double[] xData = (double[]) xAxis.getCoordsAsArray().get1DJavaArray(DataType.DOUBLE);
+    double[] yData = (double[]) yAxis.getCoordsAsArray().get1DJavaArray(DataType.DOUBLE);
+
+    int numX = xData.length;
+    int numY = yData.length;
+
+    double[] latData = new double[numX * numY];
+    double[] lonData = new double[numX * numY];
+
+    // create the data
+    for (int i = 0; i < numY; i++) {
+      for (int j = 0; j < numX; j++) {
+        projPoint.setLocation(xData[j], yData[i]);
+        proj.projToLatLon(projPoint, latlonPoint);
+        latData[i * numX + j] = latlonPoint.getLatitude();
+        lonData[i * numX + j] = latlonPoint.getLongitude();
+      }
+    }
+
+    Variable latVar = writer.findVariable("lat");
+    assert latVar != null : "We should have added lat var in addLatLon2D().";
+    Array latDataArray = Array.factory(DataType.DOUBLE, new int[] { numY, numX }, latData);
+    writer.write(latVar, latDataArray);
+
+    Variable lonVar = writer.findVariable("lon");
+    assert lonVar != null : "We should have added lon var in addLatLon2D().";
+    Array lonDataArray = Array.factory(DataType.DOUBLE, new int[] { numY, numX }, lonData);
+    writer.write(lonVar, lonDataArray);
+  }
+
+  private void checkConformance(Coverage gridSubset, GeoReferencedArray geo, String where) {
     CoverageCoordSys csys = gridSubset.getCoordSys();
 
     CoverageCoordSys csysData = geo.getCoordSysForData();
@@ -337,8 +490,5 @@ public class CFGridCoverageWriter2 {
 
     if (!ok || !ok2)
       logger.warn("CFGridCoverageWriter2 checkConformance fails " +where);
-
   }
-
 }
-

--- a/cdm/src/test/groovy/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter2Spec.groovy
+++ b/cdm/src/test/groovy/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter2Spec.groovy
@@ -1,0 +1,129 @@
+package ucar.nc2.ft2.coverage.writer
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import ucar.ma2.Array
+import ucar.ma2.DataType
+import ucar.ma2.MAMath
+import ucar.nc2.NetcdfFile
+import ucar.nc2.NetcdfFileWriter
+import ucar.nc2.ft2.coverage.CoverageCollection
+import ucar.nc2.ft2.coverage.CoverageDatasetFactory
+import ucar.nc2.ft2.coverage.FeatureDatasetCoverage
+import ucar.nc2.ft2.coverage.HorizCoordSysCrossSeamBoundarySpec
+
+/**
+ * Tests that CFGridCoverageWriter2 properly adds 2D lat/lon variables to output file when {@code addLatLon == true}.
+ *
+ * @author cwardgar
+ * @since 2018-03-17
+ */
+class CFGridCoverageWriter2Spec extends Specification {
+    def "calc output file sizes with and without 2D lat/lon"() {
+        def numY = 4, numX = 4  // Lengths of the y and x axes in the dataset.
+        
+        setup: "Open test resource as FeatureDatasetCoverage"
+        File testFile = new File(HorizCoordSysCrossSeamBoundarySpec.getResource("crossSeamProjection.ncml").toURI())
+        FeatureDatasetCoverage featDsetCov = CoverageDatasetFactory.open(testFile.absolutePath)
+        
+        and: "assert that featDsetCov was opened without failure and get its 1 CoverageCollection"
+        assert featDsetCov != null
+        assert featDsetCov.getCoverageCollections().size() == 1
+        CoverageCollection covColl = featDsetCov.getCoverageCollections().get(0)
+        
+        when: "calculate expected size excluding 2D lat/lon vars"
+        long expectedSizeNoLatLon =
+                numY * numX * DataType.FLOAT.size +  // Temperature_surface
+                numY * DataType.FLOAT.size +         // y
+                numX * DataType.FLOAT.size +         // x
+                1 * DataType.INT.size                // PolarStereographic_Projection
+        
+        and: "calculate actual size excluding 2D lat/lon vars"
+        long actualSizeNoLatLon = CFGridCoverageWriter2.writeOrTestSize(
+                // No subset; don't addLatLon; calc file size but don't write file.
+                covColl, null, null, false, true, null).get()
+        
+        then: "expected equals actual"
+        expectedSizeNoLatLon == actualSizeNoLatLon
+    
+        when: "calculate expected size including 2D lat/lon vars"
+        long expectedSizeWithLatLon = expectedSizeNoLatLon +
+                numY * numX * DataType.DOUBLE.size +          // lat
+                numY * numX * DataType.DOUBLE.size            // lon
+    
+        and: "calculate actual size excluding 2D lat/lon vars"
+        long actualSizeWithLatLon = CFGridCoverageWriter2.writeOrTestSize(
+                // No subset; do addLatLon; calc file size but don't write file.
+                covColl, null, null, true, true, null).get()
+    
+        then: "expected equals actual"
+        expectedSizeWithLatLon == actualSizeWithLatLon
+        
+        cleanup: "close all resources"
+        featDsetCov?.close()
+    }
+    
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder()
+    
+    def "CFGridCoverageWriter2 properly adds 2D lat/lon variables"() {
+        setup: "Open test resource as FeatureDatasetCoverage"
+        File testFile = new File(HorizCoordSysCrossSeamBoundarySpec.getResource("crossSeamProjection.ncml").toURI())
+        FeatureDatasetCoverage featDsetCov = CoverageDatasetFactory.open(testFile.absolutePath)
+    
+        and: "assert that featDsetCov was opened without failure and get its 1 CoverageCollection"
+        assert featDsetCov != null
+        assert featDsetCov.getCoverageCollections().size() == 1
+        CoverageCollection covColl = featDsetCov.getCoverageCollections().get(0)
+        
+        and: "setup NetcdfFileWriter"
+        File outputFile = tempFolder.newFile()
+        NetcdfFileWriter writer = NetcdfFileWriter.createNew(outputFile.absolutePath, false)
+        
+        and: "write output file"
+        // No subset; do addLatLon; write to outputFile.
+        CFGridCoverageWriter2.writeOrTestSize(covColl, null, null, true, false, writer)
+        
+        and: "open output file"
+        NetcdfFile ncFile = NetcdfFile.open(outputFile.absolutePath)
+        
+        and: "declare expected lats"
+        def expectedShape = [4, 4] as int[]
+        def expectedLatsList = [  // These come from crossSeamLatLon2D.ncml
+                48.771275207078986, 56.257940168398875, 63.23559652027781, 68.69641273007204,
+                51.52824383539942,  59.91283563136657,  68.26407960692367, 75.7452461192097,
+                52.765818800755305, 61.615297053148296, 70.80822358575152, 80.19456756234185,
+                52.28356434154232,  60.94659393490472,  69.78850194830888, 78.27572828144659
+        ]
+        Array expectedLats = Array.factory(DataType.DOUBLE, expectedShape, expectedLatsList as double[])
+        
+        and: "declare expected lons"
+        def expectedLonsList = [  // These come from crossSeamLatLon2D.ncml
+                -168.434948822922,   -161.3099324740202,  -150.0,              -131.56505117707798,
+                -179.6237487511738,  -174.86369657175186, -166.1892062570269,  -147.27368900609372,
+                 167.86240522611175,  168.81407483429038,  170.71059313749964,  176.3099324740202,
+                 155.0737544933483,   151.8659776936037,   145.70995378081128,  130.00797980144134
+        ]
+        Array expectedLons = Array.factory(DataType.DOUBLE, expectedShape, expectedLonsList as double[])
+        
+        when: "read actual latitudes"
+        Array actualLats = ncFile.findVariable("lat").read()
+        
+        then: "expected nearly equals actual"
+        Assert.assertArrayEquals(expectedLats.shape, actualLats.shape)
+        MAMath.nearlyEquals(expectedLats, actualLats)
+        
+        when: "read actual longitudes"
+        Array actualLons = ncFile.findVariable("lon").read()
+        
+        then: "expected nearly equals actual"
+        Assert.assertArrayEquals(expectedLons.shape, actualLons.shape)
+        MAMath.nearlyEquals(expectedLons, actualLons)
+        
+        cleanup: "close all resources"
+        ncFile?.close()
+        writer?.close()
+        featDsetCov?.close()
+    }
+}

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -138,15 +138,13 @@ public class NcssGridController extends AbstractNcssController {
 
   private File makeCFNetcdfFile(CoverageCollection gcd, String responseFilename, NcssGridParamsBean params,
           NetcdfFileWriter.Version version) throws InvalidRangeException, IOException {
-    // default chunking - let user control at some point
-    NetcdfFileWriter writer = NetcdfFileWriter.createNew(version, responseFilename, null);
     SubsetParams subset = params.makeSubset(gcd);
 
     // Test maxFileDownloadSize
     long maxFileDownloadSize = ThreddsConfig.getBytes("NetcdfSubsetService.maxFileDownloadSize", -1L);
     if (maxFileDownloadSize > 0) {
       Optional<Long> estimatedSizeo = CFGridCoverageWriter2.writeOrTestSize(
-              gcd, params.getVar(), subset, params.isAddLatLon(), true, writer);
+              gcd, params.getVar(), subset, params.isAddLatLon(), true, null);
       if (!estimatedSizeo.isPresent())
         throw new InvalidRangeException("Request contains no data: " + estimatedSizeo.getErrorMessage());
 
@@ -160,6 +158,9 @@ public class NcssGridController extends AbstractNcssController {
     }
 
     // write the file
+    NetcdfFileWriter writer = NetcdfFileWriter.createNew(
+            version, responseFilename, null);  // default chunking - let user control at some point
+
     Optional<Long> estimatedSizeo = CFGridCoverageWriter2.writeOrTestSize(
             gcd, params.getVar(), subset, params.isAddLatLon(), false, writer);
     if (!estimatedSizeo.isPresent())


### PR DESCRIPTION
Significantly improved `CFGridCoverageWriter2.writeOrTestSize()`.
* Can now add 2D latitude and longitude variables to the output file it produces.
* Returns a more accurate estimate of the output size, by also including the sizes of non-coverage variables.
* Gracefully handles null arguments.
* Reworked logic a bit to improve clarity. Also split up huge block of code into smaller auxiliary methods.

Other:
* Added tests that assert that `CFGridCoverageWriter2` properly adds 2D lat/lon variables to output file when `addLatLon == true`.
* Updated `TestCoverageMisc.TestCFWriterCoverageSize()` to account for new size calculation in `CFGridCoverageWriter2.writeOrTestSize()`.
* Removed/refactored cruft in `TestCoverageMisc`.