### PR TITLE
handle case where coordinate axis does not have a type

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
@@ -176,11 +176,14 @@ public class Geostationary extends AbstractCoordTransBuilder {
 
       List<CoordinateAxis> cas = ds.getCoordinateAxes();
       for (CoordinateAxis ca : cas) {
-        if (ca.getAxisType().equals(AxisType.GeoX)) {
-          xScaleFactor = checkMapCoordinateUnits(ca);
-        } else if (ca.getAxisType().equals(AxisType.GeoY)) {
-          yScaleFactor = checkMapCoordinateUnits(ca);
-        }
+          AxisType axisType = ca.getAxisType();
+          if (axisType != null) {
+              if (ca.getAxisType().equals(AxisType.GeoX)) {
+                  xScaleFactor = checkMapCoordinateUnits(ca);
+              } else if (ca.getAxisType().equals(AxisType.GeoY)) {
+                  yScaleFactor = checkMapCoordinateUnits(ca);
+              }
+          }
       }
 
       ProjectionImpl proj = new ucar.unidata.geoloc.projection.sat.Geostationary(


### PR DESCRIPTION
For some coordinates in GOES-16 ABI files, netCDF-Java does not set a value for the `AxisType` (for example, `band_id`). This was causing an error in reading these files through `NetcdfDataset`. This was a bug introduced by PR Unidata/thredds#1023, which fixed GOES-16 full globe support.