### PR TITLE
Enable logging interface thru Nc4prototypes.java

### DIFF
--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4prototypes.java
@@ -380,4 +380,8 @@ public interface Nc4prototypes extends Library {
   
   /* Set the per-variable cache size, nelems, and preemption policy. */
   int nc_get_var_chunk_cache(int ncid, int varid, SizeTByReference sizep, SizeTByReference nelemsp, FloatByReference preemptionp);  // size_t
+
+  /* Set the log level. */
+  int nc_set_log_level(int newlevel);
+
 }


### PR DESCRIPTION
1. Added nc_set_log_level to the Nc4prototypes interface.
2. Modified Nc4Iosp.load() so that it
   tries to set the log level to 0 (zero).
   This will provide at lease HDF5 traceback
   plus probably some other (hopefully) minimal
   netcdf-c output.
3. Defined a -Djna.library.loglevel for the JVM
   to control what log level to set. Setting to -1
   will turn off logging.