### PR TITLE
make sure scan_geom and sweep_angle_axis are properly tracked and used

### DIFF
--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
@@ -115,12 +115,15 @@ public class GEOSTransform {
                        double semi_major_axis,
                        double inverse_flattening,
                        String sweep_angle_axis) {
+
     Geoid geoid;
     if (Double.isNaN(inverse_flattening)) {
       geoid = new Geoid(semi_minor_axis, semi_major_axis);
     } else {
       geoid = new Geoid(semi_minor_axis, semi_major_axis, inverse_flattening);
     }
+
+    scan_geom = sweepAngleAxisToScanGeom(sweep_angle_axis);
 
     init(subLonDegrees, scan_geom, geoid, perspective_point_height);
   }
@@ -131,6 +134,9 @@ public class GEOSTransform {
                        double semi_major_axis,
                        String sweep_angle_axis) {
     Geoid geoid = new Geoid(semi_minor_axis, semi_major_axis);
+
+    scan_geom = sweepAngleAxisToScanGeom(sweep_angle_axis);
+
     init(subLonDegrees, scan_geom, geoid, perspective_point_height);
   }
 
@@ -361,6 +367,37 @@ public class GEOSTransform {
     return new double[]{fgf_x, fgf_y};
   }
 
+  /**
+   * Find sweep_angle_axis associated with a scan geometry
+   *
+   * @param scanGeometry scanning geometry (GOES or GEOS)
+   * @return sweep_angle_axis (x or y)
+   */
+  public static String scanGeomToSweepAngleAxis(String scanGeometry) {
+
+    String sweepAngleAxis = "y";
+    if (scanGeometry.equals(GOES)) {
+      sweepAngleAxis = "x";
+    }
+
+    return sweepAngleAxis;
+  }
+
+  /**
+   * Find scan geometry associated with sweep_angle_axis
+   *
+   * @param sweepAngleAxis sweep_angle_axis (x or y)
+   * @return scan_geom scanning geometry (GOES or GEOS)
+   */
+  public static String sweepAngleAxisToScanGeom(String sweepAngleAxis) {
+
+    String scanGeom = GOES;
+    if (sweepAngleAxis.equals("y")) {
+      scanGeom = GEOS;
+    }
+
+    return scanGeom;
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -108,9 +108,9 @@ public class Geostationary extends ProjectionImpl {
                        double yScaleFactor) {
     super(NAME, false);
 
-    String scanGeometry = GEOSTransform.GOES;
-    if (!isSweepX) {
-      scanGeometry = GEOSTransform.GEOS;
+    String sweepAngleAxis = "y";
+    if (isSweepX) {
+      sweepAngleAxis = "x";
     }
 
     /* Must assume incoming distances are SI units, so convert 'm' -> 'km' for GEOSTransform */
@@ -118,8 +118,7 @@ public class Geostationary extends ProjectionImpl {
     semi_minor_axis /= 1000.0;
     semi_major_axis /= 1000.0;
 
-    // double subLonDegrees, double perspective_point_height, double semi_minor_axis, double semi_major_axis, double inverse_flattening, String sweep_angle_axis
-    navigation = new GEOSTransform(subLonDegrees, perspective_point_height, semi_minor_axis, semi_major_axis, inv_flattening, scanGeometry);
+    navigation = new GEOSTransform(subLonDegrees, perspective_point_height, semi_minor_axis, semi_major_axis, inv_flattening, sweepAngleAxis);
     makePP();
 
     if (xScaleFactor > 0) {
@@ -149,10 +148,12 @@ public class Geostationary extends ProjectionImpl {
   public Geostationary(double subLonDegrees, boolean isSweepX) {
     super(NAME, false);
 
-    String scanGeometry = GEOSTransform.GOES;
-    if (!isSweepX) {
-      scanGeometry = GEOSTransform.GEOS;
+    String sweepAngleAxis = "y";
+    if (isSweepX) {
+      sweepAngleAxis = "x";
     }
+
+    String scanGeometry = GEOSTransform.sweepAngleAxisToScanGeom(sweepAngleAxis);
 
     navigation = new GEOSTransform(subLonDegrees, scanGeometry);
     makePP();
@@ -160,14 +161,8 @@ public class Geostationary extends ProjectionImpl {
 
   public Geostationary(double subLonDegrees, String sweepAngleAxis, double xScaleFactor, double yScaleFactor) {
     super(NAME, false);
-    String scanGeometry = GEOSTransform.GOES;
 
-    if (sweepAngleAxis.equals("x")) {
-       scanGeometry = GEOSTransform.GOES;
-    }
-    else if (sweepAngleAxis.equals("y")) {
-       scanGeometry = GEOSTransform.GEOS;
-    }
+    String scanGeometry = GEOSTransform.sweepAngleAxisToScanGeom(sweepAngleAxis);
 
     navigation = new GEOSTransform(subLonDegrees, scanGeometry);
 
@@ -189,7 +184,7 @@ public class Geostationary extends ProjectionImpl {
     addParameter(CF.LONGITUDE_OF_PROJECTION_ORIGIN, navigation.sub_lon_degrees);
     addParameter(CF.LATITUDE_OF_PROJECTION_ORIGIN, 0.0);
     addParameter(CF.PERSPECTIVE_POINT_HEIGHT, navigation.sat_height * 1000.0);
-    addParameter(CF.SWEEP_ANGLE_AXIS, navigation.scan_geom.equals(GEOSTransform.GOES) ? "x" : "y");
+    addParameter(CF.SWEEP_ANGLE_AXIS, GEOSTransform.scanGeomToSweepAngleAxis(navigation.scan_geom));
     addParameter(CF.SEMI_MAJOR_AXIS, navigation.r_eq * 1000.0);
     addParameter(CF.SEMI_MINOR_AXIS, navigation.r_pol * 1000.0);
   }
@@ -203,10 +198,7 @@ public class Geostationary extends ProjectionImpl {
     // scan geometry and sweep_angle_axis first
     // GOES: x
     // GEOS: y
-    String sweepAxisAngle = "x";
-    if (navigation.scan_geom == GEOSTransform.GEOS) {
-      sweepAxisAngle = "y";
-    }
+    String sweepAxisAngle = GEOSTransform.scanGeomToSweepAngleAxis(navigation.scan_geom);
 
     return new Geostationary(navigation.sub_lon_degrees, sweepAxisAngle, xScaleFactor, yScaleFactor);
   }


### PR DESCRIPTION
The `GEOSTransform` class was refactored in 2014, and while the types of the parameters in the signature of the constructors didn't change, the meaning of some of the parameters in some of the constructors did. Specifically, some constructors started taking the sweep angle axis (`x` or `y`) instead of the scan geometry (`GOES` or `GEOS`). 

Unidata/thredds#1198 addressed this in the copy constructor, but that was only a partial fix. This PR makes sure the correct parameter is passed into the `GEOSTransform` constructor, and ensures the scan geometry field inside `GOESTransform` is correctly set.

Special thanks to @phollemans for the pointers and feedback!