### PR TITLE
Refactor NEXRAD level2 format checking

### DIFF
--- a/cdm/src/main/java/ucar/nc2/dt/radial/LevelII2Dataset.java
+++ b/cdm/src/main/java/ucar/nc2/dt/radial/LevelII2Dataset.java
@@ -32,6 +32,8 @@
  */
 package ucar.nc2.dt.radial;
 
+import static ucar.nc2.iosp.nexrad2.Nexrad2IOServiceProvider.isNEXRAD2Format;
+
 import ucar.nc2.*;
 import ucar.nc2.dataset.*;
 import ucar.nc2.constants.*;
@@ -67,11 +69,9 @@ public class LevelII2Dataset extends RadialDatasetSweepAdapter implements TypedD
     String convention = ds.findAttValueIgnoreCase(null, "Conventions", null);
     if ((null != convention) && convention.equals(_Coordinate.Convention)) {
       String format = ds.findAttValueIgnoreCase(null, "Format", null);
-      if (format != null && (format.equals("ARCHIVE2")
-              || format.equals("AR2V0001") || format.equals("CINRAD-SA")
-              || format.equals("AR2V0003") || format.equals("AR2V0002") || format.equals("AR2V0004")
-              || format.equals("AR2V0006") || format.equals("AR2V0007")))
+      if (format != null && (isNEXRAD2Format(format) || format.equals("CINRAD-SA"))) {
         return true;
+      }
     }
     return false;
   }

--- a/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Level2VolumeScan.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Level2VolumeScan.java
@@ -144,9 +144,10 @@ public class Level2VolumeScan {
         station = NexradStationDB.get(stationId);
     }
 
-    //see if we have to uncompress
-     if (dataFormat.equals(AR2V0001) || dataFormat.equals(AR2V0003)
-            || dataFormat.equals(AR2V0004) || dataFormat.equals(AR2V0006)  || dataFormat.equals(AR2V0007) ) {
+    // see if we have to uncompress--basically looking for anything but the original Level2 format
+    // technically speaking, this BZ2 compression is a detail of transmission--there's no requirement in the
+    // ICDs that this BZ2 block compression is actually applied on disk.
+    if (dataFormat.startsWith("AR2V")) {
       raf.skipBytes(4);
       String BZ = raf.readString(2);
       if (BZ.equals("BZ")) {

--- a/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -57,15 +57,24 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
   static private final int MISSING_INT = -9999;
   static private final float MISSING_FLOAT = Float.NaN;
 
+  public static boolean isNEXRAD2Format(String format) {
+    return isNEXRAD2Format(format, false);
+  }
+
+ private static boolean isNEXRAD2Format(String format, boolean checkIfKnown) {
+    if (format != null && (format.equals("ARCHIVE2") || format.startsWith("AR2V"))) {
+      if (checkIfKnown && format.startsWith("AR2V") && Integer.parseInt(format.substring(4)) > 8) {
+        logger.warn("Trying to handle unknown but valid-looking format: " + format);
+      }
+      return true;
+    }
+    return false;
+  }
 
   public boolean isValidFile( RandomAccessFile raf) throws IOException {
     try {
       raf.seek(0);
-      String test = raf.readString(8);
-      return test.equals( Level2VolumeScan.ARCHIVE2) || test.equals( Level2VolumeScan.AR2V0001) ||
-             test.equals( Level2VolumeScan.AR2V0003)|| test.equals( Level2VolumeScan.AR2V0004) ||
-             test.equals( Level2VolumeScan.AR2V0002) || test.equals( Level2VolumeScan.AR2V0006) ||
-             test.equals( Level2VolumeScan.AR2V0007);
+      return isNEXRAD2Format(raf.readString(8));
     } catch (IOException ioe) {
       return false;
     }


### PR DESCRIPTION
From @dopplershift's original commit message:

> Don't try to enumerate all the possible values. Instead, just look for AR2V and a number--and log a warning is this number is bigger than the most recent we are aware of. Also refactor to eliminate duplicated code.
>
> This is motivated by NWS ROC testing data declaring a format of AR2V0008.

Backport of Unidata/netcdf-java#153, Unidata/netcdf-java#154, and Unidata/netcdf-java#189