### PR TITLE
Fixed typo for TLS in the docs

### DIFF
--- a/docs/src/private/website/tds/tutorial/Security.adoc
+++ b/docs/src/private/website/tds/tutorial/Security.adoc
@@ -15,7 +15,7 @@ server:
 Permissions]
 * link:#unused[Removing Unused Web Applications]
 * link:#digested[Using Digested Passwords]
-* link:#ssl[Enabling TSL/SSL Encryption]
+* link:#ssl[Enabling TLS/SSL Encryption]
 * link:#manager[Securing the Tomcat `manager` Application]
 * link:#ports[Blocking Non-Essential Port Access At The Firewall]
 * link:#access[Restricting Access To The TDS By Remote IP Address Or
@@ -224,13 +224,13 @@ sure it is well-formed and without error.
 the browser (the browser auto-magically encrypts your password for you
 before it transmits it to the server).
 
-== Enabling TSL/SSL Encryption
+== Enabling TLS/SSL Encryption
 
-=== How TSL/SSL works
+=== How TLS/SSL works
 
 For more information on how SSL works, Wikipedia details the
 http://en.wikipedia.org/wiki/Transport_Layer_Security[steps involved]
-during an TSL/SSL transaction.
+during an TLS/SSL transaction.
 
 === Rationale
 
@@ -248,12 +248,12 @@ to view the message).
 * Transport Layer Security (TLS), and formerly Secure Sockets Layer
 (SSL), is a cryptographic protocol that provides security and data
 integrity for communications over TCP/IP networks.
-* TSL/SSL allows applications to communicate across a network in a way
+* TLS/SSL allows applications to communicate across a network in a way
 designed to prevent eavesdropping, tampering, and message forgery.
-* TSL/SSL uses a cryptographic system that uses two keys to encrypt
+* TLS/SSL uses a cryptographic system that uses two keys to encrypt
 data: a public key known to everyone and a private or secret key known
 only to the recipient of the message.
-* By convention, URLs that require an TSL/SSL connection start with
+* By convention, URLs that require an TLS/SSL connection start with
 `https` instead of `http`.
 
 ==== CA-signed Certificates
@@ -264,7 +264,7 @@ say I am.''_
 A certificate signed by a CA says, _``Trust me - the CA agrees I am who
 I say I am.''_
 
-=== TSL/SSL certificates
+=== TLS/SSL certificates
 
 * A public key certificate is an electronic document which incorporates
 a digital signature to bind together a public key with identity
@@ -289,12 +289,12 @@ compromised certificate, which prevents its further use.
 
 === Certificate `keystore` file
 
-* A `keystore` file stores the details of the TSL/SSL certificate
+* A `keystore` file stores the details of the TLS/SSL certificate
 necessary to make the protocol secured.
 * The Tomcat documentation includes a section on
 http://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html#Prepare_the_Certificate_Keystore[importing
 your certificate into a keystore] file.
-* Tomcat uses the `keystore` file for TSL/SSL transactions. Example:
+* Tomcat uses the `keystore` file for TLS/SSL transactions. Example:
 
 -------------------------------------------------------------
  <Connector protocol="HTTP/1.1" port="8443" maxThreads="200"
@@ -304,12 +304,12 @@ your certificate into a keystore] file.
     clientAuth="false" sslProtocol="TLS"/>
 -------------------------------------------------------------
 
-==== Enabling TSL/SSL in Tomcat
+==== Enabling TLS/SSL in Tomcat
 
-Modify the Tomcat configuration to enable TSL/SSL:
+Modify the Tomcat configuration to enable TLS/SSL:
 
 Based on what we know about Tomcat configuration, which file in
-`${tomcat_home}/conf` should we edit to to enable TSL/SSL?
+`${tomcat_home}/conf` should we edit to to enable TLS/SSL?
 
 Open `${tomcat_home}/conf/server.xml` with your favorite editor:
 
@@ -318,7 +318,7 @@ $ vi server.xml
 ---------------
 
 Locate the `Java HTTP/1.1 Connector` listening on port 8080 and verify
-it is redirecting TSL/SSL traffic to port 8443:
+it is redirecting TLS/SSL traffic to port 8443:
 
 ------------------------------------
 <Connector port="8080"
@@ -372,7 +372,7 @@ specify the new password so Tomcat can open the file:
            keystorePass="foobar" />
 ----------------------------------------------------------------------
 
-Verify TSL/SSL has been enabled.
+Verify TLS/SSL has been enabled.
 
 Restart Tomcat:
 
@@ -418,18 +418,18 @@ error: `java.io.IOException: Cannot recover key`.
 * Did you restart Tomcat after you made your changes to `server.xml`?
 * Did you specify the full path to the `keystore` file in `server.xml`?
 
-=== Configuring web applications for TSL/SSL
+=== Configuring web applications for TLS/SSL
 
 ==== Looking Ahead
 
 Other than the compelling security reasons, you will want to enable
-TSL/SSL to take advantage of a couple of monitoring and debugging tools:
+TLS/SSL to take advantage of a couple of monitoring and debugging tools:
 the http://localhost:8080/thredds/admin/debug[TDS Remote Management
 Tool], and the <<tdsMonitor#,TdsMonitor Tool>> – both of which
-(out-of-the-box) require TSL/SSL to access.
+(out-of-the-box) require TLS/SSL to access.
 
 The web application deployment descriptor, aka `web.xml`, specifies if
-all or parts of it need to be accessed via TSL/SSL.
+all or parts of it need to be accessed via TLS/SSL.
 
 Deployment descriptors are found in the `WEB-INF` directory of the web
 application: `${tomcat_home}/webapps/application_name/WEB-INF/web.xml`.
@@ -438,7 +438,7 @@ By convention, Tomcat and other servlet containers will read the web
 application deployment descriptors for initialization parameters and
 container-managed security constraints upon application deployment.
 
-_The TDS has been pre-configured to require that TSL/SSL encryption is
+_The TDS has been pre-configured to require that TLS/SSL encryption is
 enabled in order to access the both the
 http://localhost:8080/thredds/admin/debug[TDS Remote Management Tool],
 and the <<tdsMonitor#,TdsMonitor Tool>>._
@@ -484,7 +484,7 @@ client and server.
 
 1.  Specify `CONFIDENTIAL` when the application requires that data be
 transmitted so as to prevent other entities from observing the contents
-of the transmission. (E.g., via TSL/SSL.)
+of the transmission. (E.g., via TLS/SSL.)
 2.  Specify `INTEGRAL` when the application requires that the data be
 sent between client and server in such a way that it cannot be changed
 in transit.
@@ -494,15 +494,15 @@ constrained requests on any connection, including an unprotected one.
 ===== Accessing TDS Monitoring and Debugging Tools
 
 Other than the compelling security reasons, you will want to enable
-TSL/SSL to take advantage of a couple of monitoring and debugging tools:
+TLS/SSL to take advantage of a couple of monitoring and debugging tools:
 the http://localhost:8080/thredds/admin/debug[TDS Remote Management
 Tool], and the <<tdsMonitor#,TdsMonitor Tool>> – both of which
-(out-of-the-box) require TSL/SSL to access.
+(out-of-the-box) require TLS/SSL to access.
 
-Enable TSL/SSL in Tomcat
+Enable TLS/SSL in Tomcat
 
-If Tomcat has not already been configured to run via TSL/SSL, follow the
-tutorial in the previous section to link:#sslinTomcat[Enable TSL/SSL in
+If Tomcat has not already been configured to run via TLS/SSL, follow the
+tutorial in the previous section to link:#sslinTomcat[Enable TLS/SSL in
 Tomcat].
 
 Modify `${tomcat_home}/conf/tomcat-users.xml` to add the new `tdsConfig`
@@ -525,12 +525,12 @@ Restart Tomcat
 
 * https://www.ssllabs.com/ssltest/[Qualys SSL Server Test] +
  is a free online service that analyzes the configuration of any
-_public_ TSL/SSL web server. **Note**: be sure to check the _Do not show
+_public_ TLS/SSL web server. **Note**: be sure to check the _Do not show
 the results on the boards_ box if you do not want your results to be
 public.
-* http://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html[TSL/SSL
+* http://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html[TLS/SSL
 Configuration HOW-TO] +
- The Apache Tomcat document detailing how to enable TSL/SSL.
+ The Apache Tomcat document detailing how to enable TLS/SSL.
 * http://tomcat.apache.org/migration.html[Tomcat Migration Guide] +
  A document detailing the various changes between Tomcat versions.
 * http://www.sslshopper.com/article-when-are-self-signed-certificates-acceptable.html[When
@@ -558,18 +558,18 @@ Tomcat.
 * If exploited, an attacker can use the `manager` application to install
 programs on your server willy-nilly.
 * If you choose to enable the `manager` application, we _highly
-recommend_ enabling digested passwords and TSL/SSL encryption for the
+recommend_ enabling digested passwords and TLS/SSL encryption for the
 `manager`.
 * Restricting access to the `manager` application to a small subset of
 IP addressess or host names using a Tomcat valve, etc., is also a good
 idea.
 * Uninstall this application if you don’t plan to use it.
 
-=== Enabling TSL/SSL for the Tomcat `manager` application
+=== Enabling TLS/SSL for the Tomcat `manager` application
 
 1.  Modify the deployment descriptor of the Tomcat `manager`
 application.
-2.  Verify TSL/SSL has been enabled for the Tomcat `manager`
+2.  Verify TLS/SSL has been enabled for the Tomcat `manager`
 application.
 3.  NOTE: You will have to redo this every time you upgrade Tomcat.
 

--- a/docs/src/public/userguide/_data/sidebars/tdsTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/tdsTutorial_sidebar.yml
@@ -217,8 +217,8 @@ entries:
       url: /digested_passwords.html
       output: web, pdf
 
-    - title: Enable TSL/SSL Encryption
-      url: /enable_tsl_encryption.html
+    - title: Enable TLS/SSL Encryption
+      url: /enable_TLS_encryption.html
       output: web, pdf
 
     - title: Secure Tomcat Manager App

--- a/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatDirectoryStructureQT.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatDirectoryStructureQT.md
@@ -47,7 +47,7 @@ Familiarize yourself with these important directories:
 #### `conf/`
 
 * _Server-wide_ Tomcat configuration.
-* You will modify `server.xml` and `tomcat-users.xml` to adjust logging, authentication and access control, enable TSL/SSL, etc.
+* You will modify `server.xml` and `tomcat-users.xml` to adjust logging, authentication and access control, enable TLS/SSL, etc.
 * Web applications can override some server-wide settings in their own configuration file (e.g., the web deployment descriptor).
 
 #### `webapps/`

--- a/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatManagerApp.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatManagerApp.md
@@ -234,7 +234,7 @@ See the <a href=\"http://tomcat.apache.org/migration.html\" target=\"_blank\">To
 If you plan to deploy the TDS in a production environment you will need to follow the best practices outlined in the [Putting TDS Into Production](tomcat_permissions.html){:target="_blank"} section of the tutorial to finish hardening your server environment.
 
 {%include ahead.html content="
-<a href=\"enable_tsl_encryption.html\" target=\"_blank\">TSL/SSL Encryption</a> will need to be enabled in order to access a couple of TDS monitoring and debugging tools.
+<a href=\"enable_TLS_encryption.html\" target=\"_blank\">TLS/SSL Encryption</a> will need to be enabled in order to access a couple of TDS monitoring and debugging tools.
 " %}
 
 The [Basic TDS Configuration](basic_config_catalog.html){:target="_blank"} and [TDS Configuration Catalogs](config_catalog.html) sections of this tutorial cover the TDS configuration files, configuration options and TDS catalog structure.

--- a/docs/src/public/userguide/pages/tds_tutorial/production/EnableTLSEncryption.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/EnableTLSEncryption.md
@@ -18,8 +18,8 @@ This section assumes you have successfully performed the tasks as outlined in th
 * The use of digital certificates adds a layer of security by allowing the receiver of the message to verify the sender is who he or she claims to be.
 * Any intercepted information that is encrypted also adds a layer of security (the attacker must take the extra step of un-encrypting the data to view the message).
 * Transport Layer Security (TLS), and formerly Secure Sockets Layer (SSL), is a cryptographic protocol that provides security and data integrity for communications over TCP/IP networks.
-* tls/SSL allows applications to communicate across a network in a way designed to prevent eavesdropping, tampering, and message forgery.
-* tls/SSL uses a cryptographic system that uses two keys to encrypt data: a public key known to everyone and a private or secret key known only to the recipient of the message.
+* TLS/SSL allows applications to communicate across a network in a way designed to prevent eavesdropping, tampering, and message forgery.
+* TLS/SSL uses a cryptographic system that uses two keys to encrypt data: a public key known to everyone and a private or secret key known only to the recipient of the message.
 * By convention, URLs that require an TLS/SSL connection start with `https` instead of `http`.
 
 {%include note.html content="

--- a/docs/src/public/userguide/pages/tds_tutorial/production/EnableTLSEncryption.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/EnableTLSEncryption.md
@@ -1,12 +1,12 @@
 ---
-title: Enable TSL/SSL Encryption
+title: Enable TLS/SSL Encryption
 last_updated: 2018-11-02
 sidebar: tdsTutorial_sidebar
 toc: false
-permalink: enable_tsl_encryption.html
+permalink: enable_tls_encryption.html
 ---
 
-This section demonstrates how to enable TSL/SSL Encryption for the TDS and Tomcat Servlet Container.
+This section demonstrates how to enable tls/SSL Encryption for the TDS and Tomcat Servlet Container.
 
 {%include note.html content="
 This section assumes you have successfully performed the tasks as outlined in the <a href=\"install_java_tomcat.html\" target=\"_blank\">Getting Started With The TDS</a> section of this tutorial.
@@ -18,15 +18,15 @@ This section assumes you have successfully performed the tasks as outlined in th
 * The use of digital certificates adds a layer of security by allowing the receiver of the message to verify the sender is who he or she claims to be.
 * Any intercepted information that is encrypted also adds a layer of security (the attacker must take the extra step of un-encrypting the data to view the message).
 * Transport Layer Security (TLS), and formerly Secure Sockets Layer (SSL), is a cryptographic protocol that provides security and data integrity for communications over TCP/IP networks.
-* TSL/SSL allows applications to communicate across a network in a way designed to prevent eavesdropping, tampering, and message forgery.
-* TSL/SSL uses a cryptographic system that uses two keys to encrypt data: a public key known to everyone and a private or secret key known only to the recipient of the message.
-* By convention, URLs that require an TSL/SSL connection start with `https` instead of `http`.
+* tls/SSL allows applications to communicate across a network in a way designed to prevent eavesdropping, tampering, and message forgery.
+* tls/SSL uses a cryptographic system that uses two keys to encrypt data: a public key known to everyone and a private or secret key known only to the recipient of the message.
+* By convention, URLs that require an TLS/SSL connection start with `https` instead of `http`.
 
 {%include note.html content="
-For more information on how TSL/SSL works, Wikipedia details the <a href=\"https://en.wikipedia.org/wiki/Transport_Layer_Security\" target=\"_blank\">steps involved</a> during an TSL/SSL transaction.
+For more information on how TLS/SSL works, Wikipedia details the <a href=\"https://en.wikipedia.org/wiki/Transport_Layer_Security\" target=\"_blank\">steps involved</a> during an TLS/SSL transaction.
 " %}
 
-## TSL/SSL Certificates
+## TLS/SSL Certificates
 * A public key certificate is an electronic document which incorporates a digital signature to bind together a public key with identity information of the certificate user.
 * The certificate can be used to verify that a public key belongs to an individual.
 * The digital signature can be signed by a Certificate Authority (CA) or the certificate user (a self-signed certificate).
@@ -43,19 +43,19 @@ Unidata _highly_ recommends the use of a certificate signed by a Certificate Aut
   CAs on the other hand have the ability to revoke a compromised certificate, which prevents its further use.
 
 #### Certificate keystore file
-A keystore file stores the details of the TSL/SSL certificate necessary to make the protocol secured.
+A keystore file stores the details of the TLS/SSL certificate necessary to make the protocol secured.
 The Tomcat documentation includes a section on [importing your certificate](https://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html#Prepare_the_Certificate_Keystore){:target="_blank"} into a keystore file.
-Tomcat uses the keystore file for TSL/SSL transactions. 
+Tomcat uses the keystore file for TLS/SSL transactions. 
 
-## Enabling TSL/SSL In Tomcat
+## Enabling TLS/SSL In Tomcat
 
-The following example demonstrates enabling TSL/SSL in the Tomcat Servlet Container on a linux system as the `root` user. 
+The following example demonstrates enabling TLS/SSL in the Tomcat Servlet Container on a linux system as the `root` user. 
 
 {%include note.html content="
 This section assumes you have already imported your CA-signed certificate into the <a href=\"https://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html#Prepare_the_Certificate_Keystore\" target=\"_blank\">keystore</a> file.
 " %}
 
-1. Modify the Tomcat configuration to enable TSL/SSL:
+1. Modify the Tomcat configuration to enable TLS/SSL:
 
    Open `$TOMCAT_HOME/conf/server.xml` with your favorite text editor:
 
@@ -63,7 +63,7 @@ This section assumes you have already imported your CA-signed certificate into t
    # vi server.xml
    ~~~~
 
-   Locate the `Java HTTP/1.1 Connector` listening on port `8080` and verify it is redirecting TSL/SSL traffic to port `8443`:
+   Locate the `Java HTTP/1.1 Connector` listening on port `8080` and verify it is redirecting TLS/SSL traffic to port `8443`:
    ~~~~xml
    <Connector port="8080" 
               protocol="HTTP/1.1"
@@ -125,7 +125,7 @@ This section assumes you have already imported your CA-signed certificate into t
    Keep in mind: Changes to `$TOMCAT_HOME/conf/server.xml` do not take effect until Tomcat is restarted.
    " %}
 
-2. Verify TSL/SSL has been enabled.
+2. Verify TLS/SSL has been enabled.
 
    Restart Tomcat:
 
@@ -162,15 +162,15 @@ This section assumes you have already imported your CA-signed certificate into t
 * Did you specify the full path to the keystore file in `server.xml`?
 
 {%include ahead.html content="
-Other than the compelling security reasons, you will want to enable TSL/SSL to take advantage of a couple of monitoring and debugging tools: the <a href=\"http://localhost:8080/thredds/admin/debug\" target=\"_blank\">TDS Remote Management Tool</a>, and the <a href=\"/using_the_tdsmonitor_tool.html\" target=\"_blank\">TdsMonitor</a> Tool -- both of which (out-of-the-box) require TSL/SSL to access.
+Other than the compelling security reasons, you will want to enable TLS/SSL to take advantage of a couple of monitoring and debugging tools: the <a href=\"http://localhost:8080/thredds/admin/debug\" target=\"_blank\">TDS Remote Management Tool</a>, and the <a href=\"/using_the_tdsmonitor_tool.html\" target=\"_blank\">TdsMonitor</a> Tool -- both of which (out-of-the-box) require TLS/SSL to access.
 " %}
 
-## Configuring Web Applications for TSL/SSL
+## Configuring Web Applications for TLS/SSL
 
-* The web application deployment descriptor, a.k.a. `web.xml`, specifies if all or parts of it need to be accessed via TSL/SSL.
+* The web application deployment descriptor, a.k.a. `web.xml`, specifies if all or parts of it need to be accessed via TLS/SSL.
 * Deployment descriptors are found in the `WEB-INF` directory of the web application: `$TOMCAT_HOME/webapps/application_name/WEB-INF/web.xml`.
 * By convention, Tomcat and other servlet containers will read the web application deployment descriptors for initialization parameters and container-managed security constraints upon application deployment.
-* The TDS has been pre-configured to require that TSL/SSL encryption is enabled in order to access the both the [TDS Remote Management Tool](http://localhost:8080/thredds/admin/debug){:target="_blank"}, and the [TdsMonitor Tool](using_the_tdsmonitor_tool.html){:target="_blank"}.
+* The TDS has been pre-configured to require that TLS/SSL encryption is enabled in order to access the both the [TDS Remote Management Tool](http://localhost:8080/thredds/admin/debug){:target="_blank"}, and the [TdsMonitor Tool](using_the_tdsmonitor_tool.html){:target="_blank"}.
 
 This is the entry in the TDS `web.xml` for the TDS Remote Management Tool:
 
@@ -193,7 +193,7 @@ This is the entry in the TDS `web.xml` for the TDS Remote Management Tool:
 * The `<user-data-constraint>` establishes a requirement that the constrained requests be received over a protected transport layer connection.
    This guarantees how the data will be transported between client and server.
 * `<transport-guarantee>` choices for type of transport guarantee include `NONE`, `INTEGRAL`, and `CONFIDENTIAL`:
-   1. Specify `CONFIDENTIAL` when the application requires that data be transmitted so as to prevent other entities from observing the contents of the transmission. (E.g., via TSL/SSL.)
+   1. Specify `CONFIDENTIAL` when the application requires that data be transmitted so as to prevent other entities from observing the contents of the transmission. (E.g., via TLS/SSL.)
    2. Specify `INTEGRAL` when the application requires that the data be sent between client and server in such a way that it cannot be changed in transit.
    3. Specify `NONE` to indicate that the container must accept the constrained requests on any connection, including an unprotected one.
 
@@ -202,10 +202,10 @@ This is the entry in the TDS `web.xml` for the TDS Remote Management Tool:
 " %}
 
 ## Accessing TDS Monitoring and Debugging Tools
-Other than the compelling security reasons, you will want to enable TSL/SSL to take advantage of the [TDS Remote Management Tool](http://localhost:8080/thredds/admin/debug){:target="_blank"} and the [TdsMonitor Tool](using_the_tdsmonitor_tool.html){:target="_blank"} monitoring and debugging tools.  
+Other than the compelling security reasons, you will want to enable TLS/SSL to take advantage of the [TDS Remote Management Tool](http://localhost:8080/thredds/admin/debug){:target="_blank"} and the [TdsMonitor Tool](using_the_tdsmonitor_tool.html){:target="_blank"} monitoring and debugging tools.  
 
-1. Enable TSL/SSL in Tomcat
-   If Tomcat has not already been configured to run via TSL/SSL, follow the tutorial in the previous section to Enable TSL/SSL in Tomcat.
+1. Enable TLS/SSL in Tomcat
+   If Tomcat has not already been configured to run via TLS/SSL, follow the tutorial in the previous section to Enable TLS/SSL in Tomcat.
 2. Modify `$TOMCAT_HOME/conf/tomcat-users.xml` to add the new tdsConfig and tdsMonitor roles.
    Add these roles to your list of roles:
    ~~~~xml
@@ -248,10 +248,10 @@ Other than the compelling security reasons, you will want to enable TSL/SSL to t
 
 ### Resources
 * [Qualys SSL Server Test](https://www.ssllabs.com/ssltest/){:target="_blank"}
-  is a free online service that analyzes the configuration of any public TSL/SSL web server. 
+  is a free online service that analyzes the configuration of any public TLS/SSL web server. 
   Note: be sure to check the Do not show the results on the boards box if you do not want your results to be public.
-* [TSL/SSL Configuration HOW-TO](https://tomcat.apache.org/tomcat-8.5-doc/ssl-howto.html){:target="_blank"}
-  The Apache Tomcat document detailing how to enable TSL/SSL.
+* [TLS/SSL Configuration HOW-TO](https://tomcat.apache.org/tomcat-8.5-doc/ssl-howto.html){:target="_blank"}
+  The Apache Tomcat document detailing how to enable TLS/SSL.
 * [Tomcat Migration Guide](https://tomcat.apache.org/migration.html){:target="_blank"}
   A document detailing the various changes between Tomcat versions.
 * [When are self-signed certificates acceptable?](https://www.sslshopper.com/article-when-are-self-signed-certificates-acceptable.html){:target="_blank"}

--- a/docs/src/public/userguide/pages/tds_tutorial/production/InstallationChecklist.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/InstallationChecklist.md
@@ -22,7 +22,7 @@ permalink: installation_checklist.html
 2. Create a [`setenv.sh` file](running_tomcat.html#setting-java_home-java_opts-catalina_base-and-content_root){:target="_blank"} in `$TOMCAT_HOME/bin` to set JVM options and the TDS `$CONTENT_ROOT`.
 3. Make the following modifications to `${tomcat_home}/conf/server.xml`:
  * Enable [digested password support](digested_passwords.html#configure-tomcat-to-use-digested-passwords){:target="_blank"} by modifying the `UserDatabaseRealm`.
- * Enable [TSL/SSL in tomcat](enable_tsl_encryption.html#enabling-tslssl-in-tomcat){:target="_blank"} using you CA certificate.
+ * Enable [TLS/SSL in tomcat](enable_tls_encryption.html#enabling-tlsssl-in-tomcat){:target="_blank"} using you CA certificate.
  * Enable [Compression](performance_tips.html#compression){:target="_blank"} in the Tomcat connectors.
  * Modify the Tomcat [AccessLogValve](tomcat_access_log.html)){:target="_blank"} log format and changed the prefix and suffix and pattern attributes for the access log file.
 4. Create a [digested password](digested_passwords.html#digest.sh){:target="_blank"} using the algorithm specified in the `UserDatabaseRealm` of the `${tomcat_home}/conf/server.xml` file.
@@ -57,5 +57,5 @@ When installing a new `thredds.war`, everything in `${tomcat_home}/webapps/thred
 
 #### Upgrading Tomcat
 {%include important.html content="
-If you are using the Tomcat `manager` application, you will need to <a href=\"secure_manager_app.html#enabling-tslssl-for-the-tomcat-manager-application\" target=\"_blank\">modify the deployment descriptor</a> to enable access via HTTPS only.
+If you are using the Tomcat `manager` application, you will need to <a href=\"secure_manager_app.html#enabling-tlsssl-for-the-tomcat-manager-application\" target=\"_blank\">modify the deployment descriptor</a> to enable access via HTTPS only.
 " %}

--- a/docs/src/public/userguide/pages/tds_tutorial/production/SecureManagerApp.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/SecureManagerApp.md
@@ -6,10 +6,10 @@ toc: false
 permalink: secure_manager_app.html
 ---
 
-This section demonstrates how to secure the Tomcat Manager Application by enabling access via TSL/SSL Encryption.
+This section demonstrates how to secure the Tomcat Manager Application by enabling access via TLS/SSL Encryption.
 
 {%include note.html content="
-This section assumes you have successfully performed the tasks as outlined in the <a href=\"install_java_tomcat.html\" target=\"_blank\">Getting Started With The TDS</a> and <a href=\"enable_tsl_encryption.html\" target=\"_blank\">Enabling TSL/SSL</a> sections of this tutorial
+This section assumes you have successfully performed the tasks as outlined in the <a href=\"install_java_tomcat.html\" target=\"_blank\">Getting Started With The TDS</a> and <a href=\"enable_tls_encryption.html\" target=\"_blank\">Enabling TLS/SSL</a> sections of this tutorial
 " %}
 
 **If you do not intend to use the Tomcat Manager Application, you can skip this section and proceed to [removing unused web applications](remove_unused_webapps.html){:target="_blank"}.**
@@ -21,13 +21,13 @@ The Tomcat The Manager application:
 * Not enabled by default.
 * Allows Tomcat administrators to deploy, un-deploy, or reload web applications such as the TDS without having to shut down and restart Tomcat.
 * If exploited, an attacker can use the Manager application to install programs on your server willy-nilly.
-* If you choose to enable the Manager application, we _highly recommend_ [enabling digested passwords](digested_passwords.html){:target="_blank"} and [TSL/SSL encryption](enable_tsl_encryption.html){:target="_blank"} for the Manager application.
+* If you choose to enable the Manager application, we _highly recommend_ [enabling digested passwords](digested_passwords.html){:target="_blank"} and [TLS/SSL encryption](enable_tls_encryption.html){:target="_blank"} for the Manager application.
 * Restricting access to the Manager application to a small [subset of IP addresses or host names using a Tomcat valve](restict_access_to_tds.html){:target="_blank"} is also a good idea.
 * **Uninstall this application if you don't plan to use it.**
 
-## Enabling TSL/SSL For The Tomcat Manager Application
+## Enabling TLS/SSL For The Tomcat Manager Application
 
-The following example demonstrates enabling TSL/SSL for the Tomcat Manager Application on a linux system as the `root` user.
+The following example demonstrates enabling TLS/SSL for the Tomcat Manager Application on a linux system as the `root` user.
 
 1. Modify the deployment descriptor (`$TOMCAT_HOME/webapps/manager/WEB-INF/web.xml` )of the Tomcat Manager application.
 
@@ -146,9 +146,9 @@ The following example demonstrates enabling TSL/SSL for the Tomcat Manager Appli
    </security-constraint>
    ~~~~
 
-2. Verify TSL/SSL has been enabled for the Tomcat Manager application.
+2. Verify TLS/SSL has been enabled for the Tomcat Manager application.
 
-   Restart Tomcat and verify TSL/SSL has been enabled for the Tomcat Manager application: [http://localhost:8080/manager/html/](http://localhost:8080/manager/html/){:target="_blank"}
+   Restart Tomcat and verify TLS/SSL has been enabled for the Tomcat Manager application: [http://localhost:8080/manager/html/](http://localhost:8080/manager/html/){:target="_blank"}
    
    {% include image.html file="tds/tutorial/production_servers/managerssl.png" alt="manager ssl" caption="" %}
 

--- a/docs/src/public/userguide/pages/tds_tutorial/production/TdsBehindProxy.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/TdsBehindProxy.md
@@ -215,7 +215,7 @@ The following example shows how to implement a proxy using the Apache HTTPD serv
 2. Disable any active `Java HTTP/1.1 Connector` and the `SSL HTTP/1.1 Connector` Tomcat connectors.
 
    {%include important.html content="
-   Only perform this step is you have enabled Apache to handle the SSL/TSL encryption for Tomcat and the TDS.
+   Only perform this step is you have enabled Apache to handle the SSL/TLS encryption for Tomcat and the TDS.
    " %}
 
    This will prevent direct communication to Tomcat via ports `8080` and `8443` ensuring the AJP proxy via Apache is the only HTTP method by which to access Tomcat and the TDS.
@@ -242,13 +242,13 @@ The following example shows how to implement a proxy using the Apache HTTPD serv
       -->
    ~~~~ 
 
-3. Configure the TDS to relinquish control of TSL/SSL to Apache
+3. Configure the TDS to relinquish control of TLS/SSL to Apache
 
    {%include important.html content="
-   Only perform this step is you have enabled Apache to handle the SSL/TSL encryption for Tomcat and the TDS.
+   Only perform this step is you have enabled Apache to handle the SSL/TLS encryption for Tomcat and the TDS.
    " %}
 
-   The TDS deployment descriptor (`$TOMCAT_HOME/webapps/thredds/WEB-INF/web.xml`) is configured to only allow access parts of the TDS application via TSL/SSL.  Because we've disabled Tomcat's handling of the TSL/SSL, we need to update these configurations.
+   The TDS deployment descriptor (`$TOMCAT_HOME/webapps/thredds/WEB-INF/web.xml`) is configured to only allow access parts of the TDS application via TLS/SSL.  Because we've disabled Tomcat's handling of the TLS/SSL, we need to update these configurations.
 
    Use your favorite editor to open the TDS `$TOMCAT_HOME/webapps/thredds/WEB-INF/web.xml` file.  Around line 106 you'll start seeing a configs that look like the following:
     

--- a/docs/src/public/userguide/pages/tds_tutorial/production/UpgradeTo50.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/UpgradeTo50.md
@@ -228,7 +228,7 @@ shared and allowing them to be private is confusing and error-prone.
 
 * All uses of classes in `thredds.catalog` are deprecated. If you still need these, you must add `legacy.jar` to your path.
 * TDS and CDM now use `thredds.server.catalog` and `thredds.client.catalog`. The APIs are different, but with equivalent functionality to thredds.catalog.
-* `thredds.client.DatasetNode` now has `getDatasetlsogical()` and `getDatasetsLocal()` that does or does not dereference a `CatalogRef`, respectively.
+* `thredds.client.DatasetNode` now has `getDatasetsLogical()` and `getDatasetsLocal()` that does or does not dereference a `CatalogRef`, respectively.
   You can also use `getDatasets()` which includes a dereferenced catalog if it has already been read.
 
 

--- a/docs/src/public/userguide/pages/tds_tutorial/production/UpgradeTo50.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/UpgradeTo50.md
@@ -228,7 +228,7 @@ shared and allowing them to be private is confusing and error-prone.
 
 * All uses of classes in `thredds.catalog` are deprecated. If you still need these, you must add `legacy.jar` to your path.
 * TDS and CDM now use `thredds.server.catalog` and `thredds.client.catalog`. The APIs are different, but with equivalent functionality to thredds.catalog.
-* `thredds.client.DatasetNode` now has `getDatasetsLogical()` and `getDatasetsLocal()` that does or does not dereference a `CatalogRef`, respectively.
+* `thredds.client.DatasetNode` now has `getDatasetlsogical()` and `getDatasetsLocal()` that does or does not dereference a `CatalogRef`, respectively.
   You can also use `getDatasets()` which includes a dereferenced catalog if it has already been read.
 
 


### PR DESCRIPTION
We had some values as tsl instead of tls, changed all occurrences I could find in the documentation.