### PR TITLE
DiskCache2 createUniqueFile name duplication

### DIFF
--- a/cdm/src/test/java/ucar/nc2/util/DiskCache2Test.java
+++ b/cdm/src/test/java/ucar/nc2/util/DiskCache2Test.java
@@ -1,5 +1,7 @@
 package ucar.nc2.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.*;
 
 import java.io.File;
@@ -14,15 +16,16 @@ import java.nio.file.Paths;
  */
 public class DiskCache2Test {
 
-  private static Path testCacheDir;
   private static Path dirForStaticTests;
   private static DiskCache2 diskCache;
+
+  private static List<File> filesToDelete = new ArrayList<>();
 
   @BeforeClass
   public static void beforeClass() throws IOException {
     String cacheName = DiskCache2Test.class.getSimpleName();
     dirForStaticTests = Files.createTempDirectory(cacheName + "-static-tests");
-    testCacheDir = Files.createTempDirectory(cacheName);
+    Path testCacheDir = Files.createTempDirectory(cacheName);
 
     try {
       Files.deleteIfExists(testCacheDir);
@@ -50,26 +53,25 @@ public class DiskCache2Test {
   @Test
   public void canWriteFile() throws IOException {
     File file = Files.createTempFile(dirForStaticTests, "temp", null).toFile();
-
-    try {
-      Assert.assertTrue(file.exists());
-      Assert.assertTrue(DiskCache2.canWrite(file));
-    } finally {
-      file.delete();
-    }
+    Assert.assertTrue(file.exists());
+    filesToDelete.add(file);
+    Assert.assertTrue(DiskCache2.canWrite(file));
   }
 
   @Test
   public void cantWriteFile() throws IOException {
     File file = Files.createTempFile(dirForStaticTests, "temp", null).toFile();
+    filesToDelete.add(file);
 
-    try {
-      Assert.assertTrue(file.exists());
-      Assert.assertTrue(file.setWritable(false));
-      Assert.assertFalse(DiskCache2.canWrite(file));
-    } finally {
-      file.delete();
-    }
+    Assert.assertTrue(file.exists());
+
+    // make unwritable
+    Assert.assertTrue(file.setWritable(false));
+    Assert.assertFalse(DiskCache2.canWrite(file));
+
+    // change back to writable so we can clean up
+    Assert.assertTrue(file.setWritable(true));
+    Assert.assertTrue(DiskCache2.canWrite(file));
   }
 
   @Test
@@ -93,36 +95,58 @@ public class DiskCache2Test {
   public void checkUniqueFileNames() throws IOException {
     final String prefix  = "pre-";
     final String suffix  = "-suf";
+    final String lockFileExtention = ".reserve";
 
-    File first = diskCache.createUniqueFile(prefix, suffix);
-    File second = diskCache.createUniqueFile(prefix, suffix);
+    // loop a few times to make sure it triggers.
+    for (int i = 0; i < 5; i++){
+      File first = diskCache.createUniqueFile(prefix, suffix);
+      File second = diskCache.createUniqueFile(prefix, suffix);
 
-    // files do not exist yet
-    Assert.assertFalse(first.exists());
-    Assert.assertFalse(second.exists());
+      // files do not exist yet
+      Assert.assertFalse(first.exists());
+      Assert.assertFalse(second.exists());
 
-    // make the files
-    first.createNewFile();
-    second.createNewFile();
+      // make the files
+      first.createNewFile();
+      second.createNewFile();
 
-    // files should exist now
-    Assert.assertTrue(first.exists());
-    Assert.assertTrue(second.exists());
+      // keep track of files that need to be cleaned up
+      filesToDelete.add(first);
+      filesToDelete.add(second);
 
-    // make sure they start with prefix
-    Assert.assertTrue(first.getName().startsWith(prefix));
-    Assert.assertTrue(second.getName().startsWith(prefix));
+      // files should exist now
+      Assert.assertTrue(first.exists());
+      Assert.assertTrue(second.exists());
 
-    // make sure they end with suffix
-    Assert.assertTrue(first.getName().endsWith(suffix));
-    Assert.assertTrue(second.getName().endsWith(suffix));
+      // lock files should exist as well
+      File firstLockFile = Paths.get(first.getCanonicalFile().toString() + lockFileExtention).toFile();
+      File secondLockFile = Paths.get(second.getCanonicalFile().toString() + lockFileExtention).toFile();
+      Assert.assertTrue(firstLockFile.exists());
+      Assert.assertTrue(secondLockFile.exists());
+      filesToDelete.add(firstLockFile);
+      filesToDelete.add(secondLockFile);
 
-    // make sure they are different files
-    Assert.assertNotEquals(first.getAbsolutePath(), second.getAbsolutePath());
+      // make sure they start with prefix
+      Assert.assertTrue(first.getName().startsWith(prefix));
+      Assert.assertTrue(second.getName().startsWith(prefix));
+
+      // make sure they end with suffix
+      Assert.assertTrue(first.getName().endsWith(suffix));
+      Assert.assertTrue(second.getName().endsWith(suffix));
+
+      // make sure they are different files
+      Assert.assertNotEquals(first.getAbsolutePath(), second.getAbsolutePath());
+    }
   }
 
   @AfterClass
   public static void afterClass() throws IOException {
+    for (File f : filesToDelete) {
+      Files.deleteIfExists(f.toPath());
+    }
+    Files.delete(dirForStaticTests);
+
     diskCache.exit();
+    Files.deleteIfExists(Paths.get(diskCache.getRootDirectory()));
   }
 }

--- a/tds/src/main/java/thredds/server/cdmremote/PointWriter.java
+++ b/tds/src/main/java/thredds/server/cdmremote/PointWriter.java
@@ -301,7 +301,7 @@ public class PointWriter {
 
     WriterNetcdf() throws IOException {
       super(null);
-      netcdfResult = diskCache.createUniqueFile("CdmrFeature", ".nc");
+      netcdfResult = diskCache.createUniqueFile("cdmr-point", ".nc");
       List<Attribute> atts = new ArrayList<>();
       atts.add( new Attribute( CDM.TITLE, "Extracted data from TDS Feature Collection " + fd.getLocation() ));
       // String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars, List<Variable> extra, DateUnit timeUnit, String altUnits, CFPointWriterConfig config

--- a/tds/src/main/java/thredds/server/cdmremote/StationWriter.java
+++ b/tds/src/main/java/thredds/server/cdmremote/StationWriter.java
@@ -726,7 +726,7 @@ public class StationWriter {
     WriterNetcdf() throws IOException {
       super(null);
 
-      netcdfResult = diskCache.createUniqueFile("cdmSW", ".nc");
+      netcdfResult = diskCache.createUniqueFile("cdmr-station", ".nc");
       List<Attribute> atts = new ArrayList<>();
       atts.add(new Attribute(CDM.TITLE, "Extracted data from TDS using CDM remote subsetting"));
       cfWriter = null; // new WriterCFStationCollection(null, netcdfResult.getAbsolutePath(), atts);

--- a/tds/src/main/java/thredds/server/ncss/controller/GridResponder.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/GridResponder.java
@@ -230,12 +230,7 @@ class GridResponder extends GridDatasetResponder {
         throw new RequestTooLargeException("NCSS response too large = " + estimatedSize + " max = " + maxFileDownloadSize);
     }
 
- 		Random random = new Random(System.currentTimeMillis());
- 		int randomInt = random.nextInt();
-
- 		String filename = NcssRequestUtils.getFileNameForResponse(requestPathInfo, version);
- 		String pathname = Integer.toString(randomInt) + "/" + filename;
- 		File ncFile = NcssDiskCache.getInstance().getDiskCache().getCacheFile(pathname);
+		File ncFile = NcssDiskCache.getInstance().getDiskCache().createUniqueFile("ncss-grid", ".nc");
     if(ncFile == null)
       throw new IllegalStateException("NCSS misconfigured cache = ");
  		String cacheFilename = ncFile.getPath();

--- a/tds/src/main/java/thredds/server/ncss/view/dsg/point/PointSubsetWriterNetcdf.java
+++ b/tds/src/main/java/thredds/server/ncss/view/dsg/point/PointSubsetWriterNetcdf.java
@@ -43,7 +43,7 @@ public class PointSubsetWriterNetcdf extends AbstractPointSubsetWriter {
         this.out = out;
         this.version = version;
 
-        this.netcdfResult = diskCache.createUniqueFile("ncssTemp", ".nc");
+        this.netcdfResult = diskCache.createUniqueFile("ncss-point", ".nc");
         List<Attribute> attribs = new ArrayList<>();
         attribs.add(new Attribute(CDM.TITLE, "Extracted data from TDS Feature Collection " + fdPoint.getLocation()));
 

--- a/tds/src/main/java/thredds/server/ncss/view/dsg/station/StationSubsetWriterNetcdf.java
+++ b/tds/src/main/java/thredds/server/ncss/view/dsg/station/StationSubsetWriterNetcdf.java
@@ -44,7 +44,7 @@ public class StationSubsetWriterNetcdf extends AbstractStationSubsetWriter {
         this.out = out;
         this.version = version;
 
-        this.netcdfResult = diskCache.createUniqueFile("ncssTemp", ".nc");
+        this.netcdfResult = diskCache.createUniqueFile("ncss-station", ".nc");
         List<Attribute> attribs = new ArrayList<>();
         attribs.add(new Attribute(CDM.TITLE, "Extracted data from TDS Feature Collection " + fdPoint.getLocation()));
 

--- a/tds/src/main/java/thredds/server/ncss/view/gridaspoint/NetCDFPointDataWriter.java
+++ b/tds/src/main/java/thredds/server/ncss/view/gridaspoint/NetCDFPointDataWriter.java
@@ -82,7 +82,7 @@ public class NetCDFPointDataWriter implements PointDataWriter {
         this.outputStream = outputStream;
         this.version = version;
         this.diskCache = diskCache;
-        netcdfResult = diskCache.createUniqueFile("ncss", ".nc");
+        netcdfResult = diskCache.createUniqueFile("ncss-grid-as-point", ".nc");
     }
 
     //public boolean header(Map<String, List<String>> groupedVars, GridDataset gridDataset, List<CalendarDate> wDates,


### PR DESCRIPTION
DiskCache2.createUniqueFile can result in a file name duplication. This has a tremendous impact on the TDS NCSS, in which multiple writers can, under certain circumstances, unknowingly write to the same file.