### PR TITLE
Update all catalogs and docs to use NCSS's 5.0.0 service base

### DIFF
--- a/cdm/src/test/data/thredds/catalog/nestedServices.xml
+++ b/cdm/src/test/data/thredds/catalog/nestedServices.xml
@@ -5,16 +5,17 @@
 
 		<!-- compound service error -->
     <service name="all" serviceType="Compound" base="">
-     <service name="most" serviceType="Compound" base="">
-       <service name="iso" serviceType="ISO" base="/thredds/iso/" />
-       <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />
-       <service name="ncss" serviceType="NetCDFSubset" base="/thredds/ncss/" />
-       <service name="ncml" serviceType="NCML" base="/thredds/ncml/" />
-       <service name="uddc" serviceType="UDDC" base="/thredds/uddc/" />
-       <service name="wcs" serviceType="WCS" base="/thredds/wcs/" />
-       <service name="wms" serviceType="WMS" base="/thredds/wms/" />
-     </service>
-     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
+      <service name="most" serviceType="Compound" base="">
+        <service name="iso" serviceType="ISO" base="/thredds/iso/" />
+        <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />
+        <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
+        <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" />
+        <service name="ncml" serviceType="NCML" base="/thredds/ncml/" />
+        <service name="uddc" serviceType="UDDC" base="/thredds/uddc/" />
+        <service name="wcs" serviceType="WCS" base="/thredds/wcs/" />
+        <service name="wms" serviceType="WMS" base="/thredds/wms/" />
+      </service>
+      <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
     </service>
 
   <!-- use top service -->

--- a/docs/website/tds/reference/Viewers.adoc
+++ b/docs/website/tds/reference/Viewers.adoc
@@ -121,7 +121,7 @@ results in the following viewer link:
 === Selecting the Dataset access URL used in the Viewer Link
 
 When a Dataset has more than one kind of access, each access will have a
-seperate URL. Use the service type inside of curly brackets to select
+separate URL. Use the service type inside of curly brackets to select
 which access URL to use.
 
 For example, the following:
@@ -132,7 +132,8 @@ For example, the following:
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>

--- a/docs/website/tds/reference/services/CdmRemote.adoc
+++ b/docs/website/tds/reference/services/CdmRemote.adoc
@@ -17,7 +17,8 @@ include ../../../netcdf-java/reference/stream/CdmrCommon.adoc[]
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="cdmrFeature" serviceType="CdmrFeature" base="/thredds/cdmrfeature/grid/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>

--- a/docs/website/tds/reference/services/CdmrFeature.adoc
+++ b/docs/website/tds/reference/services/CdmrFeature.adoc
@@ -17,7 +17,8 @@ include ../../../netcdf-java/reference/stream/CdmrCommon.adoc[]
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="cdmrFeature" serviceType="CdmrFeature" base="/thredds/cdmrfeature/grid/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>

--- a/docs/website/tds/reference/services/NetcdfSubsetServiceConfigure.adoc
+++ b/docs/website/tds/reference/services/NetcdfSubsetServiceConfigure.adoc
@@ -31,17 +31,23 @@ the <<ThreddsConfigXMLFile#ncss,threddsConfig.xml>> docs.
 
 == Serving Datasets with the Netcdf Subset Service
 
-In your configuration catalogs, you must define the service like this:
+In your configuration catalogs, you must define the service like this is you're serving GRID data:
 
 --------------------------------------------------------------------------------
-<service name="subsetServer" serviceType="NetcdfSubset" base="/thredds/ncss/" />
+<service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
 --------------------------------------------------------------------------------
 
-Then as usual, add the service to any datasets that you want served, eg:
+and like this if you're serving POINT data:
+
+--------------------------------------------------------------------------------
+<service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" />
+--------------------------------------------------------------------------------
+
+Then, as usual, add the service to any datasets that you want served, e.g.:
 
 ------------------------------------------------------------------
 <dataset name="datasetName" ID="datasetID" urlPath="/my/urlPath">
-   <serviceName>subsetServer</serviceName>
+   <serviceName>ncssGrid</serviceName>
 </dataset>
 ------------------------------------------------------------------
 

--- a/docs/website/tds/reference/services/StandardServices.adoc
+++ b/docs/website/tds/reference/services/StandardServices.adoc
@@ -518,7 +518,8 @@ Note: The required *serviceType* and *base* values are shown in bold.
 <service name="all" serviceType="Compound" base="">
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
 
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>

--- a/docs/website/tds/tutorial/AddingServices.adoc
+++ b/docs/website/tds/tutorial/AddingServices.adoc
@@ -75,7 +75,7 @@ compound service would look something like this:
     <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/" />
     <service name="wms" serviceType="WMS" base="/thredds/wms/" />
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/" />
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
 </service>
 --------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ to the same compound service as above:
     <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/" />
     <service name="wms" serviceType="WMS" base="/thredds/wms/" />
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/" />
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/" />
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/" />

--- a/docs/website/tds/tutorial/BasicConfigCatalogs.adoc
+++ b/docs/website/tds/tutorial/BasicConfigCatalogs.adoc
@@ -76,7 +76,8 @@ catalog:
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
     <!--service name="wcs" serviceType="WCS" base="/thredds/wcs/" /-->
     <!--service name="wms" serviceType="WMS" base="/thredds/wms/" /-->
-    <!--service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/" /-->
+    <!--<service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" /-->
+    <!--<service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" /-->
   </service>
 
   <service name="dap" base="" serviceType="compound">

--- a/docs/website/tds/tutorial/ConfigCatalogs.adoc
+++ b/docs/website/tds/tutorial/ConfigCatalogs.adoc
@@ -122,10 +122,16 @@ values given here* according to service type:
 <service name="odap" serviceType="OPeNDAP" base="/thredds/dodsC/" />
 --------------------------------------------------------------------
 
-=== NetCDF Subset Service
+=== NetCDF Subset Service for Grids
 
 ------------------------------------------------------------------------
-<service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/" />
+<service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
+------------------------------------------------------------------------
+
+=== NetCDF Subset Service for Points
+
+------------------------------------------------------------------------
+<service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" />
 ------------------------------------------------------------------------
 
 === WCS

--- a/docs/website/tds/tutorial/FmrcFeatureCollectionsTutorial.adoc
+++ b/docs/website/tds/tutorial/FmrcFeatureCollectionsTutorial.adoc
@@ -55,7 +55,7 @@ from your main catalog:
    <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
    <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
    <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-   <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+   <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
    <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
    <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
    <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/docs/website/tds/tutorial/files/catalogFmrc.xml
+++ b/docs/website/tds/tutorial/files/catalogFmrc.xml
@@ -7,7 +7,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/docs/website/tds/tutorial/files/catalogGribfc.xml
+++ b/docs/website/tds/tutorial/files/catalogGribfc.xml
@@ -8,7 +8,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/docs/website/tds/tutorial/files/modelsNcep.xml
+++ b/docs/website/tds/tutorial/files/modelsNcep.xml
@@ -12,7 +12,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/docs/website/tds/tutorial/files/satellite.xml
+++ b/docs/website/tds/tutorial/files/satellite.xml
@@ -5,7 +5,7 @@
     <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
@@ -15,7 +15,7 @@
     <service name="ncdods2" serviceType="OPENDAP" base="/thredds/dodsC/"/>
     <service name="wcs2" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms2" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss2" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid2" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="ncml2" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc2" serviceType="UDDC" base="/thredds/uddc/"/>
     <service name="iso2" serviceType="ISO" base="/thredds/iso/"/>

--- a/it/src/test/java/thredds/server/catalog/TestServiceDefaults.java
+++ b/it/src/test/java/thredds/server/catalog/TestServiceDefaults.java
@@ -68,7 +68,7 @@ public class TestServiceDefaults {
     Catalog cat = TdsLocalCatalog.open(catalog);
     Assert.assertEquals(3, cat.getServices().size());
 
-    check(cat, "all", 11);
+    check(cat, "all", 12);
     check(cat, "GridServices", 11);
     check(cat, "opendapOnly", 1);
 

--- a/it/src/test/java/thredds/server/catalog/TestTdsDatasetScan.java
+++ b/it/src/test/java/thredds/server/catalog/TestTdsDatasetScan.java
@@ -161,7 +161,7 @@ public class TestTdsDatasetScan {
     Assert.assertNotNull(orgServices);
     Assert.assertEquals(ServiceType.Compound, orgServices.getType());
     Assert.assertNotNull(orgServices.getNestedServices());
-    Assert.assertEquals(11, orgServices.getNestedServices().size());  // has 11 services
+    Assert.assertEquals(12, orgServices.getNestedServices().size());  // has 12 services
     boolean hasFileServer = false;
     for (Service sn : orgServices.getNestedServices())
       if( ServiceType.HTTPServer == sn.getType()) hasFileServer = true;

--- a/it/src/test/java/thredds/server/catalog/TestTdsGrib.java
+++ b/it/src/test/java/thredds/server/catalog/TestTdsGrib.java
@@ -186,7 +186,8 @@ public class TestTdsGrib {
   public void testGlobalServices() throws IOException {
     String catalog = "/catalog/gribCollection.v5/GFS_CONUS_80km/catalog.xml"; // serviceName ="all" from root catalog
     Catalog cat = TdsLocalCatalog.open(catalog);
-    testCat(cat, 10, true, null, 0);
+    testCat(cat, 11, true, null, 0);
+    testCat(cat, 11, true, null, 0);
 
     Dataset top = cat.getDatasetsLocal().get(0);
     Assert.assertTrue(!top.hasAccess());
@@ -197,7 +198,7 @@ public class TestTdsGrib {
       } else {
         CatalogRef catref = (CatalogRef) ds;
         Catalog cat2 = TdsLocalCatalog.openFromURI(catref.getURI());
-        testCat(cat2, 10, false, "all", 11);
+        testCat(cat2, 11, false, "all", 12);
         break;
       }
     }

--- a/legacy/src/main/java/thredds/catalog/InvService.java
+++ b/legacy/src/main/java/thredds/catalog/InvService.java
@@ -19,7 +19,8 @@ public class InvService {
   public static final InvService cdmrfeature = new InvService("cdmrfeature", ServiceType.CdmrFeature.toString(), "/thredds/cdmrfeature/", "", "");
   public static final InvService fileServer = new InvService("fileServer", ServiceType.HTTPServer.toString(), "/thredds/fileServer/", "", "");
   public static final InvService latest = new InvService("latest", ServiceType.RESOLVER.toString(), "", "", "");
-  public static final InvService ncss = new InvService("ncss", ServiceType.NetcdfSubset.toString(), "/thredds/ncss/", "", "");
+  public static final InvService ncssGrid = new InvService("ncssGrid", ServiceType.NetcdfSubset.toString(), "/thredds/ncss/grid/", "", "");
+  public static final InvService ncssPoint = new InvService("ncssPoint", ServiceType.NetcdfSubset.toString(), "/thredds/ncss/point/", "", "");
   public static final InvService opendap = new InvService("opendap", ServiceType.OPENDAP.toString(), "/thredds/dodsC/", "", "");
   public static final InvService dap4 = new InvService("dap4", ServiceType.DAP4.toString(), "/thredds/dap4/", "", "");
   public static final InvService wcs = new InvService("wcs", ServiceType.WCS.toString(), "/thredds/wcs/", "", "");

--- a/tdm/src/main/resources/resources/indexNomads.xml
+++ b/tdm/src/main/resources/resources/indexNomads.xml
@@ -9,7 +9,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
   </service>
 

--- a/tdm/src/main/resources/resources/test.xml
+++ b/tdm/src/main/resources/resources/test.xml
@@ -9,7 +9,8 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/tdm/src/main/resources/resources/testMlode.xml
+++ b/tdm/src/main/resources/resources/testMlode.xml
@@ -9,7 +9,8 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/catalog.xml
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/catalog.xml
@@ -12,7 +12,8 @@
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
     <!--service name="wcs" serviceType="WCS" base="/thredds/wcs/" /-->
     <!--service name="wms" serviceType="WMS" base="/thredds/wms/" /-->
-    <!--service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/" /-->
+    <!--<service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" /-->
+    <!--<service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" /-->
   </service>
 
   <service name="dap" base="" serviceType="compound">

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -13,7 +13,8 @@
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="cdmrFeature" serviceType="CdmrFeature" base="/thredds/cdmrfeature/grid/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>

--- a/tds/src/test/content/thredds/pointCatalog.xml
+++ b/tds/src/test/content/thredds/pointCatalog.xml
@@ -10,7 +10,7 @@
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>

--- a/tds/src/test/content/thredds/testTdmMemoryUse.xml
+++ b/tds/src/test/content/thredds/testTdmMemoryUse.xml
@@ -8,7 +8,7 @@
     <service name="all" base="" serviceType="compound">
         <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/"/>
         <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
-        <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+        <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
         <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     </service>
 

--- a/tds/src/test/content/thredds/wav_mod.xml
+++ b/tds/src/test/content/thredds/wav_mod.xml
@@ -8,8 +8,8 @@
     <service name="opendap"   serviceType="OpenDAP"      base="/thredds/dodsC/"     />
     <service name="wcs"       serviceType="WCS"          base="/thredds/wcs/"       />
     <service name="wms"       serviceType="WMS"          base="/thredds/wms/"       />
-    <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/" />
-    <service name="ncss"      serviceType="NetcdfSubset" base="/thredds/ncss/" />
+    <service name="cdmremote" serviceType="CdmRemote"    base="/thredds/cdmremote/" />
+    <service name="ncssGrid"  serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
   </service>
 
   <!-- SWAN-Oahu: -->

--- a/tds/src/test/resources/thredds/server/catalog/TestDatasetScan.xml
+++ b/tds/src/test/resources/thredds/server/catalog/TestDatasetScan.xml
@@ -11,7 +11,8 @@
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>

--- a/tds/src/test/resources/thredds/server/catalog/testInheritied.xml
+++ b/tds/src/test/resources/thredds/server/catalog/testInheritied.xml
@@ -8,7 +8,8 @@
     <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/" />
     <service name="wms" serviceType="WMS" base="/thredds/wms/" />
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
   </service>
 
   <featureCollection featureType="GRIB1" name="NMME GFDL Ensembles" harvest="true" path="ensembles/nmme_gfdl">


### PR DESCRIPTION
Basically, instead of:
```xml
<service name="ncss" serviceType="NetCDFSubset" base="/thredds/ncss/" />
```
Now use one or both of:
```xml
<service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/" />
<service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/" />
```
A lot of the global compound services (usually named "all" in the root catalogs) include both, because often you don't know the types of data that they'll be applied to ahead of time (could be GRID or POINT).

Updated unit tests to account for the additional service that was added to many of the test catalogs.