### PR TITLE
updated to remove links to previous versions

### DIFF
--- a/docs/website/netcdf-java/documentation.htm
+++ b/docs/website/netcdf-java/documentation.htm
@@ -70,37 +70,7 @@ To build the latest stable version from source or contribute code  to the THREDD
   <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
   <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
 </ul>
-<h3 id="v45">Previous release version 4.5 (requires Java 7) </h3>
-<ul>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/netcdfAll/">complete netCDF library jar</a> implements the full CDM model, with all
-    dependent jars included. </li>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/toolsUI/">toolsUI.jar</a> also includes UI classes, and allows you to run the netCDF
-    ToolsUI application directly from it such as &quot;<em>java -Xmx1g -jar toolsUI.jar</em>&quot;</li>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/ncIdv/">ncIDV.jar</a> is for the development branch of the IDV. </li>
-  <li><a href="https://www.unidata.ucar.edu/software/netcdf-java/v4.5/javadoc/index.html">Public javadoc.</a> This is the public interface. Future changes to the API will attempt to remain backwards compatible
-    with this API. </li>
-  <li><a href="https://www.unidata.ucar.edu/software/netcdf-java/v4.5/javadocAll/index.html">All javadoc</a>. This is the javadoc for all packages and all methods except private. CAREFUL, much of this will
-    change. </li>
-  <li>Try out the <strong> 4.5</strong> version of ToolsUI application: <a href="https://www.unidata.ucar.edu/software/netcdf-java/v4.5/webstart/netCDFtools.jnlp">launch from webstart</a>.</li>
-  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
-  <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
-</ul>
-<h3 id="v">Previous release version 4.3 (requires Java 6) </h3>
-<ul>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/netcdfAll/">complete netCDF library jar</a> implements the full CDM model, with all
-    dependent jars included. </li>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/toolsUI/">toolsUI.jar</a> also includes UI classes, and allows you to run the netCDF
-    ToolsUI application directly from it with &quot;<em>java -Xmx1g -jar toolsUI.jar</em>&quot;</li>
-  <li>The <a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/ncIdv/">ncIDV.jar</a> is for the released version of the IDV.</li>
-  <li><a href="https://www.unidata.ucar.edu/software/netcdf-java/v4.3/v4.3/javadoc/index.html">Public javadoc.</a> This is the public interface. Future changes to the API will attempt to remain backwards compatible
-    with this API. </li>
-  <li><a href="https://www.unidata.ucar.edu/software/netcdf-java/v4.3/v4.3/javadocAll/index.html">All javadoc</a>.
-    This is the javadoc for all packages and all methods except private. CAREFUL, much of this will
-    change. </li>
-  <li>Try out the <strong> 4.3</strong> version of ToolsUI application: <a href="https://www.unidata.ucar.edu/software/thredds/netcdf-java/v4.3/webstart/netCDFtools.jnlp">launch from webstart</a>.</li>
-  <li>Unidata public <a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/">Maven repository</a> for maven artifacts </li>
-  <li>All source is on <a href="https://github.com/Unidata/thredds">GitHub</a></li>
-</ul>
+
 <h3>File format<a name="formats"></a> types</h3>
 
 <p>The NetCDF-Java library can read various <a href="reference/formats/FileTypes.html">file types and remote access

--- a/docs/website/tds/TDS.html
+++ b/docs/website/tds/TDS.html
@@ -89,22 +89,6 @@
     </ul>
   </li>
 </ul>
-<p><strong>TDS 4.3 is the previous release. It requires Tomcat 6+ and Java 6+.</strong></p>
-<ul>
-  <li>Download the latest  release: [<a href="https://artifacts.unidata.ucar.edu/service/rest/repository/browse/unidata-releases/edu/ucar/tds/">thredds.war</a>]
-    [<a href="https://github.com/Unidata/thredds">source on GitHub</a>] [<a href="https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/tds/">artifacts in Unitdata's maven repository</a>]</li>
-  <li>Documentation:
-    <ul>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/reference/index.html">Reference</a></li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/tutorial/index.html">Tutorial</a></li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/faq.html">FAQ</a></li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/UpgradingTo4.3.html">Upgrading to TDS 4.3</a> </li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/AccessChangesTds4.3.html">New GRIB handling in TDS 4.3</a></li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/tutorial/Checklist.html">Checklist for Production Installation</a></li>
-      <li><a href="https://www.unidata.ucar.edu/software/tds/v4.3/tds4.3/SourceCodeBuild.html">Building TDS 4.3 from source code</a></li>
-    </ul>
-  </li>
-</ul>
 
 <h2>TDS Services</h2>
 <blockquote>


### PR DESCRIPTION
- Removed links to v4.3 on the main page of TDS 4.6 documentation.
- Removed links to v4.3 & 4.5 on the main page of netCDF-Java 4.6 documentation.