### PR TITLE
Fix for EOFException on NCDump data Unidata/thredds#1342

### DIFF
--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
@@ -4767,6 +4767,7 @@ public class H5header {
         long startPos = raf.getFilePointer();
         HeapObject o = new HeapObject();
         o.id = raf.readShort();
+        if (o.id == 0) break; // ?? look
         o.refCount = raf.readShort();
         raf.skipBytes(4);
         o.dataSize = readLength();
@@ -4776,7 +4777,6 @@ public class H5header {
         countBytes += dsize + 16;
 
         // System.out.printf("%d heapId=%d dataSize=%d countBytes=%d%n", count, o.id, o.dataSize, countBytes);
-        if (o.id == 0) break; // ?? look
         if (o.dataSize < 0) break; // ran off the end, must be done
         if (countBytes < 0) break; // ran off the end, must be done
         if (countBytes > sizeBytes) break; // ran off the end


### PR DESCRIPTION
On GlobalHeap instantiation, we should stop reading file data just after we met a HeapObject.id equals to 0. Otherwise, we could be at the end of the file and a EOFException will be raised. Addresses the github issue Unidata/thredds#1342.