### PR TITLE
Prevent spaces in string names from being replaced with underscores

### DIFF
--- a/cdm/src/main/java/ucar/unidata/util/StringUtil2.java
+++ b/cdm/src/main/java/ucar/unidata/util/StringUtil2.java
@@ -164,9 +164,9 @@ public class StringUtil2 {
     boolean ok = true;
     for (int i = 0; i < name.length(); i++) {
       int c = name.charAt(i);
-      if (c < 0x20) ok = false;
-      if (c == '/') ok = false;
-      if (c == ' ') ok = false;
+      // if (c < 0x20) ok = false;
+      // if (c == '/') ok = false;
+      // if (c == ' ') ok = false;
       if (!ok) break;
     }
     if (ok) return name;


### PR DESCRIPTION
Prevent spaces and forward slashes in string names from being replaced with underscores.

Need this for an application that accesses HDF5 files via Java which are not NetCDF files.