### PR TITLE
Change Slf4j version

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -103,7 +103,7 @@ libraries["52n-xml-sampling-v20"] = "org.n52.sensorweb:52n-xml-sampling-v20:${ve
 
 ////////////////////////////////////////// Logging //////////////////////////////////////////
 
-versions["slf4j"] = "1.7.9"
+versions["slf4j"] = "1.7.25"
 
 libraries["slf4j-api"] = "org.slf4j:slf4j-api:${versions["slf4j"]}"
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -103,7 +103,7 @@ libraries["52n-xml-sampling-v20"] = "org.n52.sensorweb:52n-xml-sampling-v20:${ve
 
 ////////////////////////////////////////// Logging //////////////////////////////////////////
 
-versions["slf4j"] = "1.8.0-beta2"
+versions["slf4j"] = "1.7.9"
 
 libraries["slf4j-api"] = "org.slf4j:slf4j-api:${versions["slf4j"]}"
 


### PR DESCRIPTION
Starting up ToolsUI:

### SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions prior to 1.8.
SLF4J: Ignoring binding found at [jar:file:/usr/local/google/home/jlcaron/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.3/7c4f3c474fb2c041d8028740440937705ebb473a/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#ignoredBindings for an explanation.

The problem is that slf4j 1.8 is jigsaw-ready, and not compatible with logback 1.2.3
And the next version of logback is still in alpha:

EXPERIMENTAL version compatible with SLF4J 1.8.x (Jigsaw/Java9 modular)
Download logback version 1.3.0-alpha4 including full source code, class files and documentation in ZIP or TAR.GZ format:

So the right thing is to revert slf4j to 1.7. Can revisit when we start supporting Jigsaw (JDK 9+), and logback is out of alpha.

