### PR TITLE
Use the data_word_size from the level 2 message

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/nexrad2/Test16BitDataWidth.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/nexrad2/Test16BitDataWidth.java
@@ -1,0 +1,52 @@
+package ucar.nc2.iosp.nexrad2;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.MAMath.MinMax;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+@Category(NeedsCdmUnitTest.class)
+public class Test16BitDataWidth {
+
+  private static final String filename =
+      TestDir.cdmUnitTestDir + "formats/nexrad/newLevel2/testfiles/Level2_KDDC_20201007_1914.ar2v";
+  private static final double comparisonTolerance = 1e-6;
+
+
+  @Test
+  public void testNonPhiVar() throws IOException, InvalidRangeException {
+    try (NetcdfFile ncf = NetcdfFile.open(filename)) {
+      // verified against metpy
+      MinMax expectedMinMax = new MinMax(0, 1058);
+      Variable var = ncf.findVariable("DifferentialReflectivity_HI");
+      Array data = var.read("0,:,:");
+      MinMax minMax = MAMath.getMinMax(data);
+
+      Assert.assertTrue(Math.abs(minMax.min - expectedMinMax.min) < comparisonTolerance);
+      Assert.assertTrue(Math.abs(minMax.max - expectedMinMax.max) < comparisonTolerance);
+    }
+  }
+
+  @Test
+  public void testNonPhiVarEnhanced() throws IOException, InvalidRangeException {
+    try (NetcdfDataset ncf = NetcdfDataset.openDataset(filename)) {
+      // verified against metpy
+      MinMax expectedMinMax = new MinMax(-13, 20);
+      Variable var = ncf.findVariable("DifferentialReflectivity_HI");
+      Array data = var.read("0,:,:");
+      MinMax minMax = MAMath.getMinMax(data);
+
+      Assert.assertTrue(Math.abs(minMax.min - expectedMinMax.min) < comparisonTolerance);
+      Assert.assertTrue(Math.abs(minMax.max - expectedMinMax.max) < comparisonTolerance);
+    }
+  }
+}

--- a/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -288,7 +288,7 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
     dims.add( gateDim);
 
     Variable v = new Variable(ncfile, null, null, shortName);
-    if(datatype == DIFF_PHASE){
+    if (firstRecord.getDataWordSize(datatype) == 16) {
         v.setDataType(DataType.SHORT);
     } else {
         v.setDataType(DataType.BYTE);


### PR DESCRIPTION
Backport of Unidata/netcdf-java#514

Previously, the level 2 code used a fixed word size of 8 bits for the
data blocks, with a special exception for the differential phase
product, which was hardcoded to use 16 bits. This PR enables the IOSP
and Level2 Record parser to use the actual word size as encoded in the
message.