### PR TITLE
Modify URLs of XML Schema and DTD files for Unidata hostname change

### DIFF
--- a/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfig1.0.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfig1.0.xml
@@ -7,7 +7,7 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
   <dataset name="THREDDS CatalogGen test config file">
     <dataset name="NCEP Eta 80km CONUS model data">

--- a/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfigNew1.0.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfigNew1.0.xml
@@ -7,8 +7,8 @@
          xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
          xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd
-                      http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0 http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.1.0.xsd"
+         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd
+                      http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0 https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.1.0.xsd"
   >
   <service name="mlode" serviceType="DODS" base="http://localhost:8080/thredds/cataloggen/"/>
   <dataset name="THREDDS CatalogGen test config file">

--- a/cdm-test/src/test/data/thredds/cataloggen/testCatGen.badAccessPoint.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/testCatGen.badAccessPoint.xml
@@ -3,10 +3,10 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
 >
 <!--?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE catalog SYSTEM "http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.0.5.dtd"-->
+<!DOCTYPE catalog SYSTEM "https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.0.5.dtd"-->
   <dataset name="CatGen Test for Bad Access Points">
       <metadata inherited="true">
           <serviceName>testServer</serviceName>

--- a/cdm-test/src/test/data/thredds/cataloggen/testCatGen.uahRadarLevelII.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/testCatGen.uahRadarLevelII.xml
@@ -3,10 +3,10 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
 >
 <!--?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE catalog SYSTEM "http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.0.5.dtd"-->
+<!DOCTYPE catalog SYSTEM "https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.0.5.dtd"-->
   <dataset name="UAH/ITSC Data Pool NEXRAD Level 2">
       <metadata inherited="true">
           <serviceName>Data Pool server</serviceName>

--- a/cdm/src/main/java/thredds/catalog/XMLEntityResolver.java
+++ b/cdm/src/main/java/thredds/catalog/XMLEntityResolver.java
@@ -179,7 +179,7 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
   static public final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
 
   // dqc namespaces
-  //static public final String DQC_NAMESPACE_02 = "http://www.unidata.ucar.edu/schemas/thredds/queryCapability";
+  //static public final String DQC_NAMESPACE_02 = "https://schemas.unidata.ucar.edu/thredds/queryCapability";
   //static public final String DQC_NAMESPACE_03 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.3";
   static public final String DQC_NAMESPACE_04 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4";
 
@@ -226,37 +226,37 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
     // catalog 1.0 schema
     initEntity( CATALOG_NAMESPACE_10,
                 "/resources/thredds/schemas/InvCatalog.1.0.7.xsd",
-                "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd");
+                "https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd");
 
     /* catalog 0.6 schema
     initEntity( CATALOG_NAMESPACE_06,
                 "/resources/thredds/schemas/InvCatalog.0.6.xsd",
-                "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.xsd");
+                "https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.xsd");
 
     // DQC schema 0.2
     initEntity( DQC_NAMESPACE_02,
                 "/resources/thredds/schemas/queryCapability.0.2.xsd",
-                "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.2.xsd");
+                "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.2.xsd");
 
     // DQC schema 0.3
     initEntity( DQC_NAMESPACE_03,
                 "/resources/thredds/schemas/queryCapability.0.3.xsd",
-                "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.3.xsd"); */
+                "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.3.xsd"); */
 
     // DQC schema 0.4
     initEntity( DQC_NAMESPACE_04,
                 "/resources/thredds/schemas/queryCapability.0.4.xsd",
-                "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.4.xsd");
+                "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.4.xsd");
 
     // nj22 schema
     initEntity( NJ22_NAMESPACE,
                 "/resources/nj22/schemas/ncml-2.2.xsd",
-                "http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd");
+                "https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd");
 
     // XLink schema
     initEntity( XLINK_NAMESPACE,
                 "/resources/thredds/schemas/xlink.xsd",
-                "http://www.unidata.ucar.edu/schemas/other/xlink.xsd");
+                "https://schemas.unidata.ucar.edu/other/xlink.xsd");
 
     /* catgen 0.5 dtd
     initEntity( "http://www.unidata.ucar.edu/projects/THREDDS/xml/CatalogGenConfig.0.5.dtd",
@@ -271,12 +271,12 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
   static public String getExternalSchemas() {
     if (externalSchemas == null) {
       externalSchemas =
-        XMLEntityResolver.CATALOG_NAMESPACE_10 + " " + "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd" +" "
-        + XMLEntityResolver.NJ22_NAMESPACE + " " + "http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd" +" "
-        + XMLEntityResolver.DQC_NAMESPACE_04 + " " + "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.4.xsd" +" "
-        /* + XMLEntityResolver.DQC_NAMESPACE_03 + " " + "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.3.xsd" +" " +
-        XMLEntityResolver.DQC_NAMESPACE_02 + " " + "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.2.xsd" +" " +
-        XMLEntityResolver.CATALOG_NAMESPACE_06 + " " + "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.xsd" */;
+        XMLEntityResolver.CATALOG_NAMESPACE_10 + " " + "https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd" +" "
+        + XMLEntityResolver.NJ22_NAMESPACE + " " + "https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd" +" "
+        + XMLEntityResolver.DQC_NAMESPACE_04 + " " + "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.4.xsd" +" "
+        /* + XMLEntityResolver.DQC_NAMESPACE_03 + " " + "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.3.xsd" +" " +
+        XMLEntityResolver.DQC_NAMESPACE_02 + " " + "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.2.xsd" +" " +
+        XMLEntityResolver.CATALOG_NAMESPACE_06 + " " + "https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.xsd" */;
     }
     return externalSchemas;
   }
@@ -430,7 +430,7 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
     }
 
     if (systemId.contains("InvCatalog.0.6.dtd")) {
-      entity = entityHash.get( "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.dtd");
+      entity = entityHash.get( "https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.dtd");
       if (entity != null) {
         logger.debug(" *** resolved2 with local copy");
         return new MyInputSource(entity);

--- a/cdm/src/main/java/thredds/catalog/dl/DCWriter.java
+++ b/cdm/src/main/java/thredds/catalog/dl/DCWriter.java
@@ -46,7 +46,7 @@ import java.util.*;
 
 public class DCWriter {
   private static final Namespace defNS = Namespace.getNamespace("http://purl.org/dc/elements/1.1/");
-  private static final String schemaLocation = defNS.getURI() + " http://www.unidata.ucar.edu/schemas/other/dc/dc.xsd";
+  private static final String schemaLocation = defNS.getURI() + " https://schemas.unidata.ucar.edu/other/dc/dc.xsd";
   private static final String threddsServerURL = "http://localhost:8080/thredds/subset.html";
 
   private InvCatalog cat;

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLGWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLGWriter.java
@@ -57,7 +57,7 @@ import ucar.unidata.util.Parameter;
  */
 
 public class NcMLGWriter {
-  protected static final String schemaLocation = "http://www.unidata.ucar.edu/schemas/netcdf-cs.xsd";
+  protected static final String schemaLocation = "https://schemas.unidata.ucar.edu/netcdf/netcdf-cs.xsd";
 
   /**
    * Write a NetcdfDataset as an NcML-G document to the specified stream.

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLWriter.java
@@ -147,10 +147,10 @@ public class NcMLWriter {
 
     if (ncfile instanceof NetcdfDataset)
       rootElem.setAttribute("schemaLocation",
-        "http://www.ucar.edu/schemas/netcdf-2.2 http://www.unidata.ucar.edu/schemas/netcdfCS-2.2.xsd", xsiNS);
+        "http://www.unindata.ucar.edu/namespaces/netcdf-2.2 https://schemas.unidata.ucar.edu/netcdfCS-2.2.xsd", xsiNS);
     else
       rootElem.setAttribute("schemaLocation",
-        "http://www.ucar.edu/schemas/netcdf-2.2 http://www.unidata.ucar.edu/schemas/netcdf-2.2.xsd", xsiNS);
+        "http://www.unidata.ucar.edu/namespaces/netcdf-2.2 https://schemas.unidata.ucar.edu/netcdf-2.2.xsd", xsiNS);
     */
 
     if (null == location)

--- a/cdm/src/main/resources/resources/thredds/schemas/CatalogGenConfig.1.0.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/CatalogGenConfig.1.0.xsd
@@ -7,7 +7,7 @@
             elementFormDefault="qualified">
 
   <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
-              schemaLocation="http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"/>
+              schemaLocation="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"/>
 
   <!--
     The catalogGenConfig element contains the CatGen config info and declares its type.

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.1.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.1.xsd
@@ -9,8 +9,8 @@
   attributeFormDefault="unqualified" version="1.0.1">
      
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.2.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.2.xsd
@@ -9,8 +9,8 @@
   attributeFormDefault="unqualified" version="1.0.2">
      
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.3.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.3.xsd
@@ -9,8 +9,8 @@
   attributeFormDefault="unqualified" version="1.0.3">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.4.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.4.xsd
@@ -10,8 +10,8 @@
   version="1.0.4">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.5.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.5.xsd
@@ -10,8 +10,8 @@
   version="1.0.5">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.6.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.6.xsd
@@ -10,8 +10,8 @@
     version="1.0.6">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
@@ -10,8 +10,8 @@
     version="1.0.7">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
+++ b/cdm/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
@@ -7,7 +7,7 @@
   elementFormDefault="qualified">
 
   <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
-    schemaLocation="http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" />
+    schemaLocation="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd" />
 
   <!--
     The queryCapability element.

--- a/cdm/src/test/data/thredds/catalog/DifTest.xml
+++ b/cdm/src/test/data/thredds/catalog/DifTest.xml
@@ -2,7 +2,7 @@
 <metadata  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
   <contributor role="Investigator">Mashor Mashnor</contributor>
           

--- a/cdm/src/test/data/thredds/catalog/MetadataLink.xml
+++ b/cdm/src/test/data/thredds/catalog/MetadataLink.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     >
  
     <documentation type="summary"> The SAGE III Ozone Loss and Validation Experiment (SOLVE) was a measurement campaign designed to examine the     processes controlling ozone levels at mid- to high latitudes. Measurements were made in the Arctic high-latitude region in winter using the NASA     DC-8 and ER-2 aircraft, as well as balloon platforms and ground-based instruments. The mission also acquired correlative data needed to     validate the Stratospheric Aerosol and Gas Experiment (SAGE) III satellite measurements that will be used to quantitatively assess high-latitude     ozone loss. SOLVE is co-sponsored by the Upper Atmosphere Research Program (UARP), Atmospheric Effects of Aviation Project (AEAP),     Atmospheric Chemistry Modeling and Analysis Program (ACMAP), and Earth Observing System (EOS) of NASA's Earth Science Enterprise     (ESE) as part of the validation program for the SAGE III instrument. 

--- a/cdm/src/test/data/thredds/catalog/MissingGCProblem.xml
+++ b/cdm/src/test/data/thredds/catalog/MissingGCProblem.xml
@@ -3,7 +3,7 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
   <service name="this" serviceType="OpenDAP" base=""/>
   

--- a/cdm/src/test/data/thredds/catalog/TestHarvest.xml
+++ b/cdm/src/test/data/thredds/catalog/TestHarvest.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     expires="6 days since 1999-01-01 12:00:02"
   >
  

--- a/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
+++ b/cdm/src/test/data/thredds/catalog/TestTimeCoverage.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     >
 
   <service base="http://acd.ucar.edu/models/MOZART/DATA_COMP/datasets_nc/solve1/" serviceType="HTTP" name="disk"/>

--- a/cdm/src/test/data/thredds/catalog/ZoneMetadata.xml
+++ b/cdm/src/test/data/thredds/catalog/ZoneMetadata.xml
@@ -2,7 +2,7 @@
 <metadata  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
 <documentation type="summary"> The SAGE III Ozone Loss and Validation Experiment (SOLVE) was a measurement campaign 
  designed to examine the processes controlling ozone levels at mid- to high latitudes. Measurements 

--- a/cdm/src/test/data/thredds/catalog/catalogDev.xml
+++ b/cdm/src/test/data/thredds/catalog/catalogDev.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
 
   <service name="this" serviceType="QueryCapability" base=""/>
   

--- a/cdm/src/test/data/thredds/catalog/catgen1.0.xml
+++ b/cdm/src/test/data/thredds/catalog/catgen1.0.xml
@@ -2,7 +2,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
 
     <service name="latest" serviceType="Resolver"

--- a/cdm/src/test/data/thredds/catalog/dif/metar.thredds.xml
+++ b/cdm/src/test/data/thredds/catalog/dif/metar.thredds.xml
@@ -3,7 +3,7 @@
 <cat:metadata xmlns:cat="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns="http://gcmd.gsfc.nasa.gov/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd
                                         http://gcmd.gsfc.nasa.gov/  file://P:/schemas/other/gcmd/dif.xsd"
   >
 

--- a/cdm/src/test/data/thredds/catalog/test2.xml
+++ b/cdm/src/test/data/thredds/catalog/test2.xml
@@ -4,7 +4,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0                          
-              http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+              https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     expires="6 days since 1999-01-01 12:00:02"
     >
  

--- a/cdm/src/test/data/thredds/catalog/testMetadata.xml
+++ b/cdm/src/test/data/thredds/catalog/testMetadata.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
  
   <service base="http://acd.ucar.edu/models/MOZART/DATA_COMP/datasets_nc/solve1/" serviceType="HTTP" name="disk"/>

--- a/docs/website/netcdf-java/ncml/LogicalView.html
+++ b/docs/website/netcdf-java/ncml/LogicalView.html
@@ -21,7 +21,7 @@
   <li>to select one slice, just use the value of the index</li>
   <li>to select a range, use start:end, eg 1:19</li>
 </ul>
-<pre>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;<br>&lt;netcdf xmlns=&quot;http://www.ucar.edu/schemas/netcdf&quot; <br>	xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;<br>	xsi:schemaLocation=&quot;http://www.ucar.edu/schemas/netcdf http://www.unidata.ucar.edu/schemas/netcdfDataset2.xsd&quot;<br>	uri=&quot;file:///C:/data/conventions/awips/awipsTestFilename.nc&quot;&gt;</pre>
+<pre>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;<br>&lt;netcdf xmlns=&quot;http://www.unidata.ucar.edu/namespaces/netcdf&quot; <br>	xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;<br>	xsi:schemaLocation=&quot;http://www.unidata.ucar.edu/namespaces/netcdf https://schemas.unidata.ucar.edu/netcdf/Dataset2.xsd&quot;<br>	uri=&quot;file:///C:/data/conventions/awips/awipsTestFilename.nc&quot;&gt;</pre>
 <pre> &lt;dimension name=&quot;record&quot; length=&quot;11&quot; isUnlimited=&quot;true&quot;/&gt;
  &lt;dimension name=&quot;x&quot; length=&quot;93&quot;/&gt;
  &lt;dimension name=&quot;y&quot; length=&quot;65&quot;/&gt;

--- a/docs/website/netcdf-java/ncml/index.htm
+++ b/docs/website/netcdf-java/ncml/index.htm
@@ -85,7 +85,7 @@ you'll have to read more:
   <li><a href="Aggregation.html">Aggregation</a></li>
   <li><a href="Cookbook.html">Cookbook Examples</a></li>
   <li><a href="AnnotatedSchema4.html">Annotated Schema for Netcdf-Java 4</a></li>
-  <li><a href="https://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd">ncml-2.2.xsd</a></li>
+  <li><a href="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd">ncml-2.2.xsd</a></li>
 </ul>
 <hr align="left">
 <h2 align="left"><b>Acknowledgments and History</b></h2>

--- a/docs/website/tds/catalog/Changes.html
+++ b/docs/website/tds/catalog/Changes.html
@@ -30,7 +30,7 @@
 <h2>Changes for version 1.0.1</h2>
 <ul>
   <li>The version attribute is "1.0.1" .</li>
-  <li>The schema can be found <a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.1.xsd">here</a>.
+  <li>The schema can be found <a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.1.xsd">here</a>.
     However, you should tell your parser to resolve to a local copy of it,
     both for performance and to decouple with Unidata's web server.
   </li>

--- a/docs/website/tds/catalog/InvCatalogServerSpec.html
+++ b/docs/website/tds/catalog/InvCatalogServerSpec.html
@@ -26,7 +26,7 @@
 <ul>
   <li><a href="../reference/DatasetScan.html">DatasetScan</a> reference </li>
   <li><a href="../reference/collections/FeatureCollections.html">FeatureCollection</a> reference</li>
-  <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd">Catalog XML xsd</a><br/>
+  <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd">Catalog XML xsd</a><br/>
   </li>
 </ul>
 <h3><strong>Change History:</strong></h3>

--- a/docs/website/tds/catalog/InvCatalogSpec.html
+++ b/docs/website/tds/catalog/InvCatalogSpec.html
@@ -64,14 +64,14 @@
   <li><a href="Example1.0rc8.xml">Example</a> 1.0 Catalog</li>
   <li>InvCatalog XML Schema:</li>
   <ul>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd">Version 1.0.7</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd">Version 1.0.6</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.5.xsd">Version 1.0.5</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.4.xsd">Version 1.0.4</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.3.xsd">Version 1.0.3</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.2.xsd">Version 1.0.2</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.1.xsd">Version 1.0.1</a></li>
-    <li><a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">Version 1.0</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd">Version 1.0.7</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.6.xsd">Version 1.0.6</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.5.xsd">Version 1.0.5</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.4.xsd">Version 1.0.4</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.3.xsd">Version 1.0.3</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.2.xsd">Version 1.0.2</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.1.xsd">Version 1.0.1</a></li>
+    <li><a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">Version 1.0</a></li>
   </ul>
   <li><a href="../reference/DigitalLibraries.html">Writing metadata for Digital Libraries</a></li>
   <li>Java API to read catalogs in the <a href="https://www.unidata.ucar.edu/software/netcdf-java/">netCDF-Java library</a>.</li>

--- a/docs/website/tds/catalog/index.html
+++ b/docs/website/tds/catalog/index.html
@@ -23,7 +23,7 @@
 <p>For client-side catalogs, see:</p>
 <ul>
   <li>The <a href="InvCatalogSpec.html">Catalog specification</a> is an annotated XML Schema that explains the details of THREDDS Catalogs.</li>
-  <li>The XML Schema document: <a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd">Online catalog schema</a>.</li>
+  <li>The XML Schema document: <a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd">Online catalog schema</a>.</li>
   <li><a href="../tutorial/CatalogPrimer.html">Catalog Primer</a></li>
 </ul>
 <p>The <a href="/netcdf-java/4.6/userguide/documentation.htm">Java NetCDF library</a> has a complete package (thredds.catalog) to parse client-side

--- a/docs/website/tds/reference/collections/GribConfig.html
+++ b/docs/website/tds/reference/collections/GribConfig.html
@@ -203,7 +203,7 @@
 <hr />
 <h2><a name="schema" id="schema"></a> gribConfig XML Schema</h2>
 <p>The gribConfig schema definition, version 1.07</p>
-<p>see: <a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd">http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd</a></p>
+<p>see: <a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd">https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd</a></p>
 <blockquote>
   <pre>&lt;xsd:complexType name=&quot;gribConfigType&quot;&gt;
  &lt;xsd:sequence&gt;

--- a/docs/website/tds/tutorial/BasicConfigCatalogs.html
+++ b/docs/website/tds/tutorial/BasicConfigCatalogs.html
@@ -84,7 +84,7 @@
     xmlns:xlink=&quot;http://www.w3.org/1999/xlink&quot;
     xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
     xsi:schemaLocation=&quot;http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
-      http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd&quot;&gt;
+      https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.6.xsd&quot;&gt;
 
   &lt;service name=&quot;all&quot; base=&quot;&quot; serviceType=&quot;compound&quot;&gt;
     &lt;service name=&quot;odap&quot; serviceType=&quot;OpenDAP&quot; base=&quot;/thredds/dodsC/&quot; /&gt;

--- a/docs/website/tds/tutorial/CatalogPrimer.html
+++ b/docs/website/tds/tutorial/CatalogPrimer.html
@@ -402,7 +402,7 @@ http://hostname:port/thredds/dodsC/sage/20061031.nc
 &lt;catalog name="Validation" xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     <strong>xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"</strong>
     <strong>xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0</strong>
-    <strong>http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd"</strong>&gt;
+    <strong>https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.6.xsd"</strong>&gt;
   ...
 &lt;/catalog&gt;
 </pre>
@@ -411,7 +411,7 @@ http://hostname:port/thredds/dodsC/sage/20061031.nc
         <h4>Reference documentation</h4>
 
         <p>The schema referenced in the example can be found
-            <a href="https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd">here</a>.
+            <a href="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.6.xsd">here</a>.
             However, you'll probably want to study the
             <a href="../catalog/InvCatalogSpec.html">catalog specification</a>
             instead, as it is much more digestable.</p>

--- a/tds/src/main/java/thredds/server/wms/config/WmsDetailedConfig.java
+++ b/tds/src/main/java/thredds/server/wms/config/WmsDetailedConfig.java
@@ -85,9 +85,9 @@ public class WmsDetailedConfig
         try
         {
             // Parse the document, with validation
-            XMLEntityResolver.initEntity("http://www.unidata.ucar.edu/schemas/thredds/dtd/ncwms/wmsConfig.dtd",
+            XMLEntityResolver.initEntity("https://schemas.unidata.ucar.edu/thredds/dtd/ncwms/wmsConfig.dtd",
                     "/resources/thredds/schemas/wmsConfig.dtd",
-                    "http://www.unidata.ucar.edu/schemas/thredds/dtd/ncwms/wmsConfig.dtd");
+                    "https://schemas.unidata.ucar.edu/thredds/dtd/ncwms/wmsConfig.dtd");
             Document doc = new XMLEntityResolver(true).getSAXBuilder().build(in);
             in.close();
 

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/catalog.xml
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/catalog.xml
@@ -4,7 +4,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
-           http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd">
+           https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.6.xsd">
 
   <service name="all" base="" serviceType="compound">
     <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/wmsConfig.xml
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/wmsConfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE wmsConfig SYSTEM "http://www.unidata.ucar.edu/schemas/thredds/dtd/ncwms/wmsConfig.dtd">
+<!DOCTYPE wmsConfig SYSTEM "https://schemas.unidata.ucar.edu/thredds/dtd/ncwms/wmsConfig.dtd">
 <!--
 Detailed configuration of the WMS service.  This config file can be used to
 set default styling parameters for each dataset/variable, and to enable or disable


### PR DESCRIPTION
Update URLs of Unidata XML Schema and DTD files which are now served from "schemas.unidata.ucar.edu" instead of from "www.unidata.ucar.edu/schemas".