### PR TITLE
URL Encode (%XX) queries

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -29,7 +29,12 @@ import java.util.*;
 public class DatasetUrl {
   static final protected String alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   static final protected String slashalpha = "\\/" + alpha;
-  static final String[] FRAGPROTOCOLS = {"dap4", "dap2"};
+
+  static final String[] FRAGPROTOCOLS =
+          {"dap4", "dap2", "dods", "cdmremote", "thredds", "ncml"};
+  static final ServiceType[] FRAGPROTOSVCTYPE =
+          {ServiceType.DAP4, ServiceType.OPENDAP, ServiceType.OPENDAP, ServiceType.THREDDS, ServiceType.THREDDS, ServiceType.NCML};
+
 
   /**
    * Return the set of leading protocols for a url; may be more than one.
@@ -107,9 +112,11 @@ public class DatasetUrl {
     // Priority in deciding
     // the service type is as follows.
     // 1. "protocol" tag in fragment
-    // 2. leading protocol
-    // 3. path extension
-    // 4. contact the server (if defined)
+    // 2. specific protocol in fragment
+    // 3. leading protocol
+    // 4. path extension
+    // 5. "/thredds/XXX" in path
+    // 6. contact the server (if defined)
 
     // temporarily remove any trailing query or fragment
     String fragment = null;
@@ -130,6 +137,9 @@ public class DatasetUrl {
     if (svctype == null) // See if leading protocol tells us how to interpret
       svctype = decodeLeadProtocol(leadprotocol);
 
+    if (svctype == null) // See if path tells us how to interpret
+      svctype = searchPath(trueurl);
+
     if (svctype == null) {
       //There are several possibilities at this point; all of which
       // require further info to disambiguate
@@ -138,7 +148,7 @@ public class DatasetUrl {
       //  - we have a simple url: e.g. http://... ; contact the server
       if (leadprotocol.equals("file")) {
         svctype = decodePathExtension(trueurl); // look at the path extension
-        if (svctype == null && checkIfNcml(new File(location))) {
+        if(svctype == null && checkIfNcml(new File(location))) {
           svctype = ServiceType.NCML;
         }
       } else {
@@ -242,11 +252,30 @@ public class DatasetUrl {
   }
 
   /**
-   * Check path extension; assumes no query or fragment
+   * Given a url, search the path to look for protocol indicators
    *
-   * @param path the path to examine for extension
-   * @return ServiceType inferred from the extension or null
+   * @param url the url is to be examined
+   * @return The discovered ServiceType, or null
    */
+  static private ServiceType searchPath(String url) {
+      if(url == null || url.length() == 0)
+        return null;
+      url = url.toLowerCase(); // for matching purposes
+      for(int i=0; i<FRAGPROTOCOLS.length;i++) {
+        String p = FRAGPROTOCOLS[i];
+        if(url.indexOf("/thredds/"+p.toLowerCase()+"/")>= 0) {
+          return FRAGPROTOSVCTYPE[i];
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Check path extension; assumes no query or fragment
+     *
+     * @param path the path to examine for extension
+     * @return ServiceType inferred from the extension or null
+     */
   static private ServiceType decodePathExtension(String path) {
     // Look at the path extensions
     if (path.endsWith(".dds") || path.endsWith(".das") || path.endsWith(".dods"))
@@ -413,10 +442,11 @@ public class DatasetUrl {
       location = location.substring(0, location.length() - ".dap".length());
     else if (location.endsWith(".dmr"))
       location = location.substring(0, location.length() - ".dmr".length());
+    else if (location.endsWith(".dmr.xml"))
+      location = location.substring(0, location.length() - ".dmr.xml".length());
     else if (location.endsWith(".dsr"))
       location = location.substring(0, location.length() - ".dsr".length());
-
-    try (HTTPMethod method = HTTPFactory.Get(location + ".dmr")) {
+    try (HTTPMethod method = HTTPFactory.Get(location + ".dmr.xml")) {
       int status = method.execute();
       if (status == 200) {
         Header h = method.getResponseHeader("Content-Type");

--- a/httpservices/src/main/java/ucar/httpservices/HTTPMethod.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPMethod.java
@@ -210,7 +210,7 @@ public class HTTPMethod implements Closeable, Comparable<HTTPMethod>
         if(url == null)
             throw new HTTPException("HTTPMethod: cannot find usable url");
         try {
-            this.methodurl = HTTPUtil.parseToURI(url); /// validate
+            this.methodurl = new URI(Escape.escapeURL(url)); /// validate
         } catch (URISyntaxException mue) {
             throw new HTTPException("Malformed URL: " + url, mue);
         }

--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -81,9 +81,12 @@ import java.util.zip.ZipInputStream;
  * along with the method.
  * <p>
  * Note that the term legalurl in the following code means that the url has
- * reserved characters within identifieers in escaped form. This is
- * particularly and issue for queries. Especially: ?x[0:5] is legal and the
- * square brackets need not be encoded.
+ * reserved characters within identifiers in escaped form. This is
+ * particularly an issue for queries. Especially square brackets
+ * (e.g. ?x[0:5]) are an issue. Recently (2018) Apache Tomcat stopped
+ * accepting square brackets (and maybe other characters) as ok
+ * when left unencoded. So, now we need to be aware of this
+ * and cause queries encoding to include square brackets.
  * <p>
  * As of the move to Apache Httpclient 4.4 and later, the underlying
  * HttpClient objects are generally immutable. This means that at least


### PR DESCRIPTION
re: Issue https://github.com/Unidata/thredds/issues/1144

For DAP2 and DAP4 requests, encode at least
the query part because the square brackets are no
longer being accepted by the default Tomcat setup.

Turns out that some servers (e.g. http://iridl.ldeo.columbia.edu)
do not handle this correctly so some provision will have to be
made for this at some point.

In any case, the change is a one-liner in HTTPMethod.java, line 213:
-            this.methodurl = HTTPUtil.parseToURI(url); /// validate
+            this.methodurl = new URI(Escape.escapeURL(url)); /// validate

Misc. Unrelated changes:
1. Modify DatasetUrl.java to add a heuristic for choosing the
   protocol by searching the path for the string "/thredds/XXX/"
   where XXX is some protocol like dodsC or dap4.