### PR TITLE
Use plugins.gradle.org rather than Unidata proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,6 @@ buildscript {
         maven {
             url "https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/"  // For 'com.cwardgar.gretty-fork:gretty'.
         }
-        maven {
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-jcenter-proxy/" // For shadow plugin
-        }
     }
     dependencies {
         classpath libraries["gretty"]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -50,9 +50,6 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
         maven {
             url "http://52north.org/maven/repo/releases/"  // For "52n-oxf-xmlbeans".
         }
-        maven {
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-jcenter-proxy/" // For shadow plugin
-        }
 
         // Hosted snapshot repository. We want this to be last so that we can minimize warnings such as:
         //   Failed to get resource: HEAD. [HTTP HTTP/1.1 400 Repository version policy:

--- a/gradle/fatJars.gradle
+++ b/gradle/fatJars.gradle
@@ -37,7 +37,7 @@ buildscript {
 
     repositories {
         maven {
-            url "https://artifacts.unidata.ucar.edu/repository/unidata-jcenter-proxy/" // For shadow plugin
+            url "https://plugins.gradle.org/m2" // For shadow plugin
         }
     }
     dependencies {


### PR DESCRIPTION
We don't actually need a jcentry proxy, as the plugins we need are available at the gradle plugin repository.