### PR TITLE
update edal-java (ncwms)

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -33,6 +33,11 @@ repositories {
     maven {
         url "https://dl.bintray.com/cwardgar/maven/"  // For "gretty".
     }
+
+    // edal-java SNAPSHOTS
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
 }
 
 //================================================ Dependencies ================================================//
@@ -233,7 +238,7 @@ libraries["oro"] = "oro:oro:2.0.8"
 // The latest version is 3.0.1.RELEASE. Can we update?
 libraries["thymeleaf-spring4"] = "org.thymeleaf:thymeleaf-spring4:3.0.2.RELEASE"
 
-versions["edal"] = "1.4.0"
+versions["edal"] = "1.4.2-SNAPSHOT"
 
 libraries["edal-common"] = "uk.ac.rdg.resc:edal-common:${versions["edal"]}"
 


### PR DESCRIPTION
This PR pulls in the latest SNAPSHOT of edal-java, which will allow ncWMS to work in TDS 5 again (fixes the issue mentioned [here](https://github.com/Unidata/thredds/pull/1111#issuecomment-401583852))