### PR TITLE
automatically resize header and footer buffer to header/footer height…

### DIFF
--- a/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/CustomizingTds.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/CustomizingTds.md
@@ -48,20 +48,13 @@ To contribute a template fragment, place the `fragment` element in `templates/td
 
 *Example: Overwriting the default header*
 
-'template/tdstemplateFragments.html'
+'template/tdsTemplateFragments.html'
 ~~~html
 <div th:fragment="header">Your header content here</div>
 ~~~
 
-Note: The above example will replace the default TDS header with our own and exclude all default style for TDS headers.
-To include TDS style, the header fragment must invoke the classes `header` and `header-buffer` as follows:
-
-~~~html
-<div th:fragment="header">
-  <div class="header-buffer"></div>
-  <div class="header">Your header content here</div>
-</div>
-~~~
+Note: The templating system will automatically attach default TDS CSS properties to custom headers and footers;
+to avoid this behavior, users must provide their own overrides through custom stylesheets.
 
 Current default fragments which may be overridden are:
   * `header`

--- a/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
+++ b/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
@@ -370,7 +370,7 @@ class DatasetContext {
     String catUrl = ds.getCatalogUrl();
     if (catUrl.indexOf('#') > 0)
       catUrl = catUrl.substring(0, catUrl.lastIndexOf('#'));
-    this.catUrl = catUrl;
+    this.catUrl = catUrl.replace("xml", "html");
     this.catName = ds.getParentCatalog().getName();
 
     setContext(ds);

--- a/tds/src/main/webapp/WEB-INF/templates/catalog.html
+++ b/tds/src/main/webapp/WEB-INF/templates/catalog.html
@@ -26,7 +26,7 @@
 
     <div class="container">
 
-        <div th:replace="~{ext:tdsTemplateFragments :: header} ?: ~{templates/commonFragments :: header}"/>
+        <div th:replace="~{templates/commonFragments :: header-container}"/>
 
         <div class="content" th:if="${rootCatalog}">
             <div th:replace="~{ext:tdsTemplateFragments :: banner} ?: ~{templates/commonFragments :: banner}"/>
@@ -70,9 +70,12 @@
             <div th:replace="~{ext:tdsTemplateFragments :: catalogCustomContentBottom}"></div>
         </div>
 
-        <div th:replace="~{ext:tdsTemplateFragments :: footer} ?: ~{templates/commonFragments :: footer}"/>
+        <div th:replace="~{templates/commonFragments :: footer-container}"/>
 
     </div>
 
 </body>
+
+<script th:replace="~{templates/commonFragments :: load-scripts}"></script>
+
 </html>

--- a/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
@@ -15,25 +15,31 @@
 
   <!--/* This is a placeholder where our "script" block containing inline Javascript will be inserted. */-->
   <th:block th:replace="${scripts}" />
+
 </head>
 
 <body>
 
-    <div th:fragment="header">
-      <div class="header-buffer"></div>
-      <div class="header">
-        <div class="header-logo"><img th:src="${logoUrl}" th:alt="${logoAlt}"></div>
-        <div class="header-info"><h3><strong><a class="static" th:href="${webappUrl}" th:text="${webappName}"></a></strong></h3>
-          <h3><strong><a class="static" th:href="${installUrl}" th:text="${installName}"></a></strong></h3></div>
+    <div th:fragment="header-container">
+      <div id="header-buffer"></div>
+      <div id="header" th:insert="~{ext:tdsTemplateFragments :: header} ?: ~{templates/commonFragments :: header-content}">
       </div>
     </div>
 
-    <div th:fragment="footer">
-      <div class="footer-buffer"></div>
-      <div class="footer">
-        <h4><a class="static" th:href="${installUrl}" th:text="${installName}"></a> at <a class="static" th:href="${hostInstUrl}" th:text="${hostInst}"></a> see <a class="static" th:href="${contextPath} + '/serverInfo.html'"> Info </a></h4>
-        <h4><th:block th:text="${webappName} + ' [Version ' + ${webappVersion} + ' - ' + ${webappBuildTimestamp} + ']'"/><a class="static" th:href="${webappDocsUrl}"> Documentation</a></h4>
-      </div>
+    <div th:fragment="header-content">
+      <div class="header-logo"><img th:src="${logoUrl}" th:alt="${logoAlt}"></div>
+      <div class="header-info"><h3><strong><a class="static" th:href="${webappUrl}" th:text="${webappName}"></a></strong></h3>
+        <h3><strong><a class="static" th:href="${installUrl}" th:text="${installName}"></a></strong></h3></div>
+    </div>
+
+    <div th:fragment="footer-container">
+      <div id="footer-buffer"></div>
+      <div id="footer" th:insert="~{ext:tdsTemplateFragments :: footer} ?: ~{templates/commonFragments :: footer-content}"/>
+    </div>
+
+    <div th:fragment="footer-content">
+      <h4><a class="static" th:href="${installUrl}" th:text="${installName}"></a> at <a class="static" th:href="${hostInstUrl}" th:text="${hostInst}"></a> see <a class="static" th:href="${contextPath} + '/serverInfo.html'"> Info </a></h4>
+      <h4><th:block th:text="${webappName} + ' [Version ' + ${webappVersion} + ' - ' + ${webappBuildTimestamp} + ']'"/><a class="static" th:href="${webappDocsUrl}"> Documentation</a></h4>
     </div>
 
     <div th:fragment="banner" class="banner">
@@ -47,5 +53,10 @@
     </div>
 
 </body>
+
+<script th:fragment="load-scripts" type="text/javascript">
+  document.getElementById("header-buffer").style.height = document.getElementById("header").clientHeight + "px";
+  document.getElementById("footer-buffer").style.height = document.getElementById("footer").clientHeight + "px";
+</script>
 
 </html>

--- a/tds/src/main/webapp/WEB-INF/templates/dataset.html
+++ b/tds/src/main/webapp/WEB-INF/templates/dataset.html
@@ -51,7 +51,7 @@
 
     <div class="container">
 
-        <div th:replace="~{ext:tdsTemplateFragments :: header} ?: ~{templates/commonFragments :: header}"/>
+        <div th:replace="~{templates/commonFragments :: header-container}"/>
 
         <div th:replace="~{templates/datasetFragments :: returnButton}"/>
 
@@ -140,9 +140,12 @@
 
         <div th:replace="~{templates/datasetFragments :: returnButton}"/>
 
-        <div th:replace="~{ext:tdsTemplateFragments :: footer} ?: ~{templates/commonFragments :: footer}"/>
+        <div th:replace="~{templates/commonFragments :: footer-container}"/>
 
     </div>
 
 </body>
+
+<script th:replace="~{templates/commonFragments :: load-scripts}"></script>
+
 </html>

--- a/tds/src/main/webapp/tds.css
+++ b/tds/src/main/webapp/tds.css
@@ -213,7 +213,7 @@ small.imageinc {
    text-align: justify;
 }
 
-div.header, div.footer {
+div#header, div#footer {
     position: absolute;
     left: 0px;
     right: 0px;
@@ -225,29 +225,25 @@ div.header, div.footer {
     overflow: hidden;
 }
 
-div.header {
-    height: 94px;
+div#header {
     top: 0px;
     margin-bottom: 8px;
 }
 
-div.footer {
-    height: 90px;
+div#footer {
     bottom: 0px;
 }
 
 .header-logo {
     float: left;
-    margin-top: 1.2em;
 }
 
 .header-info {
     margin-left: 75px;
 }
 
-.footer-buffer, .header-buffer {
+#footer-buffer, #header-buffer {
     background-color:  #E3E4E6;
-    height: 90px;
     margin-top: 4px;
 }
 


### PR DESCRIPTION
- resize header/footer buffer to header/footer/height on page load
- default template provides header/footer containers and buffer; only header/footer content needs to be contributed for a custom header/footer
- header/footer are no longer fixed height
- docs updated to show the now simpler way to contribute header/footer