### PR TITLE
re-shade jna from chronicle-map

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -206,6 +206,13 @@ libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotatio
 libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.6"
 
 libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.15.1") {
+    // the version of jna shipped with chronicle-map requires GLIBC 2.14
+    // which prevents the use of the TDS on several versions of linux, such
+    // as CentOS and Hed Hat 6. We already include jna in netCDF-Java for
+    // netCDF-C support, so we will rely on that version instead.
+    // We should be able to get rid of this on the next release of chronicle-map,
+    // as their snapshot BOM pom shows that they pulled back on jna.
+    exclude group: 'net.java.dev.jna', module: 'jna'
     // We do not need XStream for our use of chronicle-map.
     // Nuke it.
     exclude group: 'com.thoughtworks.xstream', module: 'xstream'


### PR DESCRIPTION
the JNA issue with chronicle-map is back. I though it was fixed in the
latest release of chronicle-map, but I was wrong. Note that CentOS 6 is
supported until 2020, which means we won't really be able to get around
this for a bit :-/