### PR TITLE
suppress several spring-core CVEs that don't affect 4.6.x

### DIFF
--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -74,9 +74,13 @@
   <suppress>
     <notes><![CDATA[
       file name: spring-core-4.3.29.RELEASE.jar
-      reason: this CVE does not point to a vulnerability in the project itself, it is a vulnerability that occurs with improper use of HTTPInvoker (which we do not use)
+      reason: (CVE-2016-1000027) this CVE does not point to a vulnerability in the project itself, it is a vulnerability that occurs with improper use of HTTPInvoker, which we do not use.
+      (CVE-2022-22965) only vulnerable for JDK 9+.
+      (CVE-2022-22968) case sensitivity vulnerability in DataBinder disallowedFields, which we do not use
      ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring-core@.*$</packageUrl>
     <cve>CVE-2016-1000027</cve>
+    <cve>CVE-2022-22965</cve>
+    <cve>CVE-2022-22968</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
CVE-2022-22965 - we don't use JDK9+
CVE-2022-22968 - we don't use `disallowedFields` for `DataBinder`
