### PR TITLE
Do fuzzy floating-point comparisons in EnhanceScaleMissingImpl

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/EnhanceScaleMissing.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/EnhanceScaleMissing.java
@@ -144,11 +144,15 @@ public interface EnhanceScaleMissing extends IsMissingEvaluator {
 
   /** true if Variable has _FillValue attribute */
   boolean hasFillValue();
+  /** return value of _FillValue attribute */
+  double getFillValue();
   /** return true if val equals the _FillValue  */
   boolean isFillValue( double val );
 
   /** true if Variable has missing_value attribute */
   boolean hasMissingValue();
+  /** return values of missing_value attributes */
+  double[] getMissingValues();
   /** return true if val equals a missing_value  */
   boolean isMissingValue( double val );
 

--- a/cdm/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -326,6 +326,14 @@ public class VariableDS extends ucar.nc2.Variable implements VariableEnhanced, E
     return scaleMissingProxy.getValidMin();
   }
 
+  public double getFillValue() {
+    return scaleMissingProxy.getFillValue();
+  }
+
+  public double[] getMissingValues() {
+    return scaleMissingProxy.getMissingValues();
+  }
+
   public boolean hasFillValue() {
     return scaleMissingProxy.hasFillValue();
   }

--- a/cdm/src/test/resources/ucar/nc2/dataset/testScaleMissingFloatingPointComparisons.ncml
+++ b/cdm/src/test/resources/ucar/nc2/dataset/testScaleMissingFloatingPointComparisons.ncml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <variable name="foo" shape="4" type="byte">
+        <attribute name="scale_factor" type="float" value="0.01" />
+        <attribute name="valid_min" type="byte" value="0" />
+        <attribute name="valid_max" type="byte" value="100" />
+        <attribute name="_FillValue" type="byte" value="-1" />
+        <values>-1 0 100 101</values>
+    </variable>
+</netcdf>

--- a/cdm/src/test/resources/ucar/nc2/dataset/testScaledFillValue.ncml
+++ b/cdm/src/test/resources/ucar/nc2/dataset/testScaledFillValue.ncml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
-    
     <variable name="foo" shape="" type="double">
         <attribute name="_FillValue" type="double" value="99999" />
         <attribute name="scale_factor" type="double" value="1.e-05" />


### PR DESCRIPTION
* Comparisons include `valid_min`, `valid_max`, `_FillValue`, and `missing_value`.
* Added `getFillValue()` and `getMissingValues()` methods to `EnhanceScaleMissing`. Also added implementations for those methods to `VariableDS`, which simply defer to `EnhanceScaleMissingImpl`.
* This fixes https://github.com/Unidata/thredds/issues/1068. I added a regression test that demonstrated the bug.