### PR TITLE
Ignore YUI CVEs

### DIFF
--- a/.github/workflows/ncj-tds-test.yml
+++ b/.github/workflows/ncj-tds-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: netCDF-Java_JUnit_Results_${{ github.sha }}_Zulu-${{ matrix.java }}
+          name: netCDF-Java-TDS_JUnit_Results_${{ github.sha }}_Zulu-${{ matrix.java }}
           path: build/reports/allTests
 
   tests-adpotopen-hs:
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: netCDF-Java_JUnit_Results_${{ github.sha }}Adoptium-HS-${{ matrix.java }}
+          name: netCDF-Java-TDS_JUnit_Results_${{ github.sha }}Adoptium-HS-${{ matrix.java }}
           path: build/reports/allTests
 
   check-assemble-adpotopen-hs:

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -17,4 +17,14 @@
     <packageUrl regex="true">^pkg:maven/uk\.ac\.rdg\.resc/ncwms@.*$</packageUrl>
     <cpe>cpe:/a:trac:trac</cpe>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name example: godiva2/js/yui/treeview-min.js
+      reason: These CVEs only impact the Flash component of YUI.
+    ]]></notes>
+    <filePath regex="true">.*\/godiva2\/js\/yui\/.*\.js</filePath>
+    <cve>CVE-2012-5881</cve>
+    <cve>CVE-2012-5882</cve>
+    <cve>CVE-2012-5883</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
The flagged YUI related CVEs are for the flash component of YUI, which we do not use anywhere in the project (nor do we ship them in the tds war file).