### PR TITLE
fix constructor copy to pass in correct parameter

### DIFF
--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -199,7 +199,16 @@ public class Geostationary extends ProjectionImpl {
    */
   @Override
   public ProjectionImpl constructCopy() {
-    return new Geostationary(navigation.sub_lon_degrees, navigation.scan_geom, xScaleFactor, yScaleFactor);
+    // constructor takes sweep_angle_axis, so need to translate between
+    // scan geometry and sweep_angle_axis first
+    // GOES: x
+    // GEOS: y
+    String sweepAxisAngle = "x";
+    if (navigation.scan_geom == GEOSTransform.GEOS) {
+      sweepAxisAngle = "y";
+    }
+
+    return new Geostationary(navigation.sub_lon_degrees, sweepAxisAngle, xScaleFactor, yScaleFactor);
   }
 
   @Override


### PR DESCRIPTION
We were incorrectly passing in the scan_geometry (`GOES` or `GEOS`) rather than the sweep_angle_axis (`x` or `y`) in the constructor copy. The net effect is that all `GEOS` projections were being treated as `GOES` projections.