### PR TITLE
Update hibernate and add jaxb-api

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -239,9 +239,11 @@ libraries["javax.servlet-api"] = "javax.servlet:javax.servlet-api:3.1.0"
 
 libraries["taglibs-standard-impl"] = "org.apache.taglibs:taglibs-standard-impl:1.2.5"
 
-libraries["validation-api"] = "javax.validation:validation-api:1.0.0.GA"
+libraries["validation-api"] = "javax.validation:validation-api:1.1.0.Final"
 
-libraries["hibernate-validator"] = "org.hibernate:hibernate-validator:4.3.2.Final"
+libraries["hibernate-validator"] = "org.hibernate:hibernate-validator:5.1.3.Final"
+
+libraries["jaxb-api"] = "javax.xml.bind:jaxb-api:2.3.1"
 
 libraries["jaxen"] = "jaxen:jaxen:1.1.4"
 

--- a/it/src/test/java/thredds/server/cdmr/TestNcstreamCompareWithFiles.java
+++ b/it/src/test/java/thredds/server/cdmr/TestNcstreamCompareWithFiles.java
@@ -62,12 +62,14 @@ public class TestNcstreamCompareWithFiles {
       });
       addFromScan(result, contentRoot + "/grib1/", new FileFilter() {
         public boolean accept(File pathname) {
-          return !pathname.getPath().endsWith(".gbx9") && !pathname.getPath().endsWith(".ncx") && !pathname.getPath().endsWith(".ncx2")&& !pathname.getPath().endsWith(".ncx3");
+          return !pathname.getPath().endsWith(".gbx9") && !pathname.getPath().endsWith(".ncx") && !pathname.getPath().endsWith(".ncx2")&& !pathname.getPath().endsWith(".ncx3")
+              && !pathname.getPath().endsWith(".ncx4");
         }
       });
       addFromScan(result, contentRoot + "/grib2/", new FileFilter() {
         public boolean accept(File pathname) {
-          return !pathname.getPath().endsWith(".gbx9") && !pathname.getPath().endsWith(".ncx") && !pathname.getPath().endsWith(".ncx2")&& !pathname.getPath().endsWith(".ncx3");
+          return !pathname.getPath().endsWith(".gbx9") && !pathname.getPath().endsWith(".ncx") && !pathname.getPath().endsWith(".ncx2")&& !pathname.getPath().endsWith(".ncx3")
+              && !pathname.getPath().endsWith(".ncx4");
         }
       });
       addFromScan(result, contentRoot + "/gini/", new SuffixFileFilter(".gini"));

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -81,4 +81,12 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring-web@.*$</packageUrl>
     <cve>CVE-2016-1000027</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[(
+      file name: hibernate-validator-5.1.3.Final.jar
+      reason: we do not use EL expressions in this project.
+      ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate-validator@.*$</packageUrl>
+    <cve>CVE-2020-10693</cve>
+  </suppress>
 </suppressions>

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     runtime libraries["taglibs-standard-impl"]
     compile libraries["validation-api"]
     runtime libraries["hibernate-validator"]
+    runtime libraries["jaxb-api"]
     runtime libraries["jaxen"]
     
     testCompile libraries["javax.servlet-api"]  // Needed during test runtime as well, so testCompileOnly is no good.


### PR DESCRIPTION
To fix the server startup error "java.lang.ClassNotFoundException: javax.validation.ParameterNameProvider"
- As mentioned [here](https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x), Spring 5 requires hibernate 5+. Not sure which specific Hibernate 5 version is best to use.
- Hibernate 5 requires validation api 1.1.

Then to fix server startup error "java.lang.ClassNotFoundException: javax.xml.bind.ValidationException"
- Added jaxb-api

Also suppress CVE-2020-10693 that came from updating hibernate.