### PR TITLE
Publish to raw repo using multipart POST requests, not individual PUTs

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ apply from: "../gradle/any/dependencies.gradle"
 apply from: "../gradle/any/coverage.gradle"
 
 dependencies {
-    compile libraries["http-builder-ng-core"]
+    compile libraries["http-builder-ng-okhttp"]  // For Nexus tasks.
     
     testCompile (libraries["spock-core"]) {
         // The Gradle API drags in the bundled version of Groovy that Gradle ships with (localGroovy()) –

--- a/buildSrc/src/main/groovy/edu/ucar/build/publishing/DeleteFromNexusTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/publishing/DeleteFromNexusTask.groovy
@@ -3,6 +3,7 @@ package edu.ucar.build.publishing
 import groovyx.net.http.ContentTypes
 import groovyx.net.http.FromServer
 import groovyx.net.http.HttpBuilder
+import groovyx.net.http.OkHttpBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.internal.tasks.options.Option
@@ -127,17 +128,9 @@ class DeleteFromNexusTask extends DefaultTask {
     }
     
     def destroy(List<Component> components) {
-        HttpBuilder http = HttpBuilder.configure {
+        HttpBuilder http = OkHttpBuilder.configure {
             request.uri = host
-            
-            // The DELETE command at '/rest/beta/components/$id' will not respond with an authentication challenge.
-            // Therefore, our authentication must be preemptive, which basically means pre-sending the Authorization
-            // header. The 'request.auth.basic()' method doesn't provide this functionality (it has a 'preemptive'
-            // argument, but it doesn't seem to do anything). This is probably because the underlying core, apache,
-            // and okhttp client libraries don't support preemptive auth out of the box. So, we must manually add the
-            // header ourselves.
-            // See https://www.javaworld.com/article/2092353/core-java/httpclient-basic-authentication.html
-            request.headers['Authorization'] = 'Basic ' + "$username:$password".bytes.encodeBase64().toString()
+            request.auth.basic username, password
         }
         
         components.each { Component component ->

--- a/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishToRawRepoTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishToRawRepoTaskSpec.groovy
@@ -13,20 +13,6 @@ import spock.lang.Specification
 class PublishToRawRepoTaskSpec extends Specification {
     private static final Logger logger = LoggerFactory.getLogger(PublishToRawRepoTaskSpec)
     
-    def "stripLeadingAndTrailingSlashes"() {
-        expect: 'empty string produces empty string'
-        PublishToRawRepoTask.stripLeadingAndTrailingSlashes('') == ''
-    
-        and: 'before and after stripped'
-        PublishToRawRepoTask.stripLeadingAndTrailingSlashes('/some/path/') == 'some/path'
-    
-        and: 'multiple stripped before, none stripped in middle '
-        PublishToRawRepoTask.stripLeadingAndTrailingSlashes('//bunch//of//slashes') == 'bunch//of//slashes'
-    
-        and: 'slash-only string produces empty string'
-        PublishToRawRepoTask.stripLeadingAndTrailingSlashes('/////') == ''
-    }
-    
     def "relativize"() {
         expect: 'common case'
         PublishToRawRepoTask.relativize(new File("/one/two/three/"), new File("/one/two/three/four/foo.txt")) ==
@@ -38,30 +24,6 @@ class PublishToRawRepoTaskSpec extends Specification {
         when: 'parent is not a prefix of child'
         PublishToRawRepoTask.relativize(new File("/one/two/"), new File("/three/four/baz.txt"))
         
-        then: 'an exception is thrown'
-        thrown(IllegalArgumentException)
-    }
-    
-    def "makeResourcePath"() {
-        expect: 'common case'
-        PublishToRawRepoTask.makeResourcePath("thredds-doc", "/5.0.0", new File("/thredds/docs/website"),
-                                              new File("/thredds/docs/website/netcdf-java/CDM/index.adoc")) ==
-                "/repository/thredds-doc/5.0.0/netcdf-java/CDM/index.adoc"
-    
-        and: 'empty destPath'
-        PublishToRawRepoTask.makeResourcePath("thredds-doc", "/", new File("/thredds/docs/website"),
-                                              new File("/thredds/docs/website/netcdf-java/CDM/index.adoc")) ==
-                "/repository/thredds-doc/netcdf-java/CDM/index.adoc"
-
-        and: 'srcBase == srcFile'
-        PublishToRawRepoTask.makeResourcePath("cdm-unit-test", "/some/dumb/prefix/",
-                                              new File("/thredds/docs/website/netcdf-java/CDM/index.adoc"),
-                                              new File("/thredds/docs/website/netcdf-java/CDM/index.adoc")) ==
-                "/repository/cdm-unit-test/some/dumb/prefix/index.adoc"
-        
-        when: 'repoName is empty'
-        PublishToRawRepoTask.makeResourcePath("", "5.0.0", new File("/one/two/bar.txt"), new File("/one/two/bar.txt"))
-    
         then: 'an exception is thrown'
         thrown(IllegalArgumentException)
     }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -23,10 +23,10 @@ dependencies {
 }
 
 ext {
-    userGuideSrc = file("src/public/userguide/").absolutePath
-    userGuideDest = file("$buildDir/userguide/").absolutePath
+    userGuideSrcDir = file("src/public/userguide/")
+    userGuideDestDir = file("$buildDir/userguide/")
     
-    commonFlags = [ '--source', userGuideSrc, '--destination', userGuideDest ]
+    commonFlags = [ '--source', userGuideSrcDir.absolutePath, '--destination', userGuideDestDir.absolutePath ]
 }
 
 import com.github.jrubygradle.JRubyExec
@@ -35,9 +35,8 @@ task buildUserGuide(type: JRubyExec) {
     group = "Documentation"
     description = 'Build user guide website.'
     
-    // Enable task to be UP-TO-DATE.
-    inputs.file userGuideSrc
-    outputs.file userGuideDest
+    inputs.files userGuideSrcDir
+    outputs.dir userGuideDestDir
     
     script "jekyll"
     
@@ -141,15 +140,15 @@ tasks.withType(PublishToRawRepoTask).all {  // Common PublishToRawRepoTask confi
 task publishUserGuide(type: PublishToRawRepoTask, dependsOn: buildUserGuide) {
     description = "Publish user guide to Nexus."
 
-    srcFile = file(userGuideDest)
-    destPath = "$version/userguide"
+    srcFile = userGuideDestDir
+    destPath = "$version/userguide/"
 }
 
 task publishJavadocCdm(type: PublishToRawRepoTask, dependsOn: buildJavadocCdm) {
     description = "Publish Javadoc for the CDM subproject to Nexus."
     
     srcFile = tasks.buildJavadocCdm.destinationDir
-    destPath = "$version/javadoc"
+    destPath = "$version/javadoc/"
 }
 
 gradle.projectsEvaluated {
@@ -160,7 +159,7 @@ gradle.projectsEvaluated {
         description = "Publish Javadoc for all Java subprojects to Nexus."
         
         srcFile = tasks.buildJavadocAll.destinationDir
-        destPath = "$version/javadocAll"
+        destPath = "$version/javadocAll/"
     }
     
     // We're deliberately NOT naming this task "publish", because we don't want it running when we do a:

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -183,7 +183,7 @@ libraries["commons-lang3"] = "org.apache.commons:commons-lang3:3.4"
 libraries["jj2000"] = "edu.ucar:jj2000:5.3"
 
 // The easy HTTP client for Groovy (and Java). Used in buildSrc.
-libraries["http-builder-ng-core"] = "io.github.http-builder-ng:http-builder-ng-core:1.0.0"
+libraries["http-builder-ng-okhttp"] = "io.github.http-builder-ng:http-builder-ng-okhttp:1.0.3"
 
 ////////////////////////////// TDS ///////////////////////////////////////////
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -142,7 +142,7 @@ task publishWebstart(type: PublishToRawRepoTask, dependsOn: buildWebstart) {
     repoName = "thredds-misc"
     
     srcFile = webstartBuildDir
-    destPath = "$version/webstart"
+    destPath = "$version/webstart/"
     
     onlyIf {
         username = getPropertyOrFailBuild NEXUS_USERNAME_KEY


### PR DESCRIPTION
Source files are packaged into a series of POST requests of roughly 5 MB. For small files--e.g. our Javadoc sets--this means that potentially hundreds of files will be sent to Nexus in the same request. This has shown dramatic speed increases for publishing "javadocAll" when compared to making one PUT request per file.

We're now publishing using the OkHttp HTTP client, not Java's built-in client. We needed this for the multipart POST requests. It's also allowed us to set the Authorization header in a simpler fashion.