### PR TITLE
suppress old spring CVE for component we don't use

### DIFF
--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -71,4 +71,12 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring-beans@.*$</packageUrl>
     <cve>CVE-2022-22965</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name: spring-core-4.3.29.RELEASE.jar
+      reason: this CVE does not point to a vulnerability in the project itself, it is a vulnerability that occurs with improper use of HTTPInvoker (which we do not use)
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring-core@.*$</packageUrl>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress [CVE-2016-1000027](https://nvd.nist.gov/vuln/detail/CVE-2016-1000027) which only applies to unsafe usage of HTTP invoker endpoints.
See [here](https://support.contrastsecurity.com/hc/en-us/articles/4402400830612-Spring-web-Java-Deserialization-CVE-2016-1000027) for more info
