### PR TITLE
make maven pom generation sort-of-work-ish

### DIFF
--- a/buildSrc/src/main/groovy/edu/ucar/build/publishing/PublishingUtil.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/publishing/PublishingUtil.groovy
@@ -164,7 +164,7 @@ abstract class PublishingUtil {
         pubs.each { MavenPublication pub ->
             MavenPomInternal pom = pub.pom
             MavenProjectIdentity projId = pom.projectIdentity
-            
+
             pub.artifacts.each { MavenArtifact artifact ->
                 if (!artifact.classifier) {
                     // This is the primary artifact, either a JAR or WAR. Obviously, we want to include it in the BOM.

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -24,16 +24,27 @@ publishing {
         
         threddsParent(MavenPublication) {  // Maven BOM publication
             artifactId 'thredds-parent'
-            
+
             pom.withXml{
                 List<Project> publishedProjects = allprojects*.findAll { it.plugins.withType(MavenPublishPlugin) }
                 List<MavenPublication> allPubs = publishedProjects.publishing.publications.flatten()
-                List<MavenPublication> webAndJavaPubs = allPubs.findAll {
-                    // Don't include threddsParent or any of the fatJar pubs in dependencyManagement.
-                    it.name.contains('Web') || it.name.contains('Java')
+
+                // Don't include threddsParent (and related), legacy, or any of the fatJar
+                // pubs in dependencyManagement.
+                def ignoreThesePubNames = ["d4ts",
+                                           "dap4lib",
+                                           "ncIdv",
+                                           "netcdfAll",
+                                           "tdmFat",
+                                           "threddsParent",
+                                           "toolsUI",
+                                           "legacy"]
+
+                List<MavenPublication> pubsToUseForBom = allPubs.findAll {
+                    !ignoreThesePubNames.contains(it.name)
                 }
-                
-                asNode().append PublishingUtil.createDependencyManagement(webAndJavaPubs)
+
+                asNode().append PublishingUtil.createDependencyManagement(pubsToUseForBom)
             }
         }
     }


### PR DESCRIPTION
Currently, the `thredds-parent` maven BOM generated by gradle has an empty dependency list. This PR addresses that, although not completely. Not all dependencies are added (for example, `sping-webmvc` does not show up, although `spring-core` does?). This at least gets a partial working BOM out there, which other projects depend on (like `ncSOS`). Getting a fully filled out BOM will be important for migrating `ncSOS` to v5.0 of the codebase, but for now, this takes us a long way towards that.