### PR TITLE
File decompression uses new class StringKeeper

### DIFF
--- a/cdm/src/main/java/ucar/nc2/StringLocker.java
+++ b/cdm/src/main/java/ucar/nc2/StringLocker.java
@@ -1,0 +1,43 @@
+package ucar.nc2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A list of strings that only allows one thread to use any given value at the same time.
+ *
+ * @author cmrose
+ */
+
+public class StringLocker {
+
+    private List stringList = Collections.synchronizedList(new ArrayList<String>());
+    private boolean waiting = false;
+
+    public synchronized void control(String item) {
+        // If the string is in use by another thread then wait() for the other thread to notify this thread it is done with it
+        waiting = stringList.contains(item);
+        while (waiting) {
+            try {
+                wait();
+            } catch (InterruptedException e)  {
+                Thread.currentThread().interrupt();
+            }
+        }
+        // Finished waiting so the thread can have the string
+        stringList.add(item);
+    }
+
+    public synchronized void release(String item) {
+        // Tell StringLocker the thread is done with the string
+        stringList.remove(item);
+        waiting = false;
+        notifyAll();
+    }
+
+    public String toString() {
+        return stringList.toString();
+    }
+
+}


### PR DESCRIPTION
File decompression uses new class StringKeeper to make sure a file is being handled only
by one thread at a time.  StringKeeper maintains a synchronised list of strings (in this case file paths) across threads.  When a thread wishes to access a file it can check the list to see if the file is already in use and thread wait() until a notifyAll() is received.  notifyAll() is sent when a thread finishes with a file.

This addresses the following issue:

While unzipping files other concurrent requests waiting for the file are unblocked prior to the file being unzipped causing issues trying to read half unzipped files.

The cause of the problem is a race condition between the caching system (FileCache.java) and the decompression in NetcdfFile.java. NetcdfFile.makeUncompressed() adequetely locks files across threads (by catching OverlappingFileLockException) to ensure mutiple threads do not attempt to decompress a file concurrently. However other threads trying to read from files (eg N3header.isValidFile, which results in the "not a valid CDM file" error) will not be aware that a file is still be written and end up reading wrong or no bytes. This is because the FileCache is not checking the file locks established during decompression.