### PR TITLE
Upgrade jackson, guava, c3p0 dependencies on 5.0

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -51,4 +51,23 @@
     <filePath regex="true">.*pax-url-aether-2.4.5.jar\/META-INF\/maven\/org.slf4j\/jcl-over-slf4j\/pom.xml</filePath>
     <cve>CVE-2018-8088</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name: toolsUI-*.jar
+      reason: toolsUI isn't data-tools -> https://github.com/clarkgrubb/data-tools/
+      ]]></notes>
+    <filePath regex="true">.*\/toolsUI.*\.jar</filePath>
+    <cve>CVE-2018-18749</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name: tds-*.war: ehcache-2.10.6.jar/rest-management-private-classpath/META-INF/maven/com.fasterxml.jackson.core/jackson-databind/pom.xml
+      reason: ehcache server not used, so safe to ignore (see https://groups.google.com/forum/#!category-topic/ehcache-users/pafTyMJIngI, https://github.com/jeremylong/DependencyCheck/issues/517)
+      ]]></notes>
+    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2.9.6.*$</gav>
+    <cve>CVE-2018-1000873</cve>
+    <cve>CVE-2018-14719</cve>
+    <cve>CVE-2018-14720</cve>
+    <cve>CVE-2018-14721</cve>
+  </suppress>
 </suppressions>

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -153,7 +153,7 @@ libraries["mockito"] = "org.mockito:mockito-core:2.+"
 // See https://github.com/coverity/coverity-security-library
 libraries["coverity-escapers"] = "com.coverity.security:coverity-escapers:1.1.1"
 
-libraries["guava"] = "com.google.guava:guava:25.1-jre"
+libraries["guava"] = "com.google.guava:guava:27.0.1-jre"
 
 libraries["httpclient"] = "org.apache.httpcomponents:httpclient:4.5.2"
 
@@ -213,9 +213,9 @@ libraries["aws-java-sdk-s3"] = dependencies.create("com.amazonaws:aws-java-sdk-s
 }
 
 // replace the jackson.core libs that were excluded from aws-java-sdk-s3
-libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.7"
-libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.9.7"
-libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.7"
+libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.8"
+libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.9.8"
+libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.8"
 
 libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.0") {
     // the version of jna shipped with chronicle-map requires GLIBC 2.14
@@ -290,7 +290,15 @@ libraries["threddsIso"] = "EDS:threddsIso:2.3.0-SNAPSHOT"
 
 libraries["Saxon-HE"] = "net.sf.saxon:Saxon-HE:9.7.0-8"
 
-libraries["quartz"] = "org.quartz-scheduler:quartz:2.2.3"
+libraries["quartz"] = dependencies.create("org.quartz-scheduler:quartz:2.2.3") {
+    // exclude c3p0 deps so that they can be overridden
+    // with 0.9.5.3 to address a potential security issue.
+    // See https://github.com/swaldman/c3p0/issues/123
+    exclude group: 'com.mchange', module: 'c3p0'
+}
+
+// replace the c3p0 lib that were excluded from quartz
+libraries["c3p0"] = "com.mchange:c3p0:0.9.5.3"
 
 // Version update note:
 // spring-context 4.x is limited to hibernate-validator 4.3.2.Final. We can't update to hibernate-validator 5.x

--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile libraries["jdom2"]        // Required for reading THREDDS, NcML, BUFR, HDF-EOS, NEXRAD2, OPeNDAP files.
     compile libraries["spring-core"]
     compile libraries["quartz"]
+    compile libraries["c3p0"] // needed to replace the excluded version from quartz
     compile libraries["chronicle-map"]
     // because we exclude jna, jna-platfrom from chronicle-map, add
     // our replacement libs here

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile libraries["coverity-escapers"]
     compile libraries["jdom2"]
     compile libraries["quartz"]
+    compile libraries["c3p0"] // needed to replace the excluded version from quartz
     compile libraries["jsr305"]
     compile libraries["guava"]
     compile libraries["joda-time"]


### PR DESCRIPTION
Also, tweak dependency check suppression file to stop false positive OWASP alert on Jenkins. Basically the same PR as the 4.6 version (Unidata/thredds#1213) but for 5.0.