### PR TITLE
encode urls by default 4.6

### DIFF
--- a/docs/website/netcdf-java/reference/DatasetUrls.html
+++ b/docs/website/netcdf-java/reference/DatasetUrls.html
@@ -14,6 +14,10 @@
 <p>The netCDF-Java library can read <em><strong>datasets</strong></em> from a variety of sources. The dataset is named using a Uniform Resource Location
   (<em><strong>URL</strong></em>). This page summarizes the netCDF-Java API use of URLs.</p>
 
+Note: When working with remote data services, it's important to note that not all servers handle encoded URLs.
+By default, netCDF-Java will encode illegal URI characters using percent encoding (e.g. <code>[</code> will become <code>%5B</code>).
+If you find you are having trouble accessing a remote dataset due to the encoding, set the java System Property <code>httpservices.urlencode</code> to <code>"false"</code> using, for example <code>System.setProperty("httpservices.urlencode", "false");</code>.
+
 <h2>ucar.nc2.NetcdfFile.open(String location) </h2>
 
 <h3>1. Local Files</h3>

--- a/httpservices/src/main/java/ucar/httpservices/HTTPMethod.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPMethod.java
@@ -203,13 +203,16 @@ public class HTTPMethod implements Closeable
     HTTPMethod(HTTPSession.Methods m, HTTPSession session, String url)
             throws HTTPException
     {
+
+        boolean escapeUrl = Boolean.valueOf(System.getProperty("httpservices.urlencode", "true"));
+
         url = HTTPUtil.nullify(url);
         if(url == null && session != null)
             url = session.getSessionURI();
         if(url == null)
             throw new HTTPException("HTTPMethod: cannot find usable url");
         try {
-            this.methodurl = HTTPUtil.parseToURI(url); /// validate
+            this.methodurl = escapeUrl ? new URI(Escape.escapeURL(url)) : new URI(url); /// validate
         } catch (URISyntaxException mue) {
             throw new HTTPException("Malformed URL: " + url, mue);
         }

--- a/opendap/src/test/java/ucar/nc2/dods/TestBennoGrid.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestBennoGrid.java
@@ -54,6 +54,9 @@ public class TestBennoGrid {
 
   @org.junit.Test
   public void testGrid() throws IOException, InvalidRangeException {
+
+    System.setProperty("httpservices.urlencode", "false");
+
     try (DODSNetcdfFile dodsfile = TestDODSRead.openAbs("http://iridl.ldeo.columbia.edu/SOURCES/.NOAA/.NCEP/.CPC/.GLOBAL/.daily/dods")) {
 
       Variable dataV = null;
@@ -72,6 +75,9 @@ public class TestBennoGrid {
       Array data = dataV.read("0, 0:72:1, 0:143:1");
       assert null != data;
     }
+
+    System.setProperty("httpservices.urlencode", "true");
+
   }
 
 }


### PR DESCRIPTION
add check for httpservices.urlencode property to allow users to not
encode requests.

addresses Unidata/thredds#1144 for 4.6.