### PR TITLE
Chunksize can be read from an attribute now.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/write/Nc4ChunkingDefault.java
+++ b/cdm/src/main/java/ucar/nc2/write/Nc4ChunkingDefault.java
@@ -73,10 +73,10 @@ public class Nc4ChunkingDefault extends Nc4ChunkingStrategy {
 
   @Override
   public long[] computeChunking(Variable v) {
-    /* check attribute
+
     int[] resultFromAtt = computeChunkingFromAttribute(v);
     if (resultFromAtt != null)
-      return convertToLong(resultFromAtt); */
+      return convertToLong(resultFromAtt);
 
     int maxElements = defaultChunkSize / v.getElementSize();
 


### PR DESCRIPTION
Uncommented the part of the code which allows Chunksize set up from a variable attribute for NetCDF format.