### PR TITLE
Updates to doc publishing, false positive in OWASP

### DIFF
--- a/buildSrc/src/main/groovy/edu/ucar/build/publishing/DeleteFromNexusTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/publishing/DeleteFromNexusTask.groovy
@@ -86,7 +86,7 @@ class DeleteFromNexusTask extends DefaultTask {
     List<Component> search() {
         HttpBuilder http = HttpBuilder.configure {
             request.uri = host
-            request.uri.path = "/service/rest/beta/search"
+            request.uri.path = "/service/rest/v1/search"
             request.contentType = ContentTypes.JSON.first()
         }
         
@@ -135,7 +135,7 @@ class DeleteFromNexusTask extends DefaultTask {
         
         components.each { Component component ->
             http.delete {
-                request.uri.path = "/service/rest/beta/components/${component.id}"
+                request.uri.path = "/service/rest/v1/components/${component.id}"
                 
                 response.success { FromServer ret, Map<String, ?> jsonResponse ->
                     logger.info "DELETE successful (${ret.statusCode}): ${request.uri.toURI()}"

--- a/buildSrc/src/main/groovy/edu/ucar/build/publishing/PublishToRawRepoTask.groovy
+++ b/buildSrc/src/main/groovy/edu/ucar/build/publishing/PublishToRawRepoTask.groovy
@@ -99,7 +99,7 @@ class PublishToRawRepoTask extends DefaultTask {
     
         HttpBuilder http = OkHttpBuilder.configure {
             request.uri = host
-            request.uri.path = "/service/rest/beta/components"
+            request.uri.path = "/service/rest/v1/components"
             request.uri.query['repository'] = repoName
             
             request.contentType = ContentTypes.MULTIPART_FORMDATA.first()

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -78,4 +78,12 @@
     <gav regex="true">^org\.quartz-scheduler:quartz:.*$</gav>
     <cpe>cpe:/a:jenkins:jenkins</cpe>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name example: spring-security-core-4.2.7.RELEASE.jar
+      reason: Only valid if specifically using in combination with Spring 5.0.5 RELEASE. https://pivotal.io/security/cve-2018-1258
+      ]]></notes>
+    <filePath regex="true">.*\/spring-security-core-4.2.7.RELEASE.jar</filePath>
+    <cve>CVE-2018-1258</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This PR address 2 unrelated, but minor, topics.

1. Use the new v1 REST API for nexus when interacting with the raw repository (doc publishing)
2. Suppress false positive found during OWASP scan