### PR TITLE
Refactor and polish unsigned conversions

### DIFF
--- a/cdm/src/main/java/ucar/ma2/Array.java
+++ b/cdm/src/main/java/ucar/ma2/Array.java
@@ -1128,16 +1128,19 @@ public abstract class Array {
     StringBuilder sbuff = new StringBuilder();
     IndexIterator ii = getIndexIterator();
     while (ii.hasNext()) {
-      Object data = ii.getObjectNext();
-      if (data instanceof Number && isUnsigned()) {
-        // 'data' is unsigned, but will be treated as signed when we print it below, because Java only has signed
-        // types. If it is large enough ( >= 2^(BIT_WIDTH-1) ), its most-significant bit will be interpreted as the
-        // sign bit, which will result in an invalid (negative) value being printed. To prevent that, we're going
-        // to widen the number before printing it.
-        data = DataType.widenNumber((Number) data);
+      Object value = ii.getObjectNext();
+  
+      if (isUnsigned()) {
+        assert value instanceof Number : "A data type being unsigned implies that it is numeric.";
+    
+        // "value" is an unsigned number, but it will be treated as signed when we print it below, because Java only
+        // has signed types. If it's large enough ( >= 2^(BIT_WIDTH-1) ), its most-significant bit will be interpreted
+        // as the sign bit, which will result in an invalid (negative) value being printed. To prevent that, we're
+        // going to widen the number before printing it, but only if the unsigned number is being seen as negative.
+        value = DataType.widenNumberIfNegative((Number) value);
       }
 
-      sbuff.append(data);
+      sbuff.append(value);
       sbuff.append(" ");
     }
     return sbuff.toString();

--- a/cdm/src/main/java/ucar/ma2/MAMath.java
+++ b/cdm/src/main/java/ucar/ma2/MAMath.java
@@ -109,48 +109,6 @@ public class MAMath {
   }
 
   /**
-   * Convert unsigned data to signed data of a wider type.
-   *
-   * @param unsigned must be of type byte, short, int, or long.
-   * @return converted data of type short, int, long, or {@link java.math.BigInteger}.
-   */
-  public static Array convertUnsigned(Array unsigned) {
-    if (unsigned.getElementType().equals(byte.class)) {
-      Array result = Array.factory(DataType.SHORT, unsigned.getShape());
-      IndexIterator ii = result.getIndexIterator();
-      unsigned.resetLocalIterator();
-      while (unsigned.hasNext())
-        ii.setShortNext( DataType.widenNumber(unsigned.nextByte()).shortValue());
-      return result;
-
-    } else if (unsigned.getElementType().equals(short.class)) {
-      Array result = Array.factory(DataType.INT, unsigned.getShape());
-      IndexIterator ii = result.getIndexIterator();
-      unsigned.resetLocalIterator();
-      while (unsigned.hasNext())
-        ii.setIntNext( DataType.widenNumber(unsigned.nextShort()).intValue());
-      return result;
-
-    } else if (unsigned.getElementType().equals(int.class)) {
-      Array result = Array.factory(DataType.LONG, unsigned.getShape());
-      IndexIterator ii = result.getIndexIterator();
-      unsigned.resetLocalIterator();
-      while (unsigned.hasNext())
-        ii.setLongNext( DataType.widenNumber(unsigned.nextInt()).longValue());
-      return result;
-    } else if (unsigned.getElementType().equals(long.class)) {
-      Array result = ArrayObject.factory(DataType.OBJECT, BigInteger.class, false, Index.factory(unsigned.getShape()));
-      IndexIterator ii = result.getIndexIterator();
-      unsigned.resetLocalIterator();
-      while (unsigned.hasNext())
-        ii.setObjectNext( DataType.widenNumber(unsigned.nextLong()));
-      return result;
-    }
-
-    throw new IllegalArgumentException("Cant convertUnsigned type= "+unsigned.getElementType());
-  }
-
-  /**
    * Convert original array to desired type
    *
    * @param org original array

--- a/cdm/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/src/main/java/ucar/nc2/Attribute.java
@@ -111,16 +111,6 @@ public class Attribute extends CDMNode
   }
 
   /**
-   * Find whether the underlying data should be interpreted as unsigned.
-   * Only affects byte, short, and int.
-   *
-   * @return true if the data is unsigned integer type.
-   */
-  public boolean isUnsigned() {
-    return dataType.isUnsigned();
-  }
-
-  /**
    * Get the value as an Array.
    *
    * @return Array of values.
@@ -184,8 +174,7 @@ public class Attribute extends CDMNode
   }
 
   /**
-   * Retrieve numeric value.
-   * Equivalent to <code>getNumericValue(0)</code>
+   * Retrieve numeric value. Equivalent to <code>getNumericValue(0)</code>
    *
    * @return the first element of the value array, or null if its a String that cant be converted.
    */
@@ -196,10 +185,10 @@ public class Attribute extends CDMNode
   /// these deal with array-valued attributes
 
   /**
-   * Retrieve a numeric value by index. If its a String, it will try to parse it as a double.
+   * Retrieve a numeric value by index. If it's a String, it will try to parse it as a double.
    *
    * @param index the index into the value array.
-   * @return Number <code>value[index]</code>, or null if its a non-parsable String or
+   * @return Number <code>value[index]</code>, or null if its a non-parseable String or
    * the index is out of range.
    */
   public Number getNumericValue(int index) {
@@ -294,7 +283,7 @@ public class Attribute extends CDMNode
         if (i != 0) f.format(", ");
 
         Number number = getNumericValue(i);
-        if (isUnsigned()) {
+        if (dataType.isUnsigned()) {
           // 'number' is unsigned, but will be treated as signed when we print it below, because Java only has signed
           // types. If it is large enough ( >= 2^(BIT_WIDTH-1) ), its most-significant bit will be interpreted as the
           // sign bit, which will result in an invalid (negative) value being printed. To prevent that, we're going
@@ -303,7 +292,7 @@ public class Attribute extends CDMNode
         }
         f.format("%s", number);
 
-        if (isUnsigned()) {
+        if (dataType.isUnsigned()) {
           f.format("U");
         }
 
@@ -435,8 +424,7 @@ public class Attribute extends CDMNode
   public Attribute(String name, List values, boolean isUnsigned) {
     this(name);
     if(values == null || values.size() == 0)
-	throw new IllegalArgumentException("Cannot determine attribute's type");
-    int n = values.size();
+	  throw new IllegalArgumentException("Cannot determine attribute's type");
     Class c = values.get(0).getClass();
     setDataType(DataType.getType(c, isUnsigned));
     setValues(values);

--- a/cdm/src/test/java/ucar/ma2/TestDataType.java
+++ b/cdm/src/test/java/ucar/ma2/TestDataType.java
@@ -17,22 +17,6 @@ import java.math.BigInteger;
 public class TestDataType {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static void doone(String org) {
-    BigInteger biggy = new BigInteger(org);
-    long convert = biggy.longValue(); // > 63 bits will become "negative".
-    String convertS = DataType.unsignedLongToString(convert);
-    Assert.assertEquals(org, convertS);
-  }
-
-  @Test
-  public void testUnsignedLongToString () {
-    doone("18446744073709551615");
-    doone("18446744073709551614");
-    doone("18446744073709551613");
-    doone(Long.toString(Long.MAX_VALUE));
-    doone("0");
-  }
-
   @Test
   public void testUnsignedLongToBigInt() {
     Assert.assertEquals("The long round-trips as expected.",
@@ -46,5 +30,59 @@ public class TestDataType {
 
     Assert.assertEquals("Interpret signed long as unsigned long",
             overflowAsBigInt, DataType.unsignedLongToBigInt(overflowAsLong));
+  }
+  
+  @Test
+  public void convertUnsignedByte() {
+    // Widen regardless
+    assertSameNumber((short) 12, DataType.widenNumber((byte) 12));
+    
+    // Widen only if negative.
+    assertSameNumber((byte)  12,  DataType.widenNumberIfNegative((byte) 12));
+    assertSameNumber((short) 155, DataType.widenNumberIfNegative((byte) 155));
+    assertSameNumber((short) 224, DataType.widenNumberIfNegative((byte) -32));
+  }
+  
+  @Test
+  public void convertUnsignedShort() {
+    // Widen regardless
+    assertSameNumber((int) 3251, DataType.widenNumber((short) 3251));
+    
+    // Widen only if negative.
+    assertSameNumber((short) 3251,  DataType.widenNumberIfNegative((short) 3251));
+    assertSameNumber((int)   40000, DataType.widenNumberIfNegative((short) 40000));
+    assertSameNumber((int)   43314, DataType.widenNumberIfNegative((short) -22222));
+  }
+  
+  @Test
+  public void convertUnsignedInt() {
+    // Widen regardless
+    assertSameNumber((long) 123456, DataType.widenNumber((int) 123456));
+    
+    // Widen only if negative.
+    assertSameNumber((int)  123456,      DataType.widenNumberIfNegative((int) 123456));
+    assertSameNumber((long) 3500000000L, DataType.widenNumberIfNegative((int) 3500000000L));
+    assertSameNumber((long) 4289531025L, DataType.widenNumberIfNegative((int) -5436271));
+  }
+  
+  @Test
+  public void convertUnsignedLong() {
+    // The maximum signed long is 9223372036854775807.
+    // So, the number below fits in an unsigned long, but not a signed long.
+    BigInteger tenQuintillion = new BigInteger("10000000000000000000");  // Nineteen zeros.
+    
+    // Widen regardless
+    assertSameNumber(BigInteger.valueOf(3372036854775L), DataType.widenNumber((long) 3372036854775L));
+    
+    // Widen only if negative.
+    assertSameNumber(3372036854775L,                         DataType.widenNumberIfNegative((long) 3372036854775L));
+    assertSameNumber(tenQuintillion,                         DataType.widenNumberIfNegative(tenQuintillion.longValue()));
+    assertSameNumber(new BigInteger("18446620616920539271"), DataType.widenNumberIfNegative((long) -123456789012345L));
+  }
+  
+  // Asserts tha numbers have the same type and value.
+  private static void assertSameNumber(Number expected, Number actual) {
+    Assert.assertEquals(expected.getClass(), actual.getClass());
+    Assert.assertEquals(expected, actual);
   }
 }

--- a/cdm/src/test/java/ucar/ma2/TestMAMath.java
+++ b/cdm/src/test/java/ucar/ma2/TestMAMath.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -254,32 +253,5 @@ public class TestMAMath {
 
     // Null
     assertEquals(0, MAMath.hashCode(null));
-  }
-
-  @Test
-  public void convertUnsigned() {
-    Array unsignedBytes = Array.makeFromJavaArray(new byte[]  { 12, (byte) 155, -32 });
-    Array widenedBytes  = Array.makeFromJavaArray(new short[] { 12, 155,        224 });
-    assertTrue(MAMath.equals(widenedBytes, MAMath.convertUnsigned(unsignedBytes)));
-
-    Array unsignedShorts = Array.makeFromJavaArray(new short[] { 3251, (short) 40000, -22222 });
-    Array widenedShorts  = Array.makeFromJavaArray(new int[]   { 3251, 40000,         43314  });
-    assertTrue(MAMath.equals(widenedShorts, MAMath.convertUnsigned(unsignedShorts)));
-
-    Array unsignedInts = Array.makeFromJavaArray(new int[]  { 123456, (int) 3500000000L, -5436271    });
-    Array widenedInts  = Array.makeFromJavaArray(new long[] { 123456, 3500000000L,       4289531025L });
-    assertTrue(MAMath.equals(widenedInts, MAMath.convertUnsigned(unsignedInts)));
-
-    Array unsignedLongs = Array.makeFromJavaArray(new long[] {
-        // LONG.MAX_VALUE = 9223372036854775807
-        3372036854775L, new BigInteger("10000000000000000000").longValue(), -123456789012345L
-    });
-
-    Array widenedLongs = ArrayObject.factory(DataType.OBJECT, BigInteger.class, false, Index.factory(new int[] {3}));
-    widenedLongs.setObject(0, BigInteger.valueOf(3372036854775L));
-    widenedLongs.setObject(1, new BigInteger("10000000000000000000"));
-    widenedLongs.setObject(2, new BigInteger("18446620616920539271"));
-
-    assertTrue(MAMath.equals(widenedLongs, MAMath.convertUnsigned(unsignedLongs)));
   }
 }

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -2803,15 +2803,12 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   private void writeAttribute(int grpid, int varid, Attribute att, Variable v) throws IOException {
     if (v != null && att.getShortName().equals(CDM.FILL_VALUE)) {
       if (att.getLength() != 1) {
-        log.warn("_FillValue length must be one on var = " + v.getFullName());
+        log.warn("_FillValue length must be one on var = {}", v.getFullName());
         return;
       }
       if (att.getDataType() != v.getDataType()) {
-        log.warn("_FillValue type must agree with var = " + v.getFullName() + " type " + att.getDataType() + "!=" + v.getDataType());
-        return;
-      }
-      if (att.isUnsigned() != v.getDataType().isUnsigned()) {
-        log.warn("_FillValue isUnsigned must agree with var = " + v.getFullName() + " isUnsigned " + att.isUnsigned() + "!=" + v.getDataType().isUnsigned());
+        log.warn("_FillValue type ({}) does not agree with variable '{}' type ({}).",
+                att.getDataType(), v.getFullName(), v.getDataType());
         return;
       }
     }


### PR DESCRIPTION
* `DataType`'s unsigned conversion methods (named `unsignedXToY`) now defer to standard library methods that were added in JDK 8. Nuked our existing implementations.
* `DataType.widenNumber()`, in turn, employs those `unsignedXToY` methods. Greatly expanded its Javadoc.
* Also added `DataType.widenNumberIfNegative()`, which is similar to `widenNumber()`, but only widens when the argument is a negative, integral value. This is an optimization to improve performance.
* Added 4 new tests of the widen methods to `TestDataType`. Actually, they're not exactly new; they're the result of splitting apart the (now-deleted) `TestMAMath.convertUnsigned()`. That test logically had no business being in `TestMAMath`.
* After `TestMAMath.convertUnsigned()` was removed, the corresponding method `MAMath.convertUnsigned()` was no longer being used anywhere. No reason to keep it around. Nuked.
* Similarly, `DataType.unsignedLongToString()` wasn't being used anywhere, except in `TestDataType.testUnsignedLongToString()`. Nuked both.

* `Array.toString()` and `NcDumpW.printArray()` now use `DataType.widenNumberIfNegative()`. Improved nearby comments.

* Nuked `Attribute.isUnsigned()`. That info can be obtained via examining the `DataType` that's available via `Attribute.getDataType()`. This encourages users to work with `DataType` objects directly.
* Simplified `Nc4Iosp.writeAttribute()`, which was needlessly checking both `Attribute.getDataType()` and `Attribute.isUnsigned()`. `DataType` now includes signedness info! No need to check both. Besides, `Attribute.isUnsigned()` is no longer available.