### PR TITLE
add nofollow to meta on html pages

### DIFF
--- a/tds/src/main/webapp/Godiva.html
+++ b/tds/src/main/webapp/Godiva.html
@@ -9,6 +9,9 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- if webcrawler finds this page (say, from sitemap.xml), tell it to not follow the links -->
+    <meta name="robots" content="nofollow" />
+
     <title>TDS Godiva3 Viewer</title>
     
     <!-- Link to the godiva3 javascript -->

--- a/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/commonFragments.html
@@ -10,6 +10,9 @@
   <!-- Common metadata and styles. -->
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 
+  <!-- if webcrawler finds this page (say, from sitemap.xml), tell it to not follow the links -->
+  <meta name="robots" content="nofollow" />
+
   <!--/* This is a placeholder where our page-specific stylesheet  can be inserted. */-->
   <th:block th:replace="${style}" />
 

--- a/tds/src/main/webapp/WEB-INF/templates/gridFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/gridFragments.html
@@ -8,6 +8,9 @@
        Pass on the "title" element we received from ncssGrid, along with the "script" element we define below. */-->
 <head th:fragment="head(title)" th:replace="templates/commonFragments :: head(~{::title}, ~{::script}, ~{::link})">
 
+  <!-- if webcrawler finds this page (say, from sitemap.xml), tell it to not follow the links -->
+  <meta name="robots" content="nofollow" />
+
   <link rel="stylesheet" type="text/css" href="https://necolas.github.io/normalize.css/8.0.0/normalize.css">
   <link rel="stylesheet" type="text/css" href="../../style/ncss/main.css" th:href="@{/style/ncss/main.css}">
   <link rel="stylesheet" type="text/css" href="../../style/ncss/layout.css" th:href="@{/style/ncss/layout.css}">

--- a/tds/src/main/webapp/WEB-INF/templates/pointFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/pointFragments.html
@@ -8,6 +8,9 @@
        Pass on the "title" element we received from ncssPoint, along with the "script" element we define below. */-->
 <head th:fragment="head(title)" th:replace="templates/commonFragments :: head(~{::title},~{::script},~{::link})">
 
+  <!-- if webcrawler finds this page (say, from sitemap.xml), tell it to not follow the links -->
+  <meta name="robots" content="nofollow" />
+
   <link rel="stylesheet" type="text/css" href="https://necolas.github.io/normalize.css/8.0.0/normalize.css">
   <link rel="stylesheet" type="text/css" href="../../style/ncss/main.css" th:href="@{/style/ncss/main.css}">
   <link rel="stylesheet" type="text/css" href="../../style/ncss/layout.css" th:href="@{/style/ncss/layout.css}">


### PR DESCRIPTION
tell google to not follow links on html pages. hopefully, this allows
for maximum control over what pages show up in google dataset search.