### PR TITLE
Publish Webstart to Nexus

### DIFF
--- a/buildSrc/src/main/groovy/edu/ucar/build/ui/SignJarsTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/ui/SignJarsTask.groovy
@@ -1,0 +1,174 @@
+package edu.ucar.build.ui
+
+import org.apache.tools.ant.BuildException
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import org.gradle.api.tasks.incremental.InputFileDetails
+
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+
+/**
+ * Digitally signs JAR files to make them suitable for use with Webstart.
+ * <p>
+ * Digital signatures are generated using the jarsigner tool (see
+ * https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html). To generate an entity's signature for
+ * a file, the entity must first have a public/private key pair associated with it and one or more certificates that
+ * authenticate its public key. Those items are typically located in a keystore, identified by an alias, and protected
+ * by a password.
+ * <p>
+ * The input JARs to this task are not actually modified. Rather, copies of them are made in {@code outputDir}, and
+ * then the signature files (typically named <code>META-INF/${keystoreAlias.toUpperCase()}.SF</code> and
+ * <code>META-INF/${keystoreAlias.toUpperCase()}.RSA</code>) are inserted into the copies.
+ * <p>
+ * jarsigner will fail to sign a JAR if it already contains digital signatures or if there are duplicate entries.
+ * If that happens, this task will remove the troublesome files and attempt to sign the JAR again.
+ *
+ * @author cwardgar
+ * @since 2018-04-23
+ */
+class SignJarsTask extends DefaultTask {
+    /** Path to the keystore containing the certificate that we sign Webstart JARs with. */
+    @Input
+    String keystorePath
+    
+    /** Password to access the keystore. */
+    @Input
+    String keystorePassword
+    
+    /** Name of the entry within the keystore associated with the certificate. */
+    @Input
+    String keystoreAlias
+    
+    /** The JARs to sign. */
+    @InputFiles
+    FileCollection sourceJars
+    
+    /** The directory where signed JARs will be created. */
+    @OutputDirectory
+    File outputDir
+    
+    SignJarsTask() {
+        group = 'Webstart'
+        description = "Digitally signs JAR files to make them suitable for use with Webstart."
+    }
+    
+    @TaskAction
+    def execute(IncrementalTaskInputs inputs) {
+        if (!inputs.incremental) {
+            project.delete(outputDir.listFiles())
+        }
+    
+        inputs.outOfDate { InputFileDetails outOfDate ->
+            deleteOutputFileCorrespondingTo outOfDate.file
+            sign outOfDate.file
+        }
+    
+        inputs.removed { InputFileDetails removed ->
+            deleteOutputFileCorrespondingTo removed.file
+        }
+    }
+    
+    void deleteOutputFileCorrespondingTo(File inputFile) {
+        def outputFile = project.file("$outputDir/${inputFile.name}")
+        if (outputFile.exists()) {
+            if (!outputFile.delete()) {
+                throw new GradleException("Couldn't delete '$file'.")
+            }
+        }
+    }
+    
+    void sign(File jarFile) {
+        // Limit to 2 iterations, just as a sanity check. The logic within the loop shouldn't allow for more.
+        for (int i : 1..2) {
+            try {
+                ant.signjar(jar: jarFile, keystore: keystorePath, storepass: keystorePassword, alias: keystoreAlias,
+                            destDir: outputDir, preservelastmodified: true, verbose: false)
+                return
+            } catch (BuildException e) {
+                // If jarFile is inside temporaryDir, that means it's a rejar created in the previous iteration.
+                // Unfortunately, jarsigner STILL failed to sign it, meaning that the failure is likely unrelated to
+                // duplicate entries. So, to avoid an infinite loop, we exit here. No point in rejarring a rejar.
+                if (jarFile.parentFile == temporaryDir) {
+                    throw new GradleException("jarsigner failed to sign '${jarFile.name}', even after rejarring it.", e)
+                }
+            
+                // The BuildException that we get when an Ant task fails isn't very helpful. In the case of signjar,
+                // it just has "e.message == 'jarsigner returned: 1'". e.cause and e.suppressed are both null.
+                // So, we can't find out exactly why the failure happened. We just have to assume it was dupes.
+                println "jarsigner failed to sign '${jarFile.name}', likely because it contains duplicate entries. " +
+                        "Removing dupes and trying again."
+                jarFile = rejar(jarFile, new File(temporaryDir, jarFile.name))
+            }
+        }
+        
+        assert false : "Control shouldn't have ever gotten here. WTF happened?"
+    }
+    
+    /**
+     * Creates a new JAR file at {@code destJarFile} containing the contents of {@code origJarFile}. Any duplicate
+     * entries in {@code origJarFile} will be excluded from {@code destJarFile}. Also, any old signature files
+     * (i.e. META-INF/*.DSA, META-INF/*.SF, META-INF/*.RSA) will be excluded.
+     *
+     * @param origJarFile the original JAR file.
+     * @param destJarFile the destination JAR file.
+     * @return {@code destJarFile}.
+     */
+    File rejar(File origJarFile, File destJarFile) {
+        JarFile origJar = new JarFile(origJarFile)
+        
+        origJar.withCloseable {
+            JarOutputStream jarOutStream = new JarOutputStream(
+                    new BufferedOutputStream(new FileOutputStream(destJarFile)))
+            
+            jarOutStream.withCloseable {
+                java.util.regex.Pattern signatureFilePattern = ~/META-INF\/.+\.(DSA|SF|RSA)/
+                Set<String> entriesWritten = new HashSet<>()
+                
+                for (JarEntry origJarEntry : origJar.entries()) {
+                    if (origJarEntry.name =~ signatureFilePattern) {
+                        logger.debug "Excluding signature file: $origJarEntry.name"
+                    } else if (!entriesWritten.add(origJarEntry.getName())) {
+                        logger.debug "Skipping duplicate entry: $origJarEntry.name"
+                    } else {
+                        copyEntry origJar, origJarEntry, jarOutStream
+                    }
+                }
+            }
+        }
+        
+        return destJarFile
+    }
+    
+    /**
+     * Copies a file entry from a source JAR to the output stream of a destination JAR.
+     *
+     * @param srcJar        the source JAR.
+     * @param jarEntry      a file entry within {@code srcJar}.
+     * @param jarOutStream  and output stream connected to a destination JAR.
+     */
+    void copyEntry(JarFile srcJar, JarEntry jarEntry, JarOutputStream jarOutStream) {
+        try {
+            jarOutStream.putNextEntry(jarEntry)
+            InputStream jarEntryInputStream = srcJar.getInputStream(jarEntry)
+            
+            jarEntryInputStream.withCloseable {
+                byte[] buffer = new byte[8192]
+                int bytesRead
+                
+                while ((bytesRead = jarEntryInputStream.read(buffer)) != -1) {
+                    jarOutStream.write(buffer, 0, bytesRead)
+                }
+            }
+        } finally {
+            jarOutStream.closeEntry()
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTask.groovy
@@ -63,7 +63,7 @@ class ToolsUiJnlpBaseTask extends DefaultTask {
     File outputFile
     
     ToolsUiJnlpBaseTask() {
-        group = 'Release'
+        group = 'Webstart'
         description = "Writes the base webstart (JNLP) file for ToolsUI."
     }
     
@@ -103,10 +103,8 @@ class ToolsUiJnlpBaseTask extends DefaultTask {
                     information() {
                         title('NetCDF ToolsUI')
                         vendor('Unidata')
-                        homepage(href: 'https://www.unidata.ucar.edu/' +
-                                       'software/thredds/current/netcdf-java/documentation.htm')
-                        description(kind: 'short', 'Graphical interface to netCDF-Java / Common Data Model')
-                        icon(href: 'nc.gif')
+                        homepage(href: "https://docs.unidata.ucar.edu/thredds/current/userguide/")
+                        description(kind: 'short', 'Graphical interface to NetCDF-Java / Common Data Model')
                         'offline-allowed'()
                     }
             

--- a/buildSrc/src/main/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTask.groovy
@@ -53,7 +53,7 @@ class ToolsUiJnlpExtensionTask extends DefaultTask {
     File outputFile
     
     ToolsUiJnlpExtensionTask() {
-        group = 'Release'
+        group = 'Webstart'
         description = "Writes the auxiliary webstart (JNLP) file for ToolsUI."
     }
     

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpBaseTaskSpec.groovy
@@ -34,7 +34,7 @@ class ToolsUiJnlpBaseTaskSpec extends Specification {
         and: "create a writer without application argument"
         ToolsUiJnlpBaseTask.Writer writer = new ToolsUiJnlpBaseTask.Writer()
         writer.with {
-            codebase = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart"
+            codebase = "https://artifacts.unidata.ucar.edu/repository/thredds-misc/current/webstart/"
             applicationVersion = '1.5'
             targetCompatibility = JavaVersion.VERSION_1_7
             extensionJnlpFileName = "netCDFtoolsExtraJars.jnlp"

--- a/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/ui/ToolsUiJnlpExtensionTaskSpec.groovy
@@ -58,7 +58,7 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
         and: "create a writer with the specified properties"
         ToolsUiJnlpExtensionTask.Writer writer = new ToolsUiJnlpExtensionTask.Writer()
         writer.with {
-            codebase = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart"
+            codebase = "https://artifacts.unidata.ucar.edu/repository/thredds-misc/current/webstart/"
             applicationVersion = rootProject.version
             applicationJarName = rootProject.jar.archiveName
             dependenciesConfig = rootProject.configurations.runtime
@@ -114,7 +114,7 @@ class ToolsUiJnlpExtensionTaskSpec extends Specification {
             }
             
             task $taskName(type: edu.ucar.build.ui.ToolsUiJnlpExtensionTask) {
-                codebase = 'https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart'
+                codebase = 'https://artifacts.unidata.ucar.edu/repository/thredds-misc/current/webstart/'
                 outputFile = file('${outputFile.name}')
             }
         """

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithOptionals.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithOptionals.jnlp
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="7.0" codebase="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart" version="1.5">
+<jnlp spec="7.0" codebase="https://artifacts.unidata.ucar.edu/repository/thredds-misc/current/webstart/" version="1.5">
     <information>
         <title>NetCDF ToolsUI</title>
         <vendor>Unidata</vendor>
-        <homepage href="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
-        <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
-        <icon href="nc.gif"/>
+        <homepage href="https://docs.unidata.ucar.edu/thredds/current/userguide/"/>
+        <description kind="short">Graphical interface to NetCDF-Java / Common Data Model</description>
         <offline-allowed/>
     </information>
     

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithoutOptionals.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpBaseWithoutOptionals.jnlp
@@ -3,9 +3,8 @@
     <information>
         <title>NetCDF ToolsUI</title>
         <vendor>Unidata</vendor>
-        <homepage href="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm"/>
-        <description kind="short">Graphical interface to netCDF-Java / Common Data Model</description>
-        <icon href="nc.gif"/>
+        <homepage href="https://docs.unidata.ucar.edu/thredds/current/userguide/"/>
+        <description kind="short">Graphical interface to NetCDF-Java / Common Data Model</description>
         <offline-allowed/>
     </information>
     

--- a/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpExtension.jnlp
+++ b/buildSrc/src/test/resources/edu/ucar/build/ui/toolsUiJnlpExtension.jnlp
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="7.0" codebase="https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart" version="1.5">
+<jnlp spec="7.0" codebase="https://artifacts.unidata.ucar.edu/repository/thredds-misc/current/webstart/" version="1.5">
     <component-desc/>
     
     <security>

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -119,6 +119,8 @@ gradle.projectsEvaluated {  // Evaluate all projects first so that SourceSets wi
 
 //////////////////////////////////////////////// Nexus ////////////////////////////////////////////////
 
+apply from: "$rootDir/gradle/any/properties.gradle"  // For Nexus credential properties.
+
 import edu.ucar.build.publishing.PublishToRawRepoTask
 
 tasks.withType(PublishToRawRepoTask).all {  // Common PublishToRawRepoTask config.
@@ -126,6 +128,14 @@ tasks.withType(PublishToRawRepoTask).all {  // Common PublishToRawRepoTask confi
     
     host = "https://artifacts.unidata.ucar.edu/"
     repoName = "thredds-doc"
+    
+    onlyIf {
+        // Will be evaluated at task execution time, not during configuration.
+        // Fails the build if the specified properties haven't been provided.
+        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+        return true
+    }
 }
 
 task publishUserGuide(type: PublishToRawRepoTask, dependsOn: buildUserGuide) {
@@ -172,21 +182,4 @@ task deleteFromNexus(type: DeleteFromNexusTask) {
     host = "https://artifacts.unidata.ucar.edu/"
     searchQueryParameters.repository = 'thredds-doc'
     searchQueryParameters.q = '*'  // Nuke everything in the repo.
-}
-
-apply from: "$rootDir/gradle/any/properties.gradle"  // For Nexus credential properties.
-
-// The above tasks require credentials for our Nexus server, which they look for in Gradle properties.
-// If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build will fail.
-// Therefore, we only want to configure the credentials when one of the above tasks is part of the execution plan.
-// Otherwise, unavailable credentials could cause a build to fail even if we aren't doing anything that interacts
-// with Nexus. The TaskExecutionGraph allows us to do that.
-gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
-    Collection<Task> nexusTasks = taskGraph.allTasks.findAll {
-        it instanceof PublishToRawRepoTask || it instanceof DeleteFromNexusTask }
-    
-    nexusTasks.each {
-        it.username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
-        it.password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
-    }
 }

--- a/gradle/any/properties.gradle
+++ b/gradle/any/properties.gradle
@@ -9,6 +9,13 @@ ext {
     // Used to publish static analysis report to https://sonarcloud.io/dashboard?id=thredds
     SONARQUBE_USER_TOKEN_KEY = 'sonarqube.user.token'
     
+    // Path to the keystore containing the certificate that we sign Webstart JARs with.
+    KEYSTORE_PATH = 'keystore.path'
+    // Password to access the keystore.
+    KEYSTORE_PASSWORD = 'keystore.password'
+    // Name of the entry within the keystore associated with the certificate.
+    KEYSTORE_ALIAS = 'keystore.alias'
+    
     // Do not propagate these system properties to the Gretty web-apps or Gradle test executors.
     systemPropertiesBlackList = [
             // Passing this causes "java.lang.ClassNotFoundException: org.jacoco.agent.rt.internal_932a715.PreMain"

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,12 +1,3 @@
-import com.google.common.collect.Iterables
-import edu.ucar.build.ui.ToolsUiJnlpBaseTask
-import edu.ucar.build.ui.ToolsUiJnlpExtensionTask
-import org.codehaus.groovy.runtime.NioGroovyMethods
-
-import java.util.jar.JarEntry
-import java.util.jar.JarFile
-import java.util.jar.JarOutputStream
-
 description = "Provides a graphical interface to much of the functionality in the CDM library."
 ext.title = "ToolsUI"
 
@@ -16,6 +7,7 @@ apply from: "$rootDir/gradle/any/testing.gradle"
 apply from: "$rootDir/gradle/any/coverage.gradle"
 apply from: "$rootDir/gradle/any/archiving.gradle"
 apply from: "$rootDir/gradle/any/publishing.gradle"
+apply from: "$rootDir/gradle/any/properties.gradle"  // For keystore and Nexus properties.
 
 dependencies {
     compile project(":cdm")
@@ -54,19 +46,16 @@ ext {
     // See http://docs.oracle.com/javase/8/docs/technotes/guides/javaws/developersguide/syntax.html#jnlp_elements
     // The Codebase attributes in the JAR manifest and JNLP must match, or else javaws fails to start with the error:
     // "Application Blocked by Java Security".
-    webstartCodebase = "https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/webstart/"
+    webstartCodebase = "https://artifacts.unidata.ucar.edu/repository/thredds-misc/$version/webstart/"
 
     // Webstart can also work if both Codebase attributes are unspecified.
     // Setting this property to null will produce a manifest and JNLP files with no Codebase attributes.
     // LOOK: Use this for local Webstart testing; use the other for deployment to production.
 //     webstartCodebase = null
 
-    webstartWorkingDir = "build/signed"
-    if (project.hasProperty("webdir")) {
-        webstartDir = new File(webdir, "webstart")
-    }
-
-    depsToRejar = ['xmlbeans-2.6.0.jar', 'Saxon-HE-9.4.0.6.jar']
+    webstartBuildDir  = file("$buildDir/webstart")
+    extensionJnlpFile = file("$webstartBuildDir/netCDFtoolsExtraJars.jnlp")
+    baseJnlpFile      = file("$webstartBuildDir/netCDFtools.jnlp")
 }
 
 jar {
@@ -98,141 +87,66 @@ jar {
     // LOOK: Does that make the 'Class-Path' manifest attribute and 'download="lazy"' JNLP attributes pointless?
 }
 
+import edu.ucar.build.ui.ToolsUiJnlpExtensionTask
+import edu.ucar.build.ui.ToolsUiJnlpBaseTask
+import edu.ucar.build.ui.SignJarsTask
+
 task toolsUiJnlpExtension(type: ToolsUiJnlpExtensionTask) {
     codebase = webstartCodebase
-    outputFile = file("$buildDir/webstart/netCDFtoolsExtraJars.jnlp")
+    outputFile = extensionJnlpFile
 }
 
 task toolsUiJnlpBase(type: ToolsUiJnlpBaseTask, dependsOn: toolsUiJnlpExtension) {
-    File toolsUiJnlpExtensionFile = Iterables.getOnlyElement(tasks.toolsUiJnlpExtension.outputs.files.files)
-
     codebase = webstartCodebase
-    extensionJnlpFileName = toolsUiJnlpExtensionFile.name
-    outputFile = file("$buildDir/webstart/netCDFtools.jnlp")
+    extensionJnlpFileName = extensionJnlpFile.name
+    outputFile = baseJnlpFile
 }
 
-/*
- * It's possible to test web start files locally before deploying them.
- * 1. Open your gradle.properties file (~/.gradle/gradle.properties) and change "webdir" to a local directory,
- *    such as '/Users/cwardgar/Desktop'
- * 2. Uncomment the 'webstartCodebase = null' line in the ext{} block above.
- * 3. Run this task: ./gradlew :ui:clean :ui:releaseWebstart
- * 4. You may need to white-list web starts from the local file system. Go to Java Control Panel->Security->
- *    Edit Site List... and add the entry "file:/".
- * 5. cd to "webdir" and execute "javaws netCDFtools.jnlp". You may also be able to simply double-click that file,
- *    but I couldn't get that working (and there was no error feedback).
- */
-/*
- * The following properties should be in gradle.properties:
- * keystore=name of keystore file
- * keystoreAlias=idv
- * keystorePassword=password of keystore file
- * webdir:parent of conan content directory
- */
-// TODO: Use the Sync task for this.
-task releaseWebstart(group: 'Release', dependsOn: ['jar', 'toolsUiJnlpExtension', 'toolsUiJnlpBase'])  {
-    doLast {
-        if (project.hasProperty("webdir") && project.hasProperty("keystore")
-                && project.hasProperty("keystoreAlias") && project.hasProperty("keystorePassword")) {
-            ant.delete(dir: webstartWorkingDir)
-            ant.mkdir(dir: webstartWorkingDir)
-
-            copy {
-                println "copyJnlp"
-                from Iterables.getOnlyElement(tasks.toolsUiJnlpExtension.outputs.files.files)
-                from Iterables.getOnlyElement(tasks.toolsUiJnlpBase.outputs.files.files)
-                from rootProject.file('docs/website/netcdf-java/nc.gif')
-                // Referenced in the ToolsUI base JNLP file.
-                into webstartWorkingDir
-            }
-
-            println "signjar:"
-            println "\twebdir = $webdir"
-            println "\tkeystore = $keystore"
-            println "\tkeystoreAlias = $keystoreAlias"
-            println "\tkeystorePassword = $keystorePassword"
-
-            ant.signjar(jar: tasks.jar.archivePath, destDir: webstartWorkingDir, alias: keystoreAlias,
-                    keystore: keystore, storepass: keystorePassword, preservelastmodified: true, verbose: false)
-
-            for (file in configurations.runtime.resolve()) {
-                if (depsToRejar.contains(file.name)) {
-                    println "$file contains duplicate entries or old signature files. Rejarring."
-
-                    File rejarredFile = new File(temporaryDir, file.name)
-                    rejar file, rejarredFile
-                    file = rejarredFile
-                }
-
-                println "Signing $file"
-                ant.signjar(jar: file, destDir: webstartWorkingDir, alias: keystoreAlias,
-                        keystore: keystore, storepass: keystorePassword, preservelastmodified: true, verbose: false)
-            }
-
-            ant.delete(dir: webstartDir)
-            ant.mkdir(dir: webstartDir)
-
-            copy {
-                println "copy2web"
-                from(webstartWorkingDir)
-                into webstartDir
-            }
-        } else {
-            println "Several properties (\"webdir\", \"keystore\", \"keystoreAlias\", \"keystorePassword\" )\n"
-            +"must be defined to run \"releaseWebstart\" task."
-        }
-    }
-
-}
-
-///////////////////////////////////////////////////////
-
-/**
- * Creates a new JAR file at {@code destJarFile} containing the contents of {@code origJarFile}. Any duplicate
- * entries in {@code origJarFile} will be excluded from {@code destJarFile}. Also, any old signature files
- * (i.e. META-INF/*.DSA, META-INF/*.SF, META-INF/*.RSA) will be excluded.
- *
- * @param origJarFile the original JAR file.
- * @param destJarFile the destination JAR file.
- */
-def rejar(File origJarFile, File destJarFile) {
-    JarFile origJar = new JarFile(origJarFile);
-
-    NioGroovyMethods.withCloseable(origJar) {
-        JarOutputStream jarOutStream = new JarOutputStream(
-                new BufferedOutputStream(new FileOutputStream(destJarFile)))
-
-        NioGroovyMethods.withCloseable(jarOutStream) {
-            java.util.regex.Pattern signatureFilePattern = ~/META-INF\/.+\.(DSA|SF|RSA)/
-            Set<String> entriesWritten = new HashSet<>()
-
-            for (JarEntry origJarEntry : origJar.entries()) {
-                if (origJarEntry.name =~ signatureFilePattern) {
-                    logger.debug "Excluding signature file: $origJarEntry.name"
-                } else if (!entriesWritten.add(origJarEntry.getName())) {
-                    logger.debug "Skipping duplicate entry: $origJarEntry.name"
-                } else {
-                    writeEntry origJar, origJarEntry, jarOutStream
-                }
-            }
-        }
+task signJars(type: SignJarsTask, dependsOn: jar) {
+    def jarsToSign = [ tasks.jar.archivePath ]          // ui-<version>.jar
+    jarsToSign.addAll configurations.runtime.resolve()  // All its dependencies.
+    
+    sourceJars = files(jarsToSign)
+    outputDir  = webstartBuildDir
+    
+    onlyIf {
+        // Will be evaluated at task execution time, not during configuration.
+        // Fails the build if the specified properties haven't been provided.
+        keystorePath     = getPropertyOrFailBuild KEYSTORE_PATH
+        keystorePassword = getPropertyOrFailBuild KEYSTORE_PASSWORD
+        keystoreAlias    = getPropertyOrFailBuild KEYSTORE_ALIAS
+        return true
     }
 }
 
-def writeEntry(JarFile jar, JarEntry jarEntry, JarOutputStream jarOutStream) {
-    try {
-        jarOutStream.putNextEntry(jarEntry);
-        InputStream jarEntryInputStream = jar.getInputStream(jarEntry)
+// It's possible to test Webstart files locally before publishing them.
+// 1. Uncomment the 'webstartCodebase = null' line in the ext{} block above.
+// 2. Run this task: ./gradlew :ui:buildWebstart
+// 3. You may need to whitelist Webstart locations that refer to the local file system.
+//    Go to "Java Control Panel->Security->Edit Site List..." and add the entry "file:/".
+// 4. Navigate to $webstartBuildDir and execute: javaws netCDFtools.jnlp
+task buildWebstart(group: "Webstart") {
+    description = "Create the JNLP and signed JARs needed for Webstart."
+    
+    // Aggregates other Webstart tasks.
+    dependsOn toolsUiJnlpExtension, toolsUiJnlpBase, signJars
+}
 
-        NioGroovyMethods.withCloseable(jarEntryInputStream) {
-            byte[] buffer = new byte[8192]
-            int bytesRead;
+import edu.ucar.build.publishing.PublishToRawRepoTask
 
-            while ((bytesRead = jarEntryInputStream.read(buffer)) != -1) {
-                jarOutStream.write(buffer, 0, bytesRead)
-            }
-        }
-    } finally {
-        jarOutStream.closeEntry()
+task publishWebstart(type: PublishToRawRepoTask, dependsOn: buildWebstart) {
+    group = "Webstart"
+    description = "Publish Webstart to Nexus."
+    
+    host = "https://artifacts.unidata.ucar.edu/"
+    repoName = "thredds-misc"
+    
+    srcFile = webstartBuildDir
+    destPath = "$version/webstart"
+    
+    onlyIf {
+        username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+        password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+        return true
     }
 }


### PR DESCRIPTION
* Refactored task that digitally signs JARs for Webstart.
  - Created a dedicated task in `:buildSrc` called `SignJarsTask`.
  - Expanded task's documentation.
  - Provided fine-grain incremental build support. The task will only run if the input changes. And even then, only the input that's been modified since last execution will be processed.
  - The list of JARs that need to be rejarred before signing is no longer hard-coded. That list could quickly become stale. Instead, we catch the exception raised when signing fails, rejar, then try again.
* Updated various URLs to point to docs.unidata.ucar.edu or artifacts.unidata.ucar.edu.
* Call `getPropertyOrFailBuild()` from within a task's `onlyIf{}`, not `gradle.taskGraph.whenReady{}`. Cleaner that way.
* Add `KEYSTORE_PATH`, `KEYSTORE_PASSWORD`, and `KEYSTORE_ALIAS` to `properties.gradle`.
* In `:ui`, nuke all code and comments that dealt with mounting a network share to publish Webstart. We're publishing to Nexus now!