### PR TITLE
fix broken link to grib paper

### DIFF
--- a/docs/website/netcdf-java/documentation.htm
+++ b/docs/website/netcdf-java/documentation.htm
@@ -184,7 +184,7 @@ To build the latest stable version from source or contribute code  to the THREDD
   <li><a href="http://www.unidata.ucar.edu/blogs/developer/en/category/NetCDF+Java">Netcdf-Java Blog</a></li>
   <li>Talk at netCDF workshop 2012 (<a
       href="http://www.unidata.ucar.edu/staff/caron/presentations/NetCDFworkshop2012.pptx">pptx</a>) </li>
-  <li><em>On the suitability of BUFR and GRIB for archiving data</em> (short paper Dec 2011 <a href="http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.docx">docx</a> <a href="http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.pdf">pdf</a>)</li>
+  <li><em>On the suitability of BUFR and GRIB for archiving data</em> (short paper Dec 2011 <a href="https://doi.org/10.5065/vkan-dp10">pdf</a>)</li>
   <li>Streaming NetCDF (netCDF workshop 2011) (<a
       href="http://www.unidata.ucar.edu/staff/caron/presentations/Streaming_NetCDF.pptx">pptx</a>) </li>
   <li>Talk at netCDF workshop 2010 (<a

--- a/docs/website/netcdf-java/documentation.htm
+++ b/docs/website/netcdf-java/documentation.htm
@@ -183,14 +183,14 @@ To build the latest stable version from source or contribute code  to the THREDD
 <ul>
   <li><a href="http://www.unidata.ucar.edu/blogs/developer/en/category/NetCDF+Java">Netcdf-Java Blog</a></li>
   <li>Talk at netCDF workshop 2012 (<a
-      href="http://www.unidata.ucar.edu/staff/caron/presentations/NetCDFworkshop2012.pptx">pptx</a>) </li>
+      href="https://www.unidata.ucar.edu/presentations/caron/NetCDFworkshop2012.pptx">pptx</a>) </li>
   <li><em>On the suitability of BUFR and GRIB for archiving data</em> (short paper Dec 2011 <a href="https://doi.org/10.5065/vkan-dp10">pdf</a>)</li>
   <li>Streaming NetCDF (netCDF workshop 2011) (<a
-      href="http://www.unidata.ucar.edu/staff/caron/presentations/Streaming_NetCDF.pptx">pptx</a>) </li>
+      href="https://www.unidata.ucar.edu/presentations/caron/Streaming_NetCDF.pptx">pptx</a>) </li>
   <li>Talk at netCDF workshop 2010 (<a
-      href="http://www.unidata.ucar.edu/staff/caron/presentations/DataSummit2010.pptx">pptx</a>) </li>
+      href="https://www.unidata.ucar.edu/presentations/caron/DataSummit2010.pptx">pptx</a>) </li>
   <li>Talk at netCDF workshop 2009 (<a
-      href="http://www.unidata.ucar.edu/staff/caron/presentations/NetCDFworkshop2009.ppt">ppt</a>) </li>
+      href="https://www.unidata.ucar.edu/presentations/caron/NetCDFworkshop2009.ppt">ppt</a>) </li>
   <li><a href="http://coast-enviro.er.usgs.gov/models/share/toolsUI.wrf">ToolsUI</a> demo (You may need to  download the <a href="http://www.webex.com/downloadplayer.html">free WebEx Player</a>)</li>
 </ul>
 <h3>Software libraries used by the Netcdf-Java library: </h3>

--- a/docs/website/netcdf-java/reference/formats/GribFiles.html
+++ b/docs/website/netcdf-java/reference/formats/GribFiles.html
@@ -63,7 +63,7 @@
 
 <h2>GRIB Tables</h2>
 
-<p>The use of external tables in GRIB is quite problematic (read <a href="http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.pdf">here</a> for more
+<p>The use of external tables in GRIB is quite problematic (read <a href="https://doi.org/10.5065/vkan-dp10">here</a> for more
   details). Nonetheless, GRIB files are in wide use internationally and contain invaluable data. The CDM is a general-purpose GRIB reading library that makes
   GRIB data available through the CDM/NetCDF API, that is, as multidimensional data arrays and <a href="http://cfconventions.org/">CF</a>-compliant metadata and
   coordinates.</p>

--- a/docs/website/netcdf-java/reference/formats/GribTables.html
+++ b/docs/website/netcdf-java/reference/formats/GribTables.html
@@ -11,7 +11,7 @@
   read.</p>
 
 <p>In principle, if everything is done right, the reader ends up using the table that the writer used. In practice, there are many ways for that to fail. In
-  order to increase the reliability of table-based file formats, I have <a href="http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.pdf">proposed</a>
+  order to increase the reliability of table-based file formats, I have <a href="https://doi.org/10.5065/vkan-dp10">proposed</a>
   a web registry of tables, which would create a unique id for each registered table. The writer would then embed the id into the GRIB or BUFR message (possibly
   in the &quot;local use&quot; section of GRIB-2, or GRIB-1 octets &gt; 41 in PDS), and the reader could use the id to unambiguously retrieve the table from the
   web registry. Stay tuned for further details and a trial implementation.</p>

--- a/docs/website/tds/tutorial/workshop2015.adoc
+++ b/docs/website/tds/tutorial/workshop2015.adoc
@@ -141,7 +141,7 @@ to explore/discuss during this time. Potential topics include:
  ** link:http://www.wmo.int/pages/prog/www/WMOCodes.html[WMO]
  *** link:http://www.wmo.int/pages/prog/www/WMOCodes/Guides/GRIB/GRIB1-Contents.html[WMO GRIB-1]
  *** link:http://www.wmo.int/pages/prog/www/WMOCodes/Guides/GRIB/GRIB2_062006.pdf[WMO GRIB-2]
- * link:http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.pdf[On the suitability of BUFR and GRIB for archiving data] (link:http://www.unidata.ucar.edu/blogs/developer/en/entry/on_the_suitability_of_grib[tl;dr;])
+ * link:https://doi.org/10.5065/vkan-dp10[On the suitability of BUFR and GRIB for archiving data] (link:http://www.unidata.ucar.edu/blogs/developer/en/entry/on_the_suitability_of_grib[tl;dr;])
 
 === 2:00 - 2:30 Reading GRIB data with the CDM (Sean)
  * General overview of tools for GRIB

--- a/docs/website/tds/tutorial/workshop2015.html
+++ b/docs/website/tds/tutorial/workshop2015.html
@@ -477,7 +477,7 @@ to explore/discuss during this time. Potential topics include:</p>
 </div>
 </li>
 <li>
-<p><a href="http://www.unidata.ucar.edu/staff/caron/papers/GRIBarchivals.pdf">On the suitability of BUFR and GRIB for archiving data</a> (<a href="http://www.unidata.ucar.edu/blogs/developer/en/entry/on_the_suitability_of_grib">tl;dr;</a>)</p>
+<p><a href="https://doi.org/10.5065/vkan-dp10">On the suitability of BUFR and GRIB for archiving data</a> (<a href="http://www.unidata.ucar.edu/blogs/developer/en/entry/on_the_suitability_of_grib">tl;dr;</a>)</p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
These links are good in the 5.0 docs, so just 4.6.