### PR TITLE
Char valued _FillValue does not work

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/TestCharFillValue.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestCharFillValue.java
@@ -1,0 +1,83 @@
+/*********************************************************************
+ * Copyright 2018, UCAR/Unidata
+ * See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ ********************************************************************/
+
+/*
+The code that demonstrates the problem can be found below. The issue is due
+to the special checks we do for fill value in Nc4Iosp, specifically around
+line 2822 and line 2841. Thanks for taking a look!
+*/
+
+package ucar.nc2;
+
+import org.junit.Test;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayChar;
+import ucar.ma2.ArrayShort;
+import ucar.ma2.DataType;
+import ucar.nc2.iosp.hdf5.H5header;
+import ucar.unidata.util.test.UnitTestCommon;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TestCharFillValue extends UnitTestCommon
+{
+
+    static String fileName = "charAttr.nc4";
+    static String charVarName = "charVar";
+    static String charFillVal = "F";
+
+    @Test
+    public void
+    testCharFillValue()
+    {
+        try {
+            try (NetcdfFileWriter ncfw =
+                         NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf4, fileName);) {
+                Dimension charDim = ncfw.addDimension("charDim", 3);
+                Variable charVar = ncfw.addVariable(charVarName, DataType.CHAR,
+                        charDim.getFullName());
+                // works
+                Array charArray = ArrayChar.makeFromString(charFillVal, 1);
+                Attribute charAttr = new Attribute("charAttrName", charArray);
+                charVar.addAttribute(charAttr);
+                Array charArrayFillValue =
+                        ArrayChar.makeFromString(charFillVal, 1);
+                Attribute charAttrFillValue;
+		        // Try to do _FillValue two ways
+                if(true) {
+                    charAttrFillValue = new Attribute("_FillValue",
+                            charArrayFillValue);
+                } else {
+                    charAttrFillValue = new Attribute("_FillValue",DataType.CHAR);
+                    charAttrFillValue.setValues(charArrayFillValue);
+                }
+                charVar.addAttribute(charAttrFillValue);
+                ncfw.create();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            try (NetcdfFile ncf = NetcdfFile.open(fileName)) {
+                Variable charVarFromFile = ncf.findVariable(charVarName);
+                H5header.Vinfo h5 = (H5header.Vinfo)
+                        charVarFromFile.getSPobject();
+                System.out.println("use fill value: " + h5.useFillValue());
+                // should be 3 charFillVal characters
+                Array arr = charVarFromFile.read();
+                char[] javaArr = (char[]) arr.get1DJavaArray(DataType.CHAR);
+                String s = new String(javaArr);
+                System.out.println("expected fill value: " + charFillVal);
+                System.out.println("actual fill value: " + s.substring(0));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } finally {
+            File f = new File(fileName);
+            if(false && f.exists())
+                f.delete();
+        }
+    }
+}

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -2819,9 +2819,13 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
         return;
       }
       if (att.getDataType() != v.getDataType()) {
-        log.warn("_FillValue type ({}) does not agree with variable '{}' type ({}).",
+	    // Special case hack for _FillValue type match for char typed variables
+        if(att.getDataType() != DataType.STRING
+           || v.getDataType() != DataType.CHAR) {
+          log.warn("_FillValue type ({}) does not agree with variable '{}' type ({}).",
                 att.getDataType(), v.getFullName(), v.getDataType());
-        return;
+          return;
+        } // else char typed variable with string typed _FillValue
       }
     }
 
@@ -2839,13 +2843,27 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     Array values = att.getValues();
     switch (att.getDataType()) {
       case STRING: // problem may be that we are mapping char * atts to string type
-        if (att.getLength() == 1 && !att.getShortName().equals(CDM.FILL_VALUE)) {
-          byte[] svalb = att.getStringValue().getBytes(CDM.utf8Charset);
-          ret = nc4.nc_put_att_text(grpid, varid, att.getShortName(), new SizeT(svalb.length), svalb);
-        } else {
-          String[] svalues = new String[att.getLength()];
-          for (int i = 0; i < att.getLength(); i++) svalues[i] = (String) att.getValue(i);
-          ret = nc4.nc_put_att_string(grpid, varid, att.getShortName(), new SizeT(att.getLength()), svalues);
+        if(v != null
+	        && att.getShortName().equals(CDM.FILL_VALUE)
+           && att.getLength() == 1
+           && v.getDataType() == DataType.CHAR) {
+           // special handling of _FillValue if v.getDataType() == CHAR
+           byte[] svalb = att.getStringValue().getBytes(CDM.utf8Charset);
+           ret = nc4.nc_put_att_text(grpid, varid, att.getShortName(), new SizeT(svalb.length), svalb);
+        } else { // String valued attribute
+            if(this.version != NetcdfFileWriter.Version.netcdf4) {
+                // Must write it as character typed attribute
+                StringBuilder text = new StringBuilder();
+                // Concatenate all the attribute strings
+                for(int i=0;i<att.getLength();i++)
+                    text.append(att.getStringValue(i));
+                byte[] svalb = text.toString().getBytes(CDM.utf8Charset);
+                ret = nc4.nc_put_att_text(grpid, varid, att.getShortName(), new SizeT(svalb.length), svalb);
+            } else { // Can write as string typed attribute
+                String[] svalues = new String[att.getLength()];
+                for(int i = 0; i < att.getLength(); i++) svalues[i] = (String) att.getValue(i);
+                ret = nc4.nc_put_att_string(grpid, varid, att.getShortName(), new SizeT(att.getLength()), svalues);
+            }
         }
         break;
       case UBYTE:


### PR DESCRIPTION
re: e-support ticket (WWW-347958)

A char valued _FillValue attribute fails complaining of a type
mismatch with the corresponding char valued variable. It turns
out that the char valued attribute get "upgraded" to type
String, so the mismatch.

Fixing this required several sets of changes to the
Nc4Iosp.java#writeAttribute function.

1. At about line 2820, modify the type equality check for
   _FillValue to add a test for the case of variable type is CHAR
   and attribute type is String.
2. At about line 2845, switch case STRING check for _FillValue
   of type char.  If so, then use nc_put_att_text function in
   NC4prototypes.
3. if the file version is NetcdfFileWriter.Version.netcdf4 then
   use nc_put_att_string.
4. Else we have some variant of the netcdf classic format, which does not
   have a string type, so use nc_put_att_text.

Finally add a test case called TestCharFillValue.java.