### PR TITLE
Release 4.6.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ allprojects {
     // Matches Maven's "project.groupId". Used in MANIFEST.MF for "Implementation-Vendor-Id".
     group = "edu.ucar"
     // Matches Maven's "project.version". Used in MANIFEST.MF for "Implementation-Version".
-    version = '4.6.17-SNAPSHOT'
+    version = '4.6.16.1'
     // Eventually, we'll stop appending "SNAPSHOT" to our versions and just use this.
-    status = 'development'
+    status = 'release'
 }
 
 // Matches Maven's "project.description".

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ allprojects {
     // Matches Maven's "project.groupId". Used in MANIFEST.MF for "Implementation-Vendor-Id".
     group = "edu.ucar"
     // Matches Maven's "project.version". Used in MANIFEST.MF for "Implementation-Version".
-    version = '4.6.16.1'
+    version = '4.6.17-SNAPSHOT'
     // Eventually, we'll stop appending "SNAPSHOT" to our versions and just use this.
-    status = 'release'
+    status = 'development'
 }
 
 // Matches Maven's "project.description".

--- a/cdm-test/src/test/java/ucar/nc2/grib/GribTestCreationOptions.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/GribTestCreationOptions.java
@@ -74,8 +74,8 @@ public class GribTestCreationOptions {
 
     String dataset = TestDir.cdmUnitTestDir + "gribCollections/hrrr/DewpointTempFromGsdHrrrrConus3surface.grib2";
     try (NetcdfDataset ds = NetcdfDataset.openDataset(dataset)) {
-      Variable v = ds.findVariable("DPT_height_above_ground");
-      Assert.assertNotNull("DPT_height_above_ground", v);
+      Variable v = ds.findVariable("DPT_P0_L103_GLC0_height_above_ground");
+      Assert.assertNotNull("DPT_P0_L103_GLC0_height_above_ground", v);
       Dimension d = v.getDimension(0);
       Assert.assertEquals(57, d.getLength());
     }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/FslLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/FslLocalTables.java
@@ -73,7 +73,7 @@ public class FslLocalTables extends NcepLocalTables {
     if (grib2Table.getId().genProcessId == 125)
       return fimTable;
     else
-      return hrrrTable;
+      return grib2Table.getPath();
   }
 
   private FslLocalTables(Grib2Table grib2Table) {
@@ -172,8 +172,8 @@ public class FslLocalTables extends NcepLocalTables {
   }
 
   protected void initLocalTable(Formatter f) {
-    if (grib2Table.getPath().equals(hrrrTable))
-      local = readCsv(hrrrTable, f);
+    if (grib2Table.getPath().contains("hrrr"))
+      local = readCsv(grib2Table.getPath(), f);
     else
       local = readFim(fimTable, f);
   }
@@ -206,7 +206,7 @@ public class FslLocalTables extends NcepLocalTables {
           VerticalLevels, Units);
     }
 
-    String name = !WGrib2Name.equals("var") ? WGrib2Name : FieldType;
+    String name = !NCLName.equals("var") ? NCLName : FieldType;
     return new Grib2Parameter(disciplineNumber, categoryNumber, parameterNumber, name, Units, null, FieldType);
   }
 

--- a/grib/src/main/resources/resources/grib2/standardTableMap.txt
+++ b/grib/src/main/resources/resources/grib2/standardTableMap.txt
@@ -7,8 +7,8 @@
 54;    -1; -1; -1; -1;    ncep; canadian met
 #
 # FSL HRRR
-59;     0;  2;  1;  -1;   gsd; FSL HRRR;  resources/grib2/noaa_gsd/Fsl-hrrr4.csv
-59;    -1; -1; -1; 125;   gsd; fsl hrrr
+59;     0;  2;  1;  -1;   gsd; fsl hrrr;  resources/grib2/noaa_gsd/Fsl-hrrr4.csv
+59;    -1; -1; -1; 125;   gsd; fsl hrrr;  resources/grib2/noaa_gsd/Fsl-hrrr2.csv
 #
 # center 8, subcenter 0 and -9999 use ndfd table
 8;      0; -1; -1; -1;    ndfd; ndfd

--- a/grib/src/test/java/ucar/nc2/grib/grib2/TestRotatedPole.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/TestRotatedPole.java
@@ -104,7 +104,7 @@ public class TestRotatedPole {
       Assert.assertEquals(36.0, projVar.findAttribute("grid_north_pole_latitude").getNumericValue().doubleValue(),
           DELTA);
       // check data variable
-      Variable dataVar = nc.findVariable("TMP_surface");
+      Variable dataVar = nc.findVariable("TMP_P0_L100_GLC0_surface");
       Assert.assertNotNull(dataVar);
       Assert.assertEquals("RotatedLatLon32769_Projection", dataVar.findAttribute("grid_mapping").getStringValue());
       Assert.assertEquals("K", dataVar.findAttribute("units").getStringValue());


### PR DESCRIPTION
The HRRR v4 table update did not cleanly backport to `4.x`, so rather we're skipping the `4.6.16` release and going with `4.6.16.1`, which fixes the table registration issue.