### PR TITLE
Update docs

### DIFF
--- a/docs/website/tds/tutorial/GettingStarted.html
+++ b/docs/website/tds/tutorial/GettingStarted.html
@@ -17,6 +17,10 @@
 <body>
 <h1>Getting Started With the TDS: Local Test Server Setup</h1>
 
+<h2>Notice: This section is out of date with respect to recent versionis of Java and Tomcat</h2>
+
+For a more up-to-date version of this content, please follow the TDS 5.0 guide starting at <a href="https://docs.unidata.ucar.edu/tds/5.0/userguide/install_java_tomcat.html">https://docs.unidata.ucar.edu/tds/5.0/userguide/install_java_tomcat.html</a>
+
 <div id="section">
   <h2><a name="context">What This Section Covers</a></h2>
 

--- a/docs/website/tds/tutorial/Security.html
+++ b/docs/website/tds/tutorial/Security.html
@@ -10,7 +10,7 @@
 
 <h1>Production Server Overview</h1>
 
-<h2>Notice: This section is out of date with respect to recent version of Tomcat</h2>
+<h2>Notice: This section is out of date with respect to recent versions of Java and Tomcat</h2>
 
 For a more up-to-date version of this content, please follow the TDS 5.0 guide starting at <a href="https://docs.unidata.ucar.edu/tds/5.0/userguide/tomcat_permissions.html">https://docs.unidata.ucar.edu/tds/5.0/userguide/tomcat_permissions.html</a>
 


### PR DESCRIPTION
Update the Getting Started and Security docs to point to the 5.0
verions, which contain up-to-date info for the most recent versions of
Tomcat 9 and Java 8 (openjdk)