### PR TITLE
Allow null valued attributes to be written

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/IospHelper.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/IospHelper.java
@@ -726,10 +726,13 @@ public class IospHelper {
   // convert char array to byte array
 
   static public byte[] convertCharToByte(char[] from) {
-    int size = from.length;
-    byte[] to = new byte[size];
-    for (int i = 0; i < size; i++)
-      to[i] = (byte) from[i]; // LOOK wrong, convert back to unsigned byte ???
+    byte[] to = null;
+    if (from != null) {
+      int size = from.length;
+      to = new byte[size];
+      for (int i = 0; i < size; i++)
+        to[i] = (byte) from[i]; // LOOK wrong, convert back to unsigned byte ???
+    }
     return to;
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
@@ -942,7 +942,7 @@ public class H5header extends NCheader
     // check for empty attribute case
     if (matt.mds.type == 2) {
       if (dtype == DataType.CHAR)
-        return new Attribute(matt.name, ""); // empty char considered to be a 0 length string
+        return new Attribute(matt.name, DataType.STRING); // empty char considered to be a null string attr
       else
         return new Attribute(matt.name, dtype);
     }

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -558,8 +558,16 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
           case Nc4prototypes.NC_UBYTE:
             att = new Attribute(attname, DataType.UBYTE);
             break;
-          case Nc4prototypes.NC_CHAR: // a zero length char is considered to be an empty string
-            att = new Attribute(attname, "");
+          case Nc4prototypes.NC_CHAR:
+            // From what I can tell, the way we should treat char attrs depends on
+            // the netCDF format used (3 vs. 4)
+            if ((format == NC_FORMAT_NETCDF4_CLASSIC) || (format == NC_FORMAT_NETCDF4)) {
+              // if netcdf4, make null char attrs null string attrs
+              att = new Attribute(attname, DataType.STRING);
+            } else {
+              // all others, treat null char attrs as empty string attrs
+              att = new Attribute(attname, "");
+            }
             break;
           case Nc4prototypes.NC_DOUBLE:
             att = new Attribute(attname, DataType.DOUBLE);

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -2841,6 +2841,10 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
 
     int ret = 0;
     Array values = att.getValues();
+    Object arrayStorage = null;
+    if (values != null) {
+      arrayStorage = values.getStorage();
+    }
     switch (att.getDataType()) {
       case STRING: // problem may be that we are mapping char * atts to string type
         if(v != null
@@ -2867,37 +2871,37 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
         }
         break;
       case UBYTE:
-        ret = nc4.nc_put_att_uchar(grpid, varid, att.getShortName(), Nc4prototypes.NC_UBYTE, new SizeT(att.getLength()), (byte[]) values.getStorage());
+        ret = nc4.nc_put_att_uchar(grpid, varid, att.getShortName(), Nc4prototypes.NC_UBYTE, new SizeT(att.getLength()), (byte[]) arrayStorage);
         break;
       case BYTE:
-        ret = nc4.nc_put_att_schar(grpid, varid, att.getShortName(), Nc4prototypes.NC_BYTE, new SizeT(att.getLength()), (byte[]) values.getStorage());
+        ret = nc4.nc_put_att_schar(grpid, varid, att.getShortName(), Nc4prototypes.NC_BYTE, new SizeT(att.getLength()), (byte[]) arrayStorage);
         break;
       case CHAR:
-        ret = nc4.nc_put_att_text(grpid, varid, att.getShortName(), new SizeT(att.getLength()), IospHelper.convertCharToByte((char[]) values.getStorage()));
+        ret = nc4.nc_put_att_text(grpid, varid, att.getShortName(), new SizeT(att.getLength()), IospHelper.convertCharToByte((char[]) arrayStorage));
         break;
       case DOUBLE:
-        ret = nc4.nc_put_att_double(grpid, varid, att.getShortName(), Nc4prototypes.NC_DOUBLE, new SizeT(att.getLength()), (double[]) values.getStorage());
+        ret = nc4.nc_put_att_double(grpid, varid, att.getShortName(), Nc4prototypes.NC_DOUBLE, new SizeT(att.getLength()), (double[]) arrayStorage);
         break;
       case FLOAT:
-        ret = nc4.nc_put_att_float(grpid, varid, att.getShortName(), Nc4prototypes.NC_FLOAT, new SizeT(att.getLength()), (float[]) values.getStorage());
+        ret = nc4.nc_put_att_float(grpid, varid, att.getShortName(), Nc4prototypes.NC_FLOAT, new SizeT(att.getLength()), (float[]) arrayStorage);
         break;
       case UINT:
-        ret = nc4.nc_put_att_uint(grpid, varid, att.getShortName(), Nc4prototypes.NC_UINT, new SizeT(att.getLength()), (int[]) values.getStorage());
+        ret = nc4.nc_put_att_uint(grpid, varid, att.getShortName(), Nc4prototypes.NC_UINT, new SizeT(att.getLength()), (int[]) arrayStorage);
         break;
       case INT:
-        ret = nc4.nc_put_att_int(grpid, varid, att.getShortName(), Nc4prototypes.NC_INT, new SizeT(att.getLength()), (int[]) values.getStorage());
+        ret = nc4.nc_put_att_int(grpid, varid, att.getShortName(), Nc4prototypes.NC_INT, new SizeT(att.getLength()), (int[]) arrayStorage);
         break;
       case ULONG:
-        ret = nc4.nc_put_att_ulonglong(grpid, varid, att.getShortName(), Nc4prototypes.NC_UINT64, new SizeT(att.getLength()), (long[]) values.getStorage());
+        ret = nc4.nc_put_att_ulonglong(grpid, varid, att.getShortName(), Nc4prototypes.NC_UINT64, new SizeT(att.getLength()), (long[]) arrayStorage);
         break;
       case LONG:
-        ret = nc4.nc_put_att_longlong(grpid, varid, att.getShortName(), Nc4prototypes.NC_INT64, new SizeT(att.getLength()), (long[]) values.getStorage());
+        ret = nc4.nc_put_att_longlong(grpid, varid, att.getShortName(), Nc4prototypes.NC_INT64, new SizeT(att.getLength()), (long[]) arrayStorage);
         break;
       case USHORT:
-        ret = nc4.nc_put_att_ushort(grpid, varid, att.getShortName(), Nc4prototypes.NC_USHORT, new SizeT(att.getLength()), (short[]) values.getStorage());
+        ret = nc4.nc_put_att_ushort(grpid, varid, att.getShortName(), Nc4prototypes.NC_USHORT, new SizeT(att.getLength()), (short[]) arrayStorage);
         break;
       case SHORT:
-        ret = nc4.nc_put_att_short(grpid, varid, att.getShortName(), Nc4prototypes.NC_SHORT, new SizeT(att.getLength()), (short[]) values.getStorage());
+        ret = nc4.nc_put_att_short(grpid, varid, att.getShortName(), Nc4prototypes.NC_SHORT, new SizeT(att.getLength()), (short[]) arrayStorage);
         break;
     }
 


### PR DESCRIPTION
Addresses Unidata/thredds#925

Before, Array.getStorage() would throw an NPE if the array was null.
Now, we handle the possibility of the NPE, and pass the null value
to netCDF-C (via JNA) and allow the C library to handle the null
pointer.