### PR TITLE
Add eccodes Grib2Table, with ecmwf + 10 other centers. 

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/GribCoordsMatchGbx.java
@@ -649,7 +649,7 @@ public class GribCoordsMatchGbx {
 
     public final String getTimeUnit() {
       int unit = pds.getTimeUnit();
-      return cust.getTableValue("4.4", unit);
+      return cust.getCodeTableValue("4.4", unit);
     }
 
     public final int getForecastTime() {

--- a/cdm/src/main/java/ucar/nc2/wmo/Util.java
+++ b/cdm/src/main/java/ucar/nc2/wmo/Util.java
@@ -37,7 +37,7 @@ public class Util {
       unit = unit.trim();
       unit = StringUtil2.remove(unit, "**");
       StringBuilder sb = new StringBuilder(unit);
-      StringUtil2.remove(sb, "^[]");
+      StringUtil2.removeAll(sb, "^[]");
       StringUtil2.replace(sb, ' ', ".");
       StringUtil2.replace(sb, '*', ".");
       unit = sb.toString();
@@ -59,7 +59,7 @@ public class Util {
     name = StringUtil2.replace(name, '/', "-");
     StringBuilder sb = new StringBuilder(name);
     StringUtil2.replace(sb, '+', "plus");
-    StringUtil2.remove(sb, ".;,=[]()/*\"");
+    StringUtil2.removeAll(sb, ".;,=[]()/*\"");
     return StringUtil2.collapseWhitespace(sb.toString().trim());
   }
 
@@ -69,7 +69,7 @@ public class Util {
     if (pos > 0) desc = desc.substring(0,pos);
 
     StringBuilder sb = new StringBuilder(desc.trim());
-    StringUtil2.remove(sb, ".;,=[]()/*");
+    StringUtil2.removeAll(sb, ".;,=[]()/*");
     return sb.toString().trim();
   }
 
@@ -84,9 +84,9 @@ public class Util {
     if (name1.equals(name2)) return true;
 
     StringBuilder sb1 = new StringBuilder(name1clean);
-    StringUtil2.remove(sb1, " -’'");
+    StringUtil2.removeAll(sb1, " -’'");
     StringBuilder sb2 = new StringBuilder(name2clean);
-    StringUtil2.remove(sb2, " -’'");
+    StringUtil2.removeAll(sb2, " -’'");
     return sb1.toString().equals(sb2.toString());
   }
 

--- a/cdm/src/main/java/ucar/unidata/util/StringUtil2.java
+++ b/cdm/src/main/java/ucar/unidata/util/StringUtil2.java
@@ -28,7 +28,7 @@ public class StringUtil2 {
    * @param replaceChar thar char to replace
    * @return resulting string.
    */
-  static public String allow(String x, String allowChars, char replaceChar) {
+  public static String allow(String x, String allowChars, char replaceChar) {
     boolean ok = true;
     for (int pos = 0; pos < x.length(); pos++) {
       char c = x.charAt(pos);
@@ -109,7 +109,7 @@ public class StringUtil2 {
    * @param okChars these are ok.
    * @return filtered string.
    */
-  static public String filter(String x, String okChars) {
+  public static String filter(String x, String okChars) {
     boolean ok = true;
     for (int pos = 0; pos < x.length(); pos++) {
       char c = x.charAt(pos);
@@ -140,7 +140,7 @@ public class StringUtil2 {
    * @param s filter this string
    * @return filtered string.
    */
-  static public String filter7bits(String s) {
+  public static String filter7bits(String s) {
     if (s == null) return null;
     char[] bo = new char[s.length()];
     int count = 0;
@@ -158,7 +158,7 @@ public class StringUtil2 {
   // remove control characters (< 0x20)
   // transform "/" to "_"
   // transform embedded space to "_"
-  static public String makeValidCdmObjectName(String name) {
+  public static String makeValidCdmObjectName(String name) {
     name = name.trim();
     // common case no change
     boolean ok = true;
@@ -189,7 +189,7 @@ public class StringUtil2 {
    * @param s2 compare this string
    * @return number of matching chars, starting from first char
    */
-  static public int match(String s1, String s2) {
+  public static int match(String s1, String s2) {
     int i = 0;
     while ((i < s1.length()) && (i < s2.length())) {
       if (s1.charAt(i) != s2.charAt(i)) {
@@ -278,7 +278,7 @@ public class StringUtil2 {
    * @param sub remove all occurrences of this substring.
    * @return result with substrings removed
    */
-  static public String remove(String s, String sub) {
+  public static String remove(String s, String sub) {
     int len = sub.length();
     int pos;
     while (0 <= (pos = s.indexOf(sub))) {
@@ -294,7 +294,7 @@ public class StringUtil2 {
    * @param c remove all occurrences of this character.
    * @return result with any character c removed
    */
-  static public String remove(String s, int c) {
+  public static String remove(String s, int c) {
     if (0 > s.indexOf(c)) {  // none
       return s;
     }
@@ -318,7 +318,7 @@ public class StringUtil2 {
    * @param c remove all occurrences of this character that are at the end of the string.
    * @return result with any character c removed
    */
-  static public String removeFromEnd(String s, int c) {
+  public static String removeFromEnd(String s, int c) {
     if (0 > s.indexOf(c))   // none
       return s;
 
@@ -331,7 +331,7 @@ public class StringUtil2 {
     return s.substring(0, len);
   }
 
-  static public String removeFromEnd(String s, String suffix) {
+  public static String removeFromEnd(String s, String suffix) {
     if (s.endsWith(suffix))
       return s.substring(0, s.length() - suffix.length());
 
@@ -363,7 +363,7 @@ public class StringUtil2 {
    * @param s operate on this string
    * @return result with collapsed whitespace
    */
-  static public String collapseWhitespace(String s) {
+  public static String collapseWhitespace(String s) {
     int len = s.length();
     StringBuilder b = new StringBuilder(len);
     for (int i = 0; i < len; i++) {
@@ -388,7 +388,7 @@ public class StringUtil2 {
    * @param in  with this string
    * @return modified string if needed
    */
-  static public String replace(String s, char out, String in) {
+  public static String replace(String s, char out, String in) {
     if (s.indexOf(out) < 0) {
       return s;
     }
@@ -408,7 +408,7 @@ public class StringUtil2 {
    * @param replaceWith replace with these
    * @return resulting string
    */
-  static public String replace(String x, char[] replaceChar, String[] replaceWith) {
+  public static String replace(String x, char[] replaceChar, String[] replaceWith) {
     // common case no replacement
     boolean ok = true;
     for (char aReplaceChar : replaceChar) {
@@ -454,7 +454,7 @@ public class StringUtil2 {
       if (idx < 0)
         break;
 
-      returnValue.append(string.substring(0, idx));
+      returnValue.append(string, 0, idx);
       if (value != null)
         returnValue.append(value);
 
@@ -473,7 +473,7 @@ public class StringUtil2 {
    * @param orgChar    replace with these
    * @return resulting string
    */
-  static public String unreplace(String x, String[] orgReplace, char[] orgChar) {
+  public static String unreplace(String x, String[] orgReplace, char[] orgChar) {
     // common case no replacement
     boolean ok = true;
     for (String anOrgReplace : orgReplace) {
@@ -504,7 +504,7 @@ public class StringUtil2 {
    * @param subst    string to substitute
    * @return a new string with substitutions
    */
-  static public String substitute(String original, String match, String subst) {
+  public static String substitute(String original, String match, String subst) {
     String s = original;
     int pos;
     while (0 <= (pos = s.indexOf(match))) {
@@ -522,7 +522,7 @@ public class StringUtil2 {
    * @param okChars these are ok.
    * @return equivilent escaped string.
    */
-  static public String escape(String x, String okChars) {
+  public static String escape(String x, String okChars) {
     StringBuilder newname = new StringBuilder();
     for (char c : x.toCharArray()) {
       if (c == '%') {
@@ -543,7 +543,7 @@ public class StringUtil2 {
    * @param x operate on this String
    * @return original String.
    */
-  static public String unescape(String x) {
+  public static String unescape(String x) {
     if (x.indexOf('%') < 0) {
       return x;
     }
@@ -595,7 +595,7 @@ public class StringUtil2 {
    * @param subst    array of strings to substitute
    * @return a new string with substitutions
    */
-  static public String substitute(String original, String[] match, String[] subst) {
+  public static String substitute(String original, String[] match, String[] subst) {
 
     boolean ok = true;
     for (String aMatch : match) {
@@ -616,7 +616,7 @@ public class StringUtil2 {
     return sb.toString();
   }
 
-  static public List<String> getTokens(String fullString, String sep) throws Exception {
+  public static List<String> getTokens(String fullString, String sep) throws Exception {
 
     List<String> strs = new ArrayList<>();
     if (sep != null) {
@@ -666,7 +666,7 @@ public class StringUtil2 {
    * @param sb  the StringBuilder
    * @param out get rid of any of these characters
    */
-  static public void remove(StringBuilder sb, String out) {
+  public static void removeAll(StringBuilder sb, String out) {
     int i = 0;
     while (i < sb.length()) {
       int c = sb.charAt(i);
@@ -689,7 +689,7 @@ public class StringUtil2 {
    * @param out repalce this character
    * @param in  with this string
    */
-  static public void replace(StringBuilder sb, char out, String in) {
+  public static void replace(StringBuilder sb, char out, String in) {
     for (int i = 0; i < sb.length(); i++) {
       if (sb.charAt(i) == out) {
         sb.replace(i, i + 1, in);
@@ -705,7 +705,7 @@ public class StringUtil2 {
    * @param out repalce this String
    * @param in  with this char
    */
-  static public void unreplace(StringBuilder sb, String out, char in) {
+  public static void unreplace(StringBuilder sb, String out, char in) {
     int pos;
     while (0 <= (pos = sb.indexOf(out))) {
       sb.setCharAt(pos, in);
@@ -720,7 +720,7 @@ public class StringUtil2 {
    * @param out get rid of any of these characters
    * @param in  replacing with the character at same index
    */
-  static public void replace(StringBuilder sb, String out, String in) {
+  public static void replace(StringBuilder sb, String out, String in) {
     for (int i = 0; i < sb.length(); i++) {
       int c = sb.charAt(i);
       for (int j = 0; j < out.length(); j++) {
@@ -739,7 +739,7 @@ public class StringUtil2 {
    * @param match string to match
    * @param subst string to substitute
    */
-  static public void substitute(StringBuilder sbuff, String match, String subst) {
+  public static void substitute(StringBuilder sbuff, String match, String subst) {
     int pos, fromIndex = 0;
     int substLen = subst.length();
     int matchLen = match.length();
@@ -756,7 +756,7 @@ public class StringUtil2 {
    * @return trimmed string
    */
 
-  static public String trim(String s, int bad) {
+  public static String trim(String s, int bad) {
     int len = s.length();
     int st = 0;
 
@@ -777,7 +777,7 @@ public class StringUtil2 {
   /**
    * @deprecated legacy only, use HtmlEscapers.htmlEscaper()
    */
-  static public String quoteHtmlContent(String x) {
+  public static String quoteHtmlContent(String x) {
     if (x == null) return null;
     return replace(x, htmlIn, htmlOut);
   }

--- a/grib/src/main/java/ucar/nc2/grib/GribUtils.java
+++ b/grib/src/main/java/ucar/nc2/grib/GribUtils.java
@@ -75,7 +75,7 @@ public class GribUtils {
       unit = unit.trim();
       unit = StringUtil2.remove(unit, "**");
       StringBuilder sb = new StringBuilder(unit);
-      StringUtil2.remove(sb, "^[]");
+      StringUtil2.removeAll(sb, "^[]");
       StringUtil2.substitute(sb, " / ", "/");
       StringUtil2.replace(sb, ' ', ".");
       StringUtil2.replace(sb, '*', ".");
@@ -92,7 +92,7 @@ public class GribUtils {
 
     StringBuilder sb = new StringBuilder(desc.trim());
     StringUtil2.replace(sb, '+', "and");
-    StringUtil2.remove(sb, ".;,=[]()/");
+    StringUtil2.removeAll(sb, ".;,=[]()/");
     return sb.toString().trim();
   }
 
@@ -105,7 +105,7 @@ public class GribUtils {
     StringBuilder sb = new StringBuilder(desc.trim());
     StringUtil2.replace(sb, '+', "plus");
     StringUtil2.replace(sb, "/. ", "-p_");
-    StringUtil2.remove(sb, ";,=[]()");
+    StringUtil2.removeAll(sb, ";,=[]()");
     return sb.toString();
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
@@ -225,7 +225,7 @@ public class Grib2Collection extends GribCollectionImmutable {
     v.addAttribute(new Attribute(Grib.VARIABLE_ID_ATTNAME, gc.makeVariableId(vindex)));
     int[] param = new int[]{vindex.getDiscipline(), vindex.getCategory(), vindex.getParameter()};
     v.addAttribute(new Attribute("Grib2_Parameter", Array.makeFromJavaArray(param, false)));
-    String disc = cust2.getTableValue("0.0", vindex.getDiscipline());
+    String disc = cust2.getCodeTableValue("0.0", vindex.getDiscipline());
     if (disc != null) v.addAttribute(new Attribute("Grib2_Parameter_Discipline", disc));
     String cat = cust2.getCategory(vindex.getDiscipline(), vindex.getCategory());
     if (cat != null)

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
@@ -72,7 +72,7 @@ public class Grib2Iosp extends GribIosp {
       }
 
       if (vindex.getSpatialStatisticalProcessType() >= 0) {
-        String statName = cust.getTableValue("4.10", vindex.getSpatialStatisticalProcessType());
+        String statName = cust.getCodeTableValue("4.10", vindex.getSpatialStatisticalProcessType());
         if (statName != null) {
           f.format("_%s", statName);
         }
@@ -127,14 +127,14 @@ public class Grib2Iosp extends GribIosp {
       }
 
       if (vindex.getSpatialStatisticalProcessType() >= 0) {
-        String statName = cust.getTableValue("4.10", vindex.getSpatialStatisticalProcessType());
+        String statName = cust.getCodeTableValue("4.10", vindex.getSpatialStatisticalProcessType());
         if (statName != null) {
           f.format("_%s", statName);
         }
       }
 
       if (vindex.getEnsDerivedType() >= 0) {
-        f.format(" (%s)", cust.getTableValue("4.10", vindex.getEnsDerivedType()));
+        f.format(" (%s)", cust.getCodeTableValue("4.10", vindex.getEnsDerivedType()));
       } else if (isProb) {
         f.format(" %s %s", vindex.getProbabilityName(),
             getVindexUnits(cust, vindex)); // add data units here
@@ -148,7 +148,7 @@ public class Grib2Iosp extends GribIosp {
       }
 
       if (vindex.getLevelType() != GribNumbers.UNDEFINED) { // satellite data doesnt have a level
-        f.format(" @ %s", cust.getTableValue("4.5", vindex.getLevelType()));
+        f.format(" @ %s", cust.getCodeTableValue("4.5", vindex.getLevelType()));
         if (vindex.isLayer()) {
           f.format(" layer");
         }
@@ -243,7 +243,7 @@ public class Grib2Iosp extends GribIosp {
 
   @Override
   protected String getVerticalCoordDesc(int vc_code) {
-    return cust.getTableValue("4.5", vc_code);
+    return cust.getCodeTableValue("4.5", vc_code);
   }
 
   @Override

--- a/grib/src/main/java/ucar/nc2/grib/grib1/tables/NcepRfcTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib1/tables/NcepRfcTables.java
@@ -112,7 +112,7 @@ public class NcepRfcTables extends NcepTables {
         }
 
         StringBuilder lineb = new StringBuilder(line);
-        StringUtil2.remove(lineb, "'+,/");
+        StringUtil2.removeAll(lineb, "'+,/");
         String[] flds = lineb.toString().split("[:]");
 
         int val = Integer.parseInt(flds[0].trim()); // must have a number

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Show.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Show.java
@@ -47,7 +47,7 @@ public class Grib2Show {
 
     int d = gr.getDiscipline();
     f.format("Grib2IndicatorSection%n");
-    f.format(" Discipline = (%d) %s%n", d, cust.getTableValue("0.0", d));
+    f.format(" Discipline = (%d) %s%n", d, cust.getCodeTableValue("0.0", d));
     f.format(" Length     = %d%n", gr.getIs().getMessageLength());
 
     Grib2SectionIdentification id = gr.getId();
@@ -56,11 +56,11 @@ public class Grib2Show {
     f.format(" SubCenter     = (%d) %s%n", id.getSubcenter_id(), cust.getSubCenterName(id.getCenter_id(), id.getSubcenter_id()));
     f.format(" Master Table  = %d%n", id.getMaster_table_version());
     f.format(" Local Table   = %d%n", id.getLocal_table_version());
-    f.format(" RefTimeSignif = %d (%s)%n", id.getSignificanceOfRT(), cust.getTableValue("1.2", id.getSignificanceOfRT()));
+    f.format(" RefTimeSignif = %d (%s)%n", id.getSignificanceOfRT(), cust.getCodeTableValue("1.2", id.getSignificanceOfRT()));
     f.format(" RefTime       = %s%n", id.getReferenceDate());
     f.format(" RefTime Fields = %d-%d-%d %d:%d:%d%n", id.getYear(), id.getMonth(), id.getDay(), id.getHour(), id.getMinute(), id.getSecond());
-    f.format(" ProductionStatus      = %d (%s)%n", id.getProductionStatus(), cust.getTableValue("1.3", id.getProductionStatus()));
-    f.format(" TypeOfProcessedData   = %d (%s)%n", id.getTypeOfProcessedData(), cust.getTableValue("1.4", id.getTypeOfProcessedData()));
+    f.format(" ProductionStatus      = %d (%s)%n", id.getProductionStatus(), cust.getCodeTableValue("1.3", id.getProductionStatus()));
+    f.format(" TypeOfProcessedData   = %d (%s)%n", id.getTypeOfProcessedData(), cust.getCodeTableValue("1.4", id.getTypeOfProcessedData()));
 
     if (gr.hasLocalUseSection()) {
       byte[] lus = gr.getLocalUseSection().getRawBytes();
@@ -74,7 +74,7 @@ public class Grib2Show {
     Grib2Gds ggds = gds.getGDS();
     f.format("%nGrib2GridDefinitionSection hash=%d crc=%d%n", ggds.hashCode(), gds.calcCRC());
     f.format(" Length             = %d%n", gds.getLength());
-    f.format(" Source  (3.0)      = %d (%s) %n", gds.getSource(), cust.getTableValue("3.0", gds.getSource()));
+    f.format(" Source  (3.0)      = %d (%s) %n", gds.getSource(), cust.getCodeTableValue("3.0", gds.getSource()));
     f.format(" Npts               = %d%n", gds.getNumberPoints());
     f.format(" Template (3.1)     = %d%n", gds.getGDSTemplateNumber());
     showGdsTemplate(gds, f, cust);
@@ -98,7 +98,7 @@ public class Grib2Show {
 
     Grib2SectionDataRepresentation drs = gr.getDataRepresentationSection();
     f.format("%nGrib2SectionDataRepresentation%n");
-    f.format("  Template           = %d (%s) %n", drs.getDataTemplate(), cust.getTableValue("5.0", drs.getDataTemplate()));
+    f.format("  Template           = %d (%s) %n", drs.getDataTemplate(), cust.getCodeTableValue("5.0", drs.getDataTemplate()));
     f.format("  NPoints            = %d%n", drs.getDataPoints());
 
     Grib2SectionData ds = gr.getDataSection();
@@ -129,8 +129,8 @@ public class Grib2Show {
 
   public static void showProcessedPds(Grib2Tables cust, Grib2Pds pds, int discipline, Formatter f) {
     int template = pds.getTemplateNumber();
-    f.format(" Product Template %3d = %s%n", template, cust.getTableValue("4.0", template));
-    f.format(" Discipline %3d     = %s%n", discipline, cust.getTableValue("0.0", discipline));
+    f.format(" Product Template %3d = %s%n", template, cust.getCodeTableValue("4.0", template));
+    f.format(" Discipline %3d     = %s%n", discipline, cust.getCodeTableValue("0.0", discipline));
     f.format(" Category %3d       = %s%n", pds.getParameterCategory(), cust.getCategory(discipline, pds.getParameterCategory()));
     GribTables.Parameter entry = cust.getParameter(discipline, pds.getParameterCategory(), pds.getParameterNumber());
     if (entry != null) {
@@ -140,17 +140,17 @@ public class Grib2Show {
       f.format(" Unknown Parameter  = %d-%d-%d %n", discipline, pds.getParameterCategory(), pds.getParameterNumber());
       cust.getParameter(discipline, pds.getParameterCategory(), pds.getParameterNumber()); // debug
     }
-    f.format(" Parameter Table  = %s%n", cust.getTablePath(discipline, pds.getParameterCategory(), pds.getParameterNumber()));
+    f.format(" Parameter Table  = %s%n", cust.getParamTablePathUsedFor(discipline, pds.getParameterCategory(), pds.getParameterNumber()));
 
     int tgp = pds.getGenProcessType();
-    f.format(" Generating Process Type = %3d %s %n", tgp, cust.getTableValue("4.3", tgp));
+    f.format(" Generating Process Type = %3d %s %n", tgp, cust.getCodeTableValue("4.3", tgp));
     f.format(" Forecast Offset    = %3d %n", pds.getForecastTime());
     f.format(" First Surface Type = %3d %s %n", pds.getLevelType1(), cust.getLevelNameShort(pds.getLevelType1()));
     f.format(" First Surface value= %3f %n", pds.getLevelValue1());
     f.format(" Second Surface Type= %3d %s %n", pds.getLevelType2(), cust.getLevelNameShort(pds.getLevelType2()));
     f.format(" Second Surface val = %3f %n", pds.getLevelValue2());
-    f.format("%n Level Name (from table 4.5) = %3s %n", cust.getTableValue("4.5", pds.getLevelType1()));
-    f.format(" Gen Process Ttype (from table 4.3) = %3s %n", cust.getTableValue("4.3", pds.getGenProcessType()));
+    f.format("%n Level Name (from table 4.5) = %3s %n", cust.getCodeTableValue("4.5", pds.getLevelType1()));
+    f.format(" Gen Process Ttype (from table 4.3) = %3s %n", cust.getCodeTableValue("4.3", pds.getGenProcessType()));
   }
 
   public static void showProcessedGridRecord(Grib2Tables cust, Grib2Record gr, Formatter f) {

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Utils.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Utils.java
@@ -29,7 +29,7 @@ public class Grib2Utils {
   public static String clean(String s) {
     StringBuilder sb = new StringBuilder(s);
     StringUtil2.replace(sb, "/. ", "-p_");
-    StringUtil2.remove(sb, "(),;");
+    StringUtil2.removeAll(sb, "(),;");
     char c = sb.charAt(0);
     if (Character.isLetter(c)) {
       if (Character.isLowerCase(c))

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/CfsrLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/CfsrLocalTables.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.grib.grib2.table;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import ucar.nc2.constants.CDM;
@@ -35,18 +36,15 @@ class CfsrLocalTables extends NcepLocalTables {
     initLocalTable();
   }
 
-  // LOOK: Have to override NcepLocalTables. Probably need delegates, not subclasses?
   @Override
-  public List<Parameter> getParameters() {
-    List<Parameter> result = new ArrayList<>(localParams.values());
-    result.sort(new ParameterSort());
-    return result;
+  public ImmutableList<Parameter> getParameters() {
+    return getLocalParameters();
   }
 
   @Override
-  public String getTablePath(int discipline, int category, int number) {
+  public String getParamTablePathUsedFor(int discipline, int category, int number) {
     if ((category <= 191) && (number <= 191)) {
-      return super.getTablePath(discipline, category, number);
+      return super.getParamTablePathUsedFor(discipline, category, number);
     }
     return config.getPath();
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/EccodesLocalConcepts.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/EccodesLocalConcepts.java
@@ -1,0 +1,442 @@
+package ucar.nc2.grib.grib2.table;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.grib.GribTables;
+import ucar.nc2.grib.grib2.Grib2Parameter;
+import ucar.unidata.util.StringUtil2;
+
+/**
+ * Parse the localConcept files needed to create tables for use by the CDM.
+ */
+class EccodesLocalConcepts {
+  private static final Logger logger = LoggerFactory.getLogger(EccodesLocalTables.class);
+  private static final String DISCIPLINE = "discipline";
+  private static final String CATEGORY = "parameterCategory";
+  private static final String NUMBER = "parameterNumber";
+  private static final Charset ENCODING = StandardCharsets.UTF_8;
+
+  private final String tableId;
+
+  private ImmutableListMultimap.Builder<String, LocalConceptPart> localConceptsBuilder = ImmutableListMultimap.builder();
+  private HashMap<String, LocalConcept> localConcepts = new HashMap<>();
+
+  EccodesLocalConcepts(String directoryPath) throws IOException {
+    String[] parts = directoryPath.split("/");
+    this.tableId = parts[parts.length-1];
+
+    parseLocalConcept(directoryPath + "/name.def", Type.name);
+    parseLocalConcept(directoryPath + "/shortName.def", Type.shortName);
+    parseLocalConcept(directoryPath + "/paramId.def", Type.paramId);
+    parseLocalConcept(directoryPath + "/units.def", Type.units);
+    parseLocalConcept(directoryPath + "/cfName.def", Type.cfName);
+    parseLocalConcept(directoryPath + "/cfVarName.def", Type.cfVarName);
+
+    ImmutableListMultimap<String, LocalConceptPart> localConceptPieces = localConceptsBuilder.build();
+
+    for (LocalConceptPart conceptPart : localConceptPieces.values()) {
+      localConcepts.merge(conceptPart.getKey(), new LocalConcept(conceptPart), LocalConcept::merge);
+    }
+  }
+
+  ImmutableListMultimap<Integer, Grib2Parameter> getLocalConceptMultimap() {
+    ImmutableListMultimap.Builder<Integer, Grib2Parameter> result = ImmutableListMultimap.builder();
+    for (LocalConcept lc : localConcepts.values()) {
+      if (lc.getName() != null && lc.getShortName() != null) {
+        int code = Grib2Tables.makeParamId(lc.discipline, lc.category, lc.number);
+        Grib2Parameter param = new Grib2Parameter(lc.discipline, lc.category, lc.number,
+            lc.getName(), lc.getUnits(), lc.getShortName(), null);
+        result.put(code, param);
+      }
+    }
+    return result.build();
+  }
+
+
+  /*
+#Mean of 10 metre wind speed
+'Mean of 10 metre wind speed' = {
+	 discipline = 192 ;
+	 parameterCategory = 228 ;
+	 parameterNumber = 5 ;
+	}
+#Mean total cloud cover
+'Mean total cloud cover' = {
+	 discipline = 192 ;
+	 parameterCategory = 228 ;
+	 parameterNumber = 6 ;
+	}
+#Lake depth
+'Lake depth' = {
+	 discipline = 192 ;
+	 parameterCategory = 228 ;
+	 parameterNumber = 7 ;
+	}
+	   */
+
+  private void parseLocalConcept(String path, Type conceptType) throws IOException {
+    ClassLoader cl = EccodesLocalConcepts.class.getClassLoader();
+    try (InputStream is = cl.getResourceAsStream(path)) {
+      if (is == null) return; // file not found is ok
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(is, ENCODING))) {
+        boolean header = true;
+
+        LocalConceptPart current = null;
+        while (true) {
+          String line = br.readLine();
+          if (line == null) {
+            break; // done with the file
+          }
+          if ((line.length() == 0)) {
+            continue;
+          }
+          // skip header lines
+          if (header && (line.startsWith("# Auto") || line.startsWith("#Provide"))) {
+            continue;
+          }
+          header = false;
+
+          // edzw has this extra line
+          if (line.startsWith("#paramId")) {
+            continue;
+          }
+
+          if (line.startsWith("#")) {
+            if (current != null) {
+              localConceptsBuilder.put(current.getKey(), current);
+            }
+            String paramName = line.substring(1);
+            line = br.readLine();
+            current = new LocalConceptPart(paramName, clean(line), conceptType);
+            continue;
+          }
+
+          if (line.contains("=")) {
+            Iterator<String> tokens = Splitter.on('=')
+                .trimResults()
+                .omitEmptyStrings()
+                .split(line)
+                .iterator();
+            String name = tokens.next();
+            String valueS = clean(tokens.next());
+            Integer value;
+            try {
+              value = Integer.parseInt(valueS);
+              current.add(name, value);
+            } catch (Exception e) {
+              logger.warn("Table {}/{} line {}", tableId, conceptType, line);
+            }
+          }
+        }
+        if (current != null) {
+          localConceptsBuilder.put(current.getKey(), current);
+        }
+      }
+    }
+  }
+
+  private String clean(String in) {
+    StringBuilder sb = new StringBuilder(in);
+    StringUtil2.removeAll(sb, ";={}'");
+    return sb.toString().trim();
+  }
+
+  private class AttributeBag {
+    final Map<String, Integer> atts;
+    AttributeBag(Map<String, Integer> atts) {
+      this.atts = atts;
+    }
+
+    public void show(Formatter f) {
+      if (atts.isEmpty()) return;
+      f.format("     ");
+      for (Map.Entry<String, Integer> entry : atts.entrySet()) {
+        f.format("%s(%3d) ",  entry.getKey(), entry.getValue());
+      }
+      f.format("%n");
+    }
+  }
+
+  private class LocalConcept implements Comparable<LocalConcept> {
+    private final List<AttributeBag> attBags = new ArrayList<>();
+    private final String key;
+    private final int discipline ;
+    private final int category;
+    private final int number;
+    private final Type type;
+    private final String value;
+
+    private String paramName;
+    private String shortName;
+    private String units;
+    private String cfName;
+    private String cfVarName;
+    private String paramId; // LOOK: WTF?
+
+    LocalConcept(LocalConceptPart part) {
+      this.key = part.getKey();
+      this.discipline = part.discipline;
+      this.category = part.category;
+      this.number = part.number;
+
+      this.attBags.add(new AttributeBag(part.att));
+      this.type = part.type;
+      this.value = part.value;
+      extract(this);
+    }
+
+    LocalConcept merge(LocalConcept other) {
+      extract(other);
+
+      // assume that only the attributes in the name.def files are important.
+      if (other.type == Type.name) {
+        this.attBags.addAll(other.attBags);
+      }
+      return this;
+    }
+
+    private void extract(LocalConcept other) {
+      switch (other.type) {
+        case name:
+          this.paramName = other.value;
+          break;
+        case shortName:
+          this.shortName = other.value;
+          break;
+        case paramId:
+          this.paramId = other.value;
+          break;
+        case units:
+          this.units = other.value;
+          break;
+        case cfName:
+          this.cfName = other.value;
+          break;
+        case cfVarName:
+          this.cfVarName = other.value;
+          break;
+      }
+    }
+
+    String getCode() {
+      return Grib2Tables.makeParamCode(discipline, category, number);
+    }
+
+    String getName() {
+      return paramName != null ? paramName : cfName;
+    }
+
+    String getShortName() {
+      return shortName != null ? shortName : cfVarName;
+    }
+
+    String getUnits() {
+      return units != null ? units : "";
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("atBag size=", attBags.size())
+          .add("paramName", paramName)
+          .add("discipline", discipline)
+          .add("category", category)
+          .add("number", number)
+          .add("type", type)
+          .add("value", value)
+          .add("shortName", shortName)
+          .add("units", units)
+          .add("paramId", paramId)
+          .toString();
+    }
+
+    @Override
+    public int compareTo(LocalConcept o) {
+      int c = discipline - o.discipline;
+      if (c != 0) return c;
+      c = category - o.category;
+      if (c != 0) return c;
+      return number - o.number;
+    }
+  }
+
+  private enum Type {name, shortName, paramId, units, cfName, cfVarName}
+  private class LocalConceptPart {
+    private final Map<String, Integer> att = new TreeMap<>();
+    private final String paramName;
+    private final String value;
+    private final Type type;
+
+    private int discipline = -1;
+    private int category = -1;
+    private int number = -1;
+
+    LocalConceptPart(String paramName, String value, Type type) {
+      this.paramName = paramName;
+      this.value = value;
+      this.type = type;
+    }
+
+    void add(String name, int value) {
+      switch (name) {
+        case DISCIPLINE:
+          discipline = value;
+          break;
+        case CATEGORY:
+          category = value;
+          break;
+        case NUMBER:
+          number = value;
+          break;
+        default:
+          att.put(name, value);
+          break;
+      }
+    }
+
+    String getKey() {
+      return paramName + ":" + Grib2Tables.makeParamCode(discipline, category, number);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("paramName", paramName)
+          .add("type", type)
+          .add("discipline", discipline)
+          .add("category", category)
+          .add("number", number)
+          .add("att", att)
+          .toString();
+    }
+  }
+
+  // Obsolete
+  private void checkLocalConceptsParts() {
+    ImmutableListMultimap<String, LocalConceptPart> localConceptPieces = localConceptsBuilder.build();
+    ImmutableList<String> keys = localConceptPieces.asMap().keySet().stream().sorted().collect(ImmutableList.toImmutableList());
+    System.out.printf("%-70s: %-10s: %-10s - %-10s - %s%n", "name", "code", "shortName", "paramId", "units");
+    System.out.printf("-------------------------------------------------------------------------------------------------------------%n");
+    for (String key : keys) {
+      LocalConceptPart name = null;
+      LocalConceptPart shortName = null;
+      LocalConceptPart paramId = null;
+      LocalConceptPart units = null;
+      for (LocalConceptPart concept : localConceptPieces.get(key)) {
+        if (concept.type == Type.name)
+          name = concept;
+        if (concept.type == Type.shortName)
+          shortName = concept;
+        if (concept.type == Type.paramId)
+          paramId = concept;
+        if (concept.type == Type.units)
+          units = concept;
+      }
+      if (name == null || shortName == null || paramId == null || units == null) {
+        System.out.printf("***Missing %s == %s, %s, %s, %s%n", key, name == null, shortName == null,
+            paramId == null, units == null);
+      } else {
+        System.out.printf("%-70s: %-10s: %-10s - %s - %s%n", key, name.getKey(), shortName.value, paramId.value, units.value);
+        for (LocalConceptPart concept : localConceptPieces.get(key)) {
+          if (!concept.att.isEmpty()) {
+            for (Map.Entry<String, Integer> entry : concept.att.entrySet()) {
+              System.out.printf("    %s: %s = %s%n", concept.type, entry.getKey(), entry.getValue());
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static final String FORMAT =  "%-10s: %-70s: %-10s - %-8s - %-10s - %-20s - %s%n";
+
+  void showDetails(Formatter f) {
+    ImmutableList<LocalConcept> sorted = localConcepts.values().stream().sorted().collect(ImmutableList.toImmutableList());
+    Set<String> attNames = new TreeSet<>();
+
+    f.format(FORMAT, "code", "name", "shortName", "paramId", "units", "cfName", "cfVarName");
+    f.format("%s%n", StringUtil2.padRight("-", 120, "-"));
+    for (LocalConcept lc : sorted) {;
+      f.format(FORMAT, lc.getCode(), lc.paramName, lc.shortName, lc.paramId, lc.units, lc.cfName, lc.cfVarName);
+      for (AttributeBag bag : lc.attBags) {
+        bag.show(f);
+        attNames.addAll(bag.atts.keySet());
+      }
+      f.format("%n");
+    }
+    f.format("%s%n", StringUtil2.padRight("-", 120, "-"));
+    f.format("All attribute names in this table:%n");
+    for (String attName : attNames) {
+      f.format(" %s%n", attName);
+    }
+  }
+
+  public void showEntryDetails(Formatter f, List<GribTables.Parameter> params) {
+    List<LocalConcept> concepts = new ArrayList<>();
+    Set<String> attNames = new TreeSet<>();
+
+    for (GribTables.Parameter param : params) {
+      String key = param.getName() + ":" + Grib2Tables.makeParamCode(param.getDiscipline(), param.getCategory(), param.getNumber());
+      LocalConcept want = localConcepts.get(key);
+      concepts.add(want);
+      showLocalConcept(f, want, attNames);
+    }
+    f.format("%n");
+
+    int count = 0;
+    f.format("%-30s   ", "");
+    for (LocalConcept concept : concepts) {
+      for (AttributeBag bag : concept.attBags) {
+        f.format("  (%2d)   ", count);
+      }
+      count++;
+    }
+    f.format("%n");
+
+    for (String attName : attNames) {
+      f.format("%-30s ", attName);
+      for (LocalConcept concept : concepts) {
+        for (AttributeBag bag : concept.attBags) {
+          Integer value = bag.atts.get(attName);
+          f.format("%8s ", value == null ? "" : value);
+        }
+      }
+      f.format("%n");
+    }
+  }
+
+  private void showLocalConcept(Formatter f, LocalConcept lc, Set<String> attNames) {
+    f.format(FORMAT, lc.getCode(), lc.paramName, lc.shortName, lc.paramId, lc.units, lc.cfName, lc.cfVarName);
+    for (AttributeBag bag : lc.attBags) {
+      bag.show(f);
+      attNames.addAll(bag.atts.keySet());
+    }
+    f.format("%n");
+  }
+
+  public static void main(String[] args) throws IOException {
+    EccodesLocalConcepts ec = new EccodesLocalConcepts("resources/grib2/ecmwf/localConcepts/ecmf");
+    //ec.checkLocalConceptsParts();
+    ec.showDetails(new Formatter(System.out));
+  }
+
+}

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/FslHrrrLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/FslHrrrLocalTables.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.grib.grib2.table;
 
+import com.google.common.collect.ImmutableList;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.grib.GribTables;
 import ucar.nc2.grib.grib2.Grib2Parameter;
@@ -32,19 +33,16 @@ public class FslHrrrLocalTables extends NcepLocalTables {
   }
 
   @Override
-  public String getTablePath(int discipline, int category, int number) {
-    if ((category <= 191) && (number <= 191)) return super.getTablePath(discipline, category, number);
+  public String getParamTablePathUsedFor(int discipline, int category, int number) {
+    if ((category <= 191) && (number <= 191)) return super.getParamTablePathUsedFor(discipline, category, number);
     return config.getPath();
   }
 
-  // must override since we are subclassing NcepLocalTables
   @Override
-  public List<GribTables.Parameter> getParameters() {
-    List<Parameter> result = new ArrayList<>(localParams.values());
-    result.sort(new ParameterSort());
-    return result;
+  public ImmutableList<Parameter> getParameters() {
+    return getLocalParameters();
   }
-
+  
   @Override
   public GribTables.Parameter getParameterRaw(int discipline, int category, int number) {
     return localParams.get(makeParamId(discipline, category, number));

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -107,7 +107,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
   }
 
   public static boolean isLocal(int discipline, int category, int number) {
-    return ((discipline > 191) || (category > 191) || (number > 191));
+    return ((discipline <= 191) || (category <= 191) || (number <= 191));
   }
 
   public static boolean isLocal(int code) {

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2TablesId.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2TablesId.java
@@ -5,7 +5,7 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 public class Grib2TablesId {
-  public enum Type {wmo, cfsr, gempak, gsd, kma, ncep, ndfd, mrms, nwsDev, ecmwf}
+  public enum Type {wmo, cfsr, gempak, gsd, kma, ncep, ndfd, mrms, nwsDev, eccodes}
 
   public final int center, subCenter, masterVersion, localVersion, genProcessId;
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/LocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/LocalTables.java
@@ -28,8 +28,8 @@ abstract class LocalTables extends Grib2Tables {
   @Override
   public String getParamTablePathUsedFor(int discipline, int category, int number) {
     return isLocal(discipline, category, number) ?
-        config.getPath() :
-        super.getParamTablePathUsedFor(discipline, category, number);
+        super.getParamTablePathUsedFor(discipline, category, number) :
+        config.getPath();
   }
 
   @Override
@@ -53,7 +53,7 @@ abstract class LocalTables extends Grib2Tables {
 
   @Override
   public String getVariableName(int discipline, int category, int number) {
-    if (!isLocal(discipline, category, number))
+    if (isLocal(discipline, category, number))
       return super.getVariableName(discipline, category, number); // LOOK may have to change
 
     GribTables.Parameter te = getParameter(discipline, category, number);

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/MrmsLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/MrmsLocalTables.java
@@ -21,9 +21,9 @@ public class MrmsLocalTables extends LocalTables {
   }
 
   @Override
-  public String getTablePath(int discipline, int category, int number) {
+  public String getParamTablePathUsedFor(int discipline, int category, int number) {
     if ((category <= 191) && (number <= 191)) {
-      return super.getTablePath(discipline, category, number);
+      return super.getParamTablePathUsedFor(discipline, category, number);
     }
     return this.getClass().getName();
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/NcepLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/NcepLocalTables.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.grib.grib2.table;
 
+import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -23,7 +24,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 /**
- * NCEP local tables
+ * NCEP local tables.
  *
  * @author caron
  * @since 4/3/11
@@ -41,8 +42,8 @@ class NcepLocalTables extends LocalTables {
   }
 
   @Override
-  public String getTablePath(int discipline, int category, int number) {
-    if ((category <= 191) && (number <= 191)) return super.getTablePath(discipline, category, number);
+  public String getParamTablePathUsedFor(int discipline, int category, int number) {
+    if ((category <= 191) && (number <= 191)) return super.getParamTablePathUsedFor(discipline, category, number);
     return ncepLocalParams.getTablePath(discipline, category);
   }
 
@@ -91,11 +92,11 @@ class NcepLocalTables extends LocalTables {
   }
 
   @Override
-  public List<GribTables.Parameter> getParameters() {
-    List<GribTables.Parameter> allParams = new ArrayList<>(3000);
+  public ImmutableList<Parameter> getParameters() {
+    ImmutableList.Builder<GribTables.Parameter> allParams = ImmutableList.builder();
     try {
       String[] fileNames = getResourceListing(config.getPath());
-      if (fileNames == null) return allParams;
+      if (fileNames == null) return ImmutableList.of();
       for (String fileName : fileNames) {
         File f = new File(fileName);
         if (f.isDirectory()) continue;
@@ -112,7 +113,7 @@ class NcepLocalTables extends LocalTables {
     } catch (URISyntaxException | IOException e) {
       logger.error("NcepLocalTables failed", e);
     }
-    return allParams;
+    return allParams.build();
   }
 
   @Override
@@ -160,16 +161,16 @@ class NcepLocalTables extends LocalTables {
   @Override
   public GribTables.Parameter getParameterRaw(int discipline, int category, int number) {
      return ncepLocalParams.getParameter(discipline, category, number);
-   }
+  }
 
   @Override
-  public String getTableValue(String tableName, int code) {
+  public String getCodeTableValue(String tableName, int code) {
     if (tableName.equals("ProcessId")) {
       return getGeneratingProcessName(code);
     }
 
     if ((code < 192) || (code > 254) || tableName.equals("4.0"))
-      return super.getTableValue(tableName, code);
+      return super.getCodeTableValue(tableName, code);
 
     return codeMap.get(tableName + "." + code);
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/NdfdLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/NdfdLocalTables.java
@@ -20,8 +20,8 @@ public class NdfdLocalTables extends LocalTables {
   }
 
   @Override
-  public String getTablePath(int discipline, int category, int number) {
-    if ((category <= 191) && (number <= 191)) return super.getTablePath(discipline, category, number);
+  public String getParamTablePathUsedFor(int discipline, int category, int number) {
+    if ((category <= 191) && (number <= 191)) return super.getParamTablePathUsedFor(discipline, category, number);
     return this.getClass().getName();
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/WmoTemplateTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/WmoTemplateTables.java
@@ -255,7 +255,7 @@ public class WmoTemplateTables {
     }
 
     private String convert(Grib2Tables tables, String table, int value) {
-      String result = tables.getTableValue(table, value);
+      String result = tables.getCodeTableValue(table, value);
       return (result != null) ? result : "Table " + table + " code " + value + " not found";
     }
   }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/tools/EcmwfCodeTableCompare.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/tools/EcmwfCodeTableCompare.java
@@ -3,7 +3,7 @@ package ucar.nc2.grib.grib2.tools;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.Formatter;
-import ucar.nc2.grib.grib2.table.EcmwfCodeTable;
+import ucar.nc2.grib.grib2.table.EccodesCodeTable;
 import ucar.nc2.grib.grib2.table.Grib2CodeTableInterface;
 import ucar.nc2.grib.grib2.table.WmoCodeFlagTables;
 import ucar.nc2.grib.grib2.table.WmoCodeFlagTables.TableType;
@@ -70,7 +70,7 @@ public class EcmwfCodeTableCompare {
       System.out.printf("%s%n", latest.getName());
 
       for (int version = 21; version >= 0; version--) {
-        Grib2CodeTableInterface next = EcmwfCodeTable.factory(version, discipline, category);
+        Grib2CodeTableInterface next = EccodesCodeTable.factory(version, discipline, category);
         if (next == null) {
           System.out.printf("Missing version %d%n", version);
         } else {

--- a/grib/src/main/java/ucar/nc2/grib/grib2/tools/EcmwfParamTableCompare.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/tools/EcmwfParamTableCompare.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.Formatter;
 import ucar.nc2.grib.GribTables;
-import ucar.nc2.grib.grib2.table.EcmwfParamTable;
+import ucar.nc2.grib.grib2.table.EccodesParamTable;
 import ucar.nc2.grib.grib2.table.Grib2ParamTableInterface;
 import ucar.nc2.grib.grib2.table.WmoCodeFlagTables;
 import ucar.nc2.time.CalendarDate;
@@ -96,7 +96,7 @@ public class EcmwfParamTableCompare {
     System.out.printf("%s%n", latest.getName());
 
     for (int version = 21; version >= 0; version--) {
-      Grib2ParamTableInterface next = EcmwfParamTable.factory(version, discipline, category);
+      Grib2ParamTableInterface next = EccodesParamTable.factory(version, discipline, category);
       if (next == null) {
         System.out.printf("Missing version %d%n", version);
       } else {

--- a/grib/src/main/resources/resources/grib2/standardTableMap.txt
+++ b/grib/src/main/resources/resources/grib2/standardTableMap.txt
@@ -26,4 +26,14 @@
 161;	0; -1; -1; -1; mrms; nssl MULTI-RADAR/MULTI-SENSOR SYSTEM;
 #
 # ECMWF and friends
-98;     -1; -1; -1; -1;   ecmwf; ECMWF; resources/grib2/ecmwf/tables/21
+98;     -1; -1; -1; -1;   eccodes; ecmwf; resources/grib2/ecmwf/localConcepts/ecmf
+80;     -1; -1; -1; -1;   eccodes; Rome; resources/grib2/ecmwf/localConcepts/cnmc
+78;     -1; -1; -1; -1;   eccodes; Offenbach; resources/grib2/ecmwf/localConcepts/edzw
+86;     -1; -1; -1; -1;   eccodes; Helsinki; resources/grib2/ecmwf/localConcepts/efkl
+74;     -1; -1; -1; -1;   eccodes; U.K. Met Office; resources/grib2/ecmwf/localConcepts/egrr
+94;     -1; -1; -1; -1;   eccodes; Copenhagen; resources/grib2/ecmwf/localConcepts/ekmi
+82;     -1; -1; -1; -1;   eccodes; Norrkoping; resources/grib2/ecmwf/localConcepts/eswi
+ 7;     -1; -1; -1; -1;   eccodes; NCEP; resources/grib2/ecmwf/localConcepts/kwbc
+84;     -1; -1; -1; -1;   eccodes; French Weather Service; resources/grib2/ecmwf/localConcepts/lfpw
+85;     -1; -1; -1; -1;   eccodes; French Weather Service; resources/grib2/ecmwf/localConcepts/lfpw1
+215;    -1; -1; -1; -1;   eccodes; Zurich; resources/grib2/ecmwf/localConcepts/lssw

--- a/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
@@ -1,7 +1,7 @@
 package ucar.nc2.grib.grib2.table;
 
 import static com.google.common.truth.Truth.assertThat;
-import static ucar.nc2.grib.grib2.table.EcmwfCodeTable.LATEST_VERSION;
+import static ucar.nc2.grib.grib2.table.EccodesCodeTable.LATEST_VERSION;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -55,10 +55,11 @@ public class TestLocalTables {
       int discipline = Integer.parseInt(tokens.next());
       int category = Integer.parseInt(tokens.next());
 
-      EcmwfCodeTable ecmwfCodeTable = EcmwfCodeTable.factory(LATEST_VERSION, discipline, category);
+      EccodesCodeTable ecmwfCodeTable = EccodesCodeTable
+          .factory(LATEST_VERSION, discipline, category);
       assertThat(ecmwfCodeTable).isNotNull();
       for (Grib2CodeTableInterface.Entry entry : ecmwfCodeTable.getEntries()) {
-        assertThat(ecmwfTable.getTableValue(tableName, entry.getCode())).isEqualTo(entry.getName());
+        assertThat(ecmwfTable.getCodeTableValue(tableName, entry.getCode())).isEqualTo(entry.getName());
       }
     }
   }

--- a/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
@@ -43,7 +43,7 @@ public class TestLocalTables {
 
     Grib2Tables ecmwfTable = Grib2Tables.factory(98, -1, -1, -1, -1);
     assertThat(ecmwfTable).isNotNull();
-    assertThat(ecmwfTable.getType()).isEqualTo(Grib2TablesId.Type.ecmwf);
+    assertThat(ecmwfTable.getType()).isEqualTo(Grib2TablesId.Type.eccodes);
 
     for (String tableName : tableOverrides) {
       Iterator<String> tokens = Splitter.on('.')

--- a/legacy/src/main/java/ucar/nc2/grib/GribVariableRenamer.java
+++ b/legacy/src/main/java/ucar/nc2/grib/GribVariableRenamer.java
@@ -179,7 +179,7 @@ public class GribVariableRenamer {
 
   private String munge(String old) {
     StringBuilder oldLower = new StringBuilder( old.toLowerCase());
-    StringUtil2.remove(oldLower, "_-");
+    StringUtil2.removeAll(oldLower, "_-");
     return oldLower.toString();
   }
   

--- a/ui/src/main/java/ucar/nc2/ui/grib/Grib2CollectionPanel.java
+++ b/ui/src/main/java/ucar/nc2/ui/grib/Grib2CollectionPanel.java
@@ -1033,7 +1033,7 @@ public class Grib2CollectionPanel extends JPanel {
     }
 
     public String getGridName() {
-      return cust.getTableValue("3.1", gdss.getGDSTemplateNumber());
+      return cust.getCodeTableValue("3.1", gdss.getGDSTemplateNumber());
     }
 
     public String getGroupName() {
@@ -1286,7 +1286,7 @@ public class Grib2CollectionPanel extends JPanel {
 
     public final String getTimeUnit() {
       int unit = pds.getTimeUnit();
-      return cust.getTableValue("4.4", unit);
+      return cust.getCodeTableValue("4.4", unit);
     }
 
     public final int getForecastTime() {

--- a/ui/src/main/java/ucar/nc2/ui/grib/Grib2TableViewer2.java
+++ b/ui/src/main/java/ucar/nc2/ui/grib/Grib2TableViewer2.java
@@ -15,6 +15,7 @@ import ucar.nc2.ui.widget.IndependentWindow;
 import ucar.nc2.ui.widget.PopupMenu;
 import ucar.nc2.ui.widget.TextHistoryPane;
 import ucar.nc2.units.SimpleUnit;
+import ucar.nc2.wmo.CommonCodeTable;
 import ucar.util.prefs.PreferencesExt;
 import ucar.util.prefs.ui.BeanTable;
 
@@ -26,7 +27,7 @@ import java.util.Formatter;
 import java.util.List;
 
 /**
- * Describe
+ * Viewer for Grib2Tables.
  *
  * @author caron
  * @since 9/14/2014
@@ -52,8 +53,8 @@ public class Grib2TableViewer2 extends JPanel {
         setEntries(csb.table);
     });
 
-    ucar.nc2.ui.widget.PopupMenu varPopup = new PopupMenu(gribTable.getJTable(), "Options");
-    varPopup.addAction("Compare two tables", new AbstractAction() {
+    ucar.nc2.ui.widget.PopupMenu tablePopup = new PopupMenu(gribTable.getJTable(), "Options");
+    tablePopup.addAction("Select and compare two tables", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
         List list = gribTable.getSelectedBeans();
         if (list.size() == 2) {
@@ -63,14 +64,25 @@ public class Grib2TableViewer2 extends JPanel {
         }
       }
     });
+    tablePopup.addAction("Compare with WMO", new AbstractAction() {
+      public void actionPerformed(ActionEvent e) {
+        lookForProblems(current);
+      }
+    });
+    tablePopup.addAction("Show low-level details", new AbstractAction() {
+      public void actionPerformed(ActionEvent e) {
+        showDetails(current);
+      }
+    });
 
     entryTable = new BeanTable(EntryBean.class, (PreferencesExt) prefs.node("EntryBean"), false);
 
-    AbstractButton dupButton = BAMutil.makeButtcon("Select", "Look for problems in this table", false);
-    dupButton.addActionListener(e -> {
-        lookForProblems();
+    ucar.nc2.ui.widget.PopupMenu entryPopup = new PopupMenu(entryTable.getJTable(), "Options");
+    entryPopup.addAction("Show low-level details for selected enties", new AbstractAction() {
+      public void actionPerformed(ActionEvent e) {
+        showEntryDetails(current, entryTable.getSelectedBeans());
+      }
     });
-    buttPanel.add(dupButton);
 
     // the info window
     infoTA = new TextHistoryPane();
@@ -83,25 +95,12 @@ public class Grib2TableViewer2 extends JPanel {
     setLayout(new BorderLayout());
     add(split, BorderLayout.CENTER);
 
-    /* AbstractButton infoButton = BAMutil.makeButtcon("Information", "Show Table Used", false);
-    infoButton.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        if (dialog == null) {
-          dialog = new Grib1TableDialog((Frame) null);
-          dialog.pack();
-        }
-        dialog.setVisible(true);
-      }
-    });
-    buttPanel.add(infoButton); */
-
     try {
       ImmutableList<Grib2Tables> tables = Grib2Tables.getAllRegisteredTables();
       java.util.List<TableBean> beans = new ArrayList<>();
       for (Grib2Tables t : tables) {
         beans.add(new TableBean(t));
       }
-      //Collections.sort(beans);
       gribTable.setBeans(beans);
 
     } catch (Exception e) {
@@ -126,17 +125,16 @@ public class Grib2TableViewer2 extends JPanel {
     current = gt;
   }
 
-  private void lookForProblems() {
+  private void lookForProblems(Grib2Tables cust) {
     int total = 0;
     int probs = 0;
 
     Formatter f = new Formatter();
-    Grib2Tables cust = current;
     cust.lookForProblems(f);
 
     f.format("PROBLEMS with units%n");
     for (Object t : entryTable.getBeans()) {
-      Grib2Tables.Parameter p = ((EntryBean) t).param;
+      GribTables.Parameter p = ((EntryBean) t).param;
       if (p.getUnit() == null) continue;
       if (p.getUnit().length() == 0) continue;
       try {
@@ -160,7 +158,7 @@ public class Grib2TableViewer2 extends JPanel {
     int unitsDiffer = 0;
     f.format("Conflicts with WMO%n");
     for (Object t : entryTable.getBeans()) {
-      Grib2Tables.Parameter p = ((EntryBean) t).param;
+      GribTables.Parameter p = ((EntryBean) t).param;
       if (Grib2Tables.isLocal(p)) {
         local++;
         continue;
@@ -194,14 +192,14 @@ public class Grib2TableViewer2 extends JPanel {
   private void compareTables(Grib2Tables t1, Grib2Tables t2) {
     Formatter f = new Formatter();
 
-    f.format("Table 1 = %s (%s)%n", t1.getName(), t1.getTablePath(0, 192,192)); // local  // WTF ??
-    f.format("Table 2 = %s (%s)%n", t2.getName(), t2.getTablePath(0, 192,192)); // local
+    f.format("Table 1 = %s (%s)%n", t1.getName(), t1.getParamTablePathUsedFor(0, 192,192)); // local  // WTF ??
+    f.format("Table 2 = %s (%s)%n", t2.getName(), t2.getParamTablePathUsedFor(0, 192,192)); // local
 
     int conflict = 0;
     f.format("Table 1 : %n");
     for (Object t : t1.getParameters()) {
-      Grib2Tables.Parameter p1 = (Grib2Tables.Parameter) t;
-      Grib2Tables.Parameter  p2 = t2.getParameterRaw(p1.getDiscipline(), p1.getCategory(), p1.getNumber());
+      GribTables.Parameter p1 = (Grib2Tables.Parameter) t;
+      GribTables.Parameter  p2 = t2.getParameterRaw(p1.getDiscipline(), p1.getCategory(), p1.getNumber());
       if (p1.getName() == null || p1.getUnit() == null) {
         f.format(" Missing name or unit in table 1 param=%s%n", p1);
       } else if (p2 != null && (!p1.getName().equals( p2.getName()) || !p1.getUnit().equals( p2.getUnit()) ||
@@ -215,8 +213,8 @@ public class Grib2TableViewer2 extends JPanel {
 
     int extra = 0;
     for (Object t : t1.getParameters()) {
-      Grib2Tables.Parameter p1 = (Grib2Tables.Parameter) t;
-      Grib2Tables.Parameter  p2 = t2.getParameterRaw(p1.getDiscipline(), p1.getCategory(), p1.getNumber());
+      GribTables.Parameter p1 = (GribTables.Parameter) t;
+      GribTables.Parameter  p2 = t2.getParameterRaw(p1.getDiscipline(), p1.getCategory(), p1.getNumber());
       if (p2 == null) {
         extra++;
         f.format(" Missing %s in table 2%n", p1);
@@ -227,8 +225,8 @@ public class Grib2TableViewer2 extends JPanel {
     extra = 0;
     f.format("Table 2 has the following not in Table 1:%n");
     for (Object t : t2.getParameters()) {
-      Grib2Tables.Parameter p2 = (Grib2Tables.Parameter) t;
-      Grib2Tables.Parameter  p1 = t1.getParameterRaw(p2.getDiscipline(), p2.getCategory(), p2.getNumber());
+      GribTables.Parameter p2 = (GribTables.Parameter) t;
+      GribTables.Parameter  p1 = t1.getParameterRaw(p2.getDiscipline(), p2.getCategory(), p2.getNumber());
       if (p1 == null) {
         extra++;
         f.format(" %s%n", p2);
@@ -236,7 +234,27 @@ public class Grib2TableViewer2 extends JPanel {
     }
     f.format("%ntotal extra=%d%n%n", extra);
 
+    infoTA.setText(f.toString());
+    infoWindow.show();
+  }
 
+  private void showDetails(Grib2Tables grib2Table) {
+    Formatter f = new Formatter();
+    grib2Table.showDetails(f);
+    infoTA.setText(f.toString());
+    infoWindow.show();
+  }
+
+  private void showEntryDetails(Grib2Tables grib2Table, List entries) {
+    int total = 0;
+    int probs = 0;
+
+    Formatter f = new Formatter();
+    List<GribTables.Parameter> params = new ArrayList<>();
+    for (Object bean : entries) {
+      params.add(((EntryBean) bean).param);
+    }
+    grib2Table.showEntryDetails(f, params);
     infoTA.setText(f.toString());
     infoWindow.show();
   }
@@ -257,15 +275,19 @@ public class Grib2TableViewer2 extends JPanel {
       return table.getName();
     }
 
-    public int getCenter_id() {
+    public String getWmoName() {
+      return CommonCodeTable.getCenterName(id.center, 11);
+    }
+
+    public int getCenter() {
       return id.center;
     }
 
-    public int getSubcenter_id() {
+    public int getSubcenter() {
       return id.subCenter;
     }
 
-    public int getVersionNumber() {
+    public int getMasterVersion() {
       return id.masterVersion;
     }
 
@@ -287,11 +309,11 @@ public class Grib2TableViewer2 extends JPanel {
 
     @Override
     public int compareTo(TableBean o) {
-      int ret = getCenter_id() - o.getCenter_id();
+      int ret = getCenter() - o.getCenter();
       if (ret == 0)
-        ret = getSubcenter_id() - o.getSubcenter_id();
+        ret = getSubcenter() - o.getSubcenter();
       if (ret == 0)
-        ret = getVersionNumber() - o.getVersionNumber();
+        ret = getMasterVersion() - o.getMasterVersion();
       return ret;
     }
   }

--- a/ui/src/main/java/ucar/nc2/ui/grib/GribIndexPanel.java
+++ b/ui/src/main/java/ucar/nc2/ui/grib/GribIndexPanel.java
@@ -424,7 +424,7 @@ public class GribIndexPanel extends JPanel {
     }
 
     public String getGridName() {
-      return cust2.getTableValue("3.1", gdss.getGDSTemplateNumber());
+      return cust2.getCodeTableValue("3.1", gdss.getGDSTemplateNumber());
     }
 
     public String getGroupName() {


### PR DESCRIPTION
These are used only for local parameters.

Add functionality in Grib2TableViewer to examine the overriding of standard parameters (overriding not used in production).

Tweek Grib2Table API, eg Grib2Table.getTableValue -> getCodeTableValue
Rename StringUtil2.remove -> StringUtil2.removeAll