### PR TITLE
fix ncss page

### DIFF
--- a/tds/src/main/webapp/WEB-INF/xsl/ncssGrid.xsl
+++ b/tds/src/main/webapp/WEB-INF/xsl/ncssGrid.xsl
@@ -253,6 +253,7 @@
 
                                     <div id="gridPreviewFrame">
                                         <div id="gridPreview">
+                                            <span></span>
                                             <!-- grid preview... -->
                                         </div>
                                     </div>

--- a/tds/src/main/webapp/WEB-INF/xsl/ncssGridAsPoint.xsl
+++ b/tds/src/main/webapp/WEB-INF/xsl/ncssGridAsPoint.xsl
@@ -253,6 +253,7 @@
 
                                     <div id="gridPreviewFrame">
                                         <div id="gridPreview">
+                                            <span></span>
                                             <!-- grid preview... -->
                                         </div>
                                     </div>


### PR DESCRIPTION
In `xsl` land, empty elements are output without closing tags when the output is `html`.
This causes all kinds of issues with the table layout.
By inserting a `<span></span>` within the empty `<div>`s used for holding ncss map previews, we keep the right table nesting, and we don't get a collision of the url builder row and the right column widgets.
Thank you @ddirks for helping debug this madness