### PR TITLE
Dependency updates

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,11 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-   <suppress>
-      <notes><![CDATA[
-      file name: tdmFat-5.0.0-SNAPSHOT.jar
-      file name: tdm-5.0.0-SNAPSHOT.jar
-      ]]></notes>
-      <filePath regex="true">.*\/tdm.*\.jar</filePath>
-      <cpe>cpe:/a:tdm_project:tdm</cpe>
-   </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: tdmFat-5.0.0-SNAPSHOT.jar
+    file name: tdm-5.0.0-SNAPSHOT.jar
+    reason: not related to the THREDDS Data Manager (TDM), but a different tdm.
+    ]]></notes>
+    <filePath regex="true">.*\/tdm.*\.jar</filePath>
+    <cpe>cpe:/a:tdm_project:tdm</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: affinity-3.1.10.jar
+    reason: CVE in mintToken function of a smart contract implementation for Thread, an Ethereum token.
+            not related to the Java Thread Affinity library pulled in my chronicle-map.
+    ]]></notes>
+    <filePath regex="true">.*\/affinity.*\.jar</filePath>
+    <cve>CVE-2018-13752</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: affinity pom
+    reason: CVE in mintToken function of a smart contract implementation for Thread, an Ethereum token.
+            not related to the Java Thread Affinity library pulled in my chronicle-map.
+    ]]></notes>
+    <filePath regex="true">.*\/net.openhft\/affinity\/pom.xml</filePath>
+    <cve>CVE-2018-13752</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: org.slf4j:slf4j-api:1.8.0-beta2
+    reason: The CVE-80888 report says this is fixed in beta2, so false positive
+    ]]></notes>
+    <filePath regex="true">.*\/slf4j-api-1.8.0-beta2.jar</filePath>
+    <cve>CVE-2018-8088</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: org.slf4j:/jcl-over-slf4j:1.8.0-beta2
+    reason: The CVE-80888 report says this is fixed in beta2, so false positive
+    ]]></notes>
+    <filePath regex="true">.*\/jcl-over-slf4j-1.8.0-beta2.jar</filePath>
+    <cve>CVE-2018-8088</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: pax-url-aether jcl-over-slf4j pom
+    reason: we override the version of jcl-over-slf4j, so the one listed in this pom is not actually being used.
+    ]]></notes>
+    <filePath regex="true">.*pax-url-aether-2.4.5.jar\/META-INF\/maven\/org.slf4j\/jcl-over-slf4j\/pom.xml</filePath>
+    <cve>CVE-2018-8088</cve>
+  </suppress>
 </suppressions>

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -103,7 +103,7 @@ libraries["52n-xml-sampling-v20"] = "org.n52.sensorweb:52n-xml-sampling-v20:${ve
 
 ////////////////////////////////////////// Logging //////////////////////////////////////////
 
-versions["slf4j"] = "1.7.25"
+versions["slf4j"] = "1.8.0-beta2"
 
 libraries["slf4j-api"] = "org.slf4j:slf4j-api:${versions["slf4j"]}"
 
@@ -336,13 +336,6 @@ configurations.all {
                 dep.useTarget libraries["jcl-over-slf4j"]
             }
         }
-
-        // Force the use of org.slf4j:slf4j-api:1.7.25 (over 1.8.0-alpha2) due to vulnerability.
-        // alpha2 is pulled in by org.apache.logging.log4j:log4j-slf4j-impl, which we pull in
-        // and is currently at the latest version. if we bump to 1.8.0-alpha2, many libraries that
-        // depend on slj4j break. See: https://github.com/gatling/gatling/issues/3290
-        // So, our only option is to override it with the latest 1.7.x version...for now...
-        force 'org.slf4j:slf4j-api:1.7.25'
     }
     
     // STAX is already included in Java 1.6+; no need for a third-party depenency.

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -213,7 +213,7 @@ libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.7"
 libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.9.7"
 libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.7"
 
-libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.15.1") {
+libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.0") {
     // the version of jna shipped with chronicle-map requires GLIBC 2.14
     // which prevents the use of the TDS on several versions of linux, such
     // as CentOS and Hed Hat 6. We already include jna in netCDF-Java for
@@ -223,7 +223,7 @@ libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.15
     exclude group: 'net.java.dev.jna', module: 'jna'
     exclude group: 'net.java.dev.jna', module: 'jna-platform'
     // We do not need XStream for our use of chronicle-map.
-    // Nuke it.
+    // Nuke it. [SEC]
     exclude group: 'com.thoughtworks.xstream', module: 'xstream'
 }
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -225,6 +225,9 @@ libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17
     // We do not need XStream for our use of chronicle-map.
     // Nuke it. [SEC]
     exclude group: 'com.thoughtworks.xstream', module: 'xstream'
+    // We do not need pax-url-aether
+    // Nuke it. [SEC]
+    exclude group: 'org.ops4j.pax.url', module: 'pax-url-aether'
 }
 
 libraries["javax.servlet-api"] = "javax.servlet:javax.servlet-api:3.1.0"


### PR DESCRIPTION
These dependency updates fix some security issues as well as allow us to run the TDS on java 11 (not build, but run). This has been tested on Jenkins.