### PR TITLE
fix chronicle-map on windows

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -168,6 +168,9 @@ libraries["je"] = "com.sleepycat:je:4.0.92"
 
 libraries["jna"] = "net.java.dev.jna:jna:4.2.2"
 
+// replaces the one that we exclude from chronicle-map
+libraries["jna-platform"] = "net.java.dev.jna:jna-platform:4.2.2"
+
 // replace by javax.time
 libraries["joda-time"] = "joda-time:joda-time:2.9.4"
 
@@ -218,6 +221,7 @@ libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.15
     // We should be able to get rid of this on the next release of chronicle-map,
     // as their snapshot BOM pom shows that they pulled back on jna.
     exclude group: 'net.java.dev.jna', module: 'jna'
+    exclude group: 'net.java.dev.jna', module: 'jna-platform'
     // We do not need XStream for our use of chronicle-map.
     // Nuke it.
     exclude group: 'com.thoughtworks.xstream', module: 'xstream'

--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     compile libraries["spring-core"]
     compile libraries["quartz"]
     compile libraries["chronicle-map"]
+    // because we exclude jna, jna-platfrom from chronicle-map, add
+    // our replacement libs here
+    compile libraries["jna"]
+    compile libraries["jna-platform"]
+
     compile libraries["jsr305"]
     compile libraries["guava"]
     compile libraries["protobuf-java"]


### PR DESCRIPTION
For windows, we need to ignore jna-platform from chronicle-map, and pull
in our own older version (all of this due to GLIBC incompatibilities and
new JNA).

This fixes an issue on windows in which the chronicle-map based `DatasetTracker` `datasetMap` object fails to initialize on windows and is null.