### PR TITLE
Remove prohibited "--" from malformed XML comment

### DIFF
--- a/tds/src/test/content/thredds/testCompareTwoCatalogs.config.xml
+++ b/tds/src/test/content/thredds/testCompareTwoCatalogs.config.xml
@@ -10,7 +10,7 @@
                  catPath="thredds/idv/rt-models.1.0.xml"/>
                  catPath="thredds/topcatalog.xml"/>
                  catPath="thredds/catalog/nexrad/level3/NVW/YUX/20060315/catalog.xml"/>
-                              Change this date as appropriate --^^^^^^^^
+                                Change this date as appropriate ^^^^^^^^
                                    (we keep about 7 days on motherlode)
     -->
 </testCompareTwoCatalogsConfig>


### PR DESCRIPTION
"For compatibility, the string " -- " (double-hyphen) MUST NOT occur within comments." See: [Section 2.5, Extensible Markup Language (XML) 1.0 (Fifth Edition), W3C Recommendation 26 November 2008](https://www.w3.org/TR/2008/REC-xml-20081126/#sec-comments)
