### PR TITLE
ugly TdsMonitor hack

### DIFF
--- a/ui/src/main/java/ucar/nc2/ui/widget/UrlAuthenticatorDialog.java
+++ b/ui/src/main/java/ucar/nc2/ui/widget/UrlAuthenticatorDialog.java
@@ -122,7 +122,11 @@ public class UrlAuthenticatorDialog extends Authenticator implements Credentials
  public Credentials getCredentials(AuthScope scope)
  {
     serverF.setText(scope.getHost()+":"+scope.getPort());
-    realmF.setText(scope.getRealm());
+    String realmName = scope.getRealm();
+    if (realmName == null) {
+      realmName = "THREDDS Data Server";
+    }
+    realmF.setText(realmName);
     dialog.setVisible( true);
     if (pwa == null) throw new IllegalStateException();
     if (debug) {


### PR DESCRIPTION
get it working for the workshop, but this isn't right. Somewhere the realm info is getting set correctly on the first request, but dropped in subsequent requests. Not that it matters to the success of downloading logs, but it does seem to cause the authentication UI widget to bomb.